### PR TITLE
Use collections.abc.Reversible if it exists

### DIFF
--- a/python2/test_typing.py
+++ b/python2/test_typing.py
@@ -527,7 +527,7 @@ class ProtocolTests(TestCase):
 
     def test_protocol_instance_type_error(self):
         with self.assertRaises(TypeError):
-            isinstance([], typing.Reversible)
+            isinstance(0, typing.SupportsAbs)
 
 
 class GenericTests(TestCase):

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -1372,7 +1372,7 @@ else:
         __slots__ = ()
 
         @abstractmethod
-        def __reversed__(self) -> 'Iterator[T_co]':
+        def __reversed__(self):
             pass
 
 

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -1363,12 +1363,16 @@ class SupportsAbs(_Protocol[T_co]):
         pass
 
 
-class Reversible(_Protocol[T_co]):
-    __slots__ = ()
+if hasattr(collections_abc, 'Reversible'):
+    class Reversible(Iterable[T_co], extra=collections_abc.Reversible):
+        __slots__ = ()
+else:    
+    class Reversible(_Protocol[T_co]):
+        __slots__ = ()
 
-    @abstractmethod
-    def __reversed__(self):
-        pass
+        @abstractmethod
+        def __reversed__(self) -> 'Iterator[T_co]':
+            pass
 
 
 Sized = collections_abc.Sized  # Not generic.
@@ -1399,8 +1403,14 @@ class MutableMapping(Mapping[KT, VT]):
     __extra__ = collections_abc.MutableMapping
 
 
-class Sequence(Sized, Iterable[T_co], Container[T_co]):
-    __extra__ = collections_abc.Sequence
+if hasattr(collections_abc, 'Reversible'):
+    class Sequence(Sized, Reversible[T_co], Container[T_co],
+               extra=collections_abc.Sequence):
+        pass
+else:
+    class Sequence(Sized, Iterable[T_co], Container[T_co],
+                   extra=collections_abc.Sequence):
+        pass
 
 
 class MutableSequence(Sequence[T]):

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -1364,8 +1364,9 @@ class SupportsAbs(_Protocol[T_co]):
 
 
 if hasattr(collections_abc, 'Reversible'):
-    class Reversible(Iterable[T_co], extra=collections_abc.Reversible):
+    class Reversible(Iterable[T_co]):
         __slots__ = ()
+        __extra__ = collections_abc.Reversible
 else:    
     class Reversible(_Protocol[T_co]):
         __slots__ = ()
@@ -1404,13 +1405,11 @@ class MutableMapping(Mapping[KT, VT]):
 
 
 if hasattr(collections_abc, 'Reversible'):
-    class Sequence(Sized, Reversible[T_co], Container[T_co],
-               extra=collections_abc.Sequence):
-        pass
+    class Sequence(Sized, Reversible[T_co], Container[T_co]):
+        __extra__ = collections_abc.Sequence
 else:
-    class Sequence(Sized, Iterable[T_co], Container[T_co],
-                   extra=collections_abc.Sequence):
-        pass
+    class Sequence(Sized, Iterable[T_co], Container[T_co]):
+        __extra__ = collections_abc.Sequence
 
 
 class MutableSequence(Sequence[T]):

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -550,7 +550,7 @@ class ProtocolTests(TestCase):
 
     def test_protocol_instance_type_error(self):
         with self.assertRaises(TypeError):
-            isinstance([], typing.Reversible)
+            isinstance(0, typing.SupportsAbs)
 
 
 class GenericTests(TestCase):

--- a/src/typing.py
+++ b/src/typing.py
@@ -1374,12 +1374,16 @@ class SupportsRound(_Protocol[T_co]):
         pass
 
 
-class Reversible(_Protocol[T_co]):
-    __slots__ = ()
+if hasattr(collections_abc, 'Reversible'):
+    class Reversible(Iterable[T_co], extra=collection_abc.Reversible):
+        __slots__ = ()
+else:    
+    class Reversible(_Protocol[T_co]):
+        __slots__ = ()
 
-    @abstractmethod
-    def __reversed__(self) -> 'Iterator[T_co]':
-        pass
+        @abstractmethod
+        def __reversed__(self) -> 'Iterator[T_co]':
+            pass
 
 
 Sized = collections_abc.Sized  # Not generic.
@@ -1410,10 +1414,14 @@ class Mapping(Sized, Iterable[KT], Container[KT], Generic[VT_co],
 class MutableMapping(Mapping[KT, VT], extra=collections_abc.MutableMapping):
     pass
 
-
-class Sequence(Sized, Iterable[T_co], Container[T_co],
+if hasattr(collections_abc, 'Reversible'):
+    class Sequence(Sized, Reversible[T_co], Container[T_co],
                extra=collections_abc.Sequence):
-    pass
+        pass
+else:
+    class Sequence(Sized, Iterable[T_co], Container[T_co],
+                   extra=collections_abc.Sequence):
+        pass
 
 
 class MutableSequence(Sequence[T], extra=collections_abc.MutableSequence):

--- a/src/typing.py
+++ b/src/typing.py
@@ -1375,7 +1375,7 @@ class SupportsRound(_Protocol[T_co]):
 
 
 if hasattr(collections_abc, 'Reversible'):
-    class Reversible(Iterable[T_co], extra=collection_abc.Reversible):
+    class Reversible(Iterable[T_co], extra=collections_abc.Reversible):
         __slots__ = ()
 else:    
     class Reversible(_Protocol[T_co]):


### PR DESCRIPTION
Fixes #172 . I assumed that if Reversible is present in collections.abc then it means that http://bugs.python.org/issue25987 is resolved as Andrew Barnert proposes (as I understand @gvanrossum agrees with this), i.e., Sequence is subclass of Reversible, and not directly of Iterable.