### PR TITLE
Add Travis CI config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 env:
+  - TOXENV=py27
   - TOXENV=py32
   - TOXENV=py33
   - TOXENV=py34

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,16 @@
+sudo: false
 language: python
-env:
-  - TOXENV=py27
-  - TOXENV=py32
-  - TOXENV=py33
-  - TOXENV=py34
 install:
   - pip install tox
 script:
   - tox
+matrix:
+  include:
+    - python: "2.7"
+      env: TOXENV=py27
+    - python: "3.2"
+      env: TOXENV=py32
+    - python: "3.3"
+      env: TOXENV=py33
+    - python: "3.4"
+      env: TOXENV=py34

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+env:
+  - TOXENV=py32
+  - TOXENV=py33
+  - TOXENV=py34
+install:
+  - pip install tox
+script:
+  - tox


### PR DESCRIPTION
I suggest running tox tests automatically via the Travis CI that integrates well with GitHub.

@ambv Could you set up a build configuration at Travis CI for this repository? You're the owner of the repository and it seems only you can do it.

Then we could add the Travis badge to the README file to browse the results of automatic builds.