### PR TITLE
Specific asserts

### DIFF
--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -131,7 +131,7 @@ class TypeVarTests(TestCase):
         # T is a subclass of itself.
         self.assertIsSubclass(T, T)
         # T is an instance of TypeVar
-        assert isinstance(T, TypeVar)
+        self.assertIsInstance(T, TypeVar)
 
     def test_typevar_instance_type_error(self):
         T = TypeVar('T')
@@ -466,20 +466,20 @@ class CallableTests(TestCase):
     def test_callable_instance_works(self):
         def f():
             pass
-        assert isinstance(f, Callable)
-        assert not isinstance(None, Callable)
+        self.assertIsInstance(f, Callable)
+        self.assertNotIsInstance(None, Callable)
 
     def test_callable_instance_type_error(self):
         def f():
             pass
         with self.assertRaises(TypeError):
-            assert isinstance(f, Callable[[], None])
+            self.assertIsInstance(f, Callable[[], None])
         with self.assertRaises(TypeError):
-            assert isinstance(f, Callable[[], Any])
+            self.assertIsInstance(f, Callable[[], Any])
         with self.assertRaises(TypeError):
-            assert not isinstance(None, Callable[[], None])
+            self.assertNotIsInstance(None, Callable[[], None])
         with self.assertRaises(TypeError):
-            assert not isinstance(None, Callable[[], Any])
+            self.assertNotIsInstance(None, Callable[[], Any])
 
     def test_repr(self):
         ct0 = Callable[[], bool]
@@ -1100,26 +1100,26 @@ if PY35:
 class CollectionsAbcTests(TestCase):
 
     def test_hashable(self):
-        assert isinstance(42, typing.Hashable)
-        assert not isinstance([], typing.Hashable)
+        self.assertIsInstance(42, typing.Hashable)
+        self.assertNotIsInstance([], typing.Hashable)
 
     def test_iterable(self):
-        assert isinstance([], typing.Iterable)
+        self.assertIsInstance([], typing.Iterable)
         # Due to ABC caching, the second time takes a separate code
         # path and could fail.  So call this a few times.
-        assert isinstance([], typing.Iterable)
-        assert isinstance([], typing.Iterable)
-        assert isinstance([], typing.Iterable[int])
-        assert not isinstance(42, typing.Iterable)
+        self.assertIsInstance([], typing.Iterable)
+        self.assertIsInstance([], typing.Iterable)
+        self.assertIsInstance([], typing.Iterable[int])
+        self.assertNotIsInstance(42, typing.Iterable)
         # Just in case, also test issubclass() a few times.
         self.assertIsSubclass(list, typing.Iterable)
         self.assertIsSubclass(list, typing.Iterable)
 
     def test_iterator(self):
         it = iter([])
-        assert isinstance(it, typing.Iterator)
-        assert isinstance(it, typing.Iterator[int])
-        assert not isinstance(42, typing.Iterator)
+        self.assertIsInstance(it, typing.Iterator)
+        self.assertIsInstance(it, typing.Iterator[int])
+        self.assertNotIsInstance(42, typing.Iterator)
 
     @skipUnless(PY35, 'Python 3.5 required')
     def test_awaitable(self):
@@ -1131,8 +1131,8 @@ class CollectionsAbcTests(TestCase):
         foo = ns['foo']
         g = foo()
         self.assertIsSubclass(type(g), typing.Awaitable[int])
-        assert isinstance(g, typing.Awaitable)
-        assert not isinstance(foo, typing.Awaitable)
+        self.assertIsInstance(g, typing.Awaitable)
+        self.assertNotIsInstance(foo, typing.Awaitable)
         self.assertIsSubclass(typing.Awaitable[Manager],
                           typing.Awaitable[Employee])
         self.assertNotIsSubclass(typing.Awaitable[Employee],
@@ -1143,56 +1143,56 @@ class CollectionsAbcTests(TestCase):
     def test_async_iterable(self):
         base_it = range(10)  # type: Iterator[int]
         it = AsyncIteratorWrapper(base_it)
-        assert isinstance(it, typing.AsyncIterable)
-        assert isinstance(it, typing.AsyncIterable)
+        self.assertIsInstance(it, typing.AsyncIterable)
+        self.assertIsInstance(it, typing.AsyncIterable)
         self.assertIsSubclass(typing.AsyncIterable[Manager],
                           typing.AsyncIterable[Employee])
-        assert not isinstance(42, typing.AsyncIterable)
+        self.assertNotIsInstance(42, typing.AsyncIterable)
 
     @skipUnless(PY35, 'Python 3.5 required')
     def test_async_iterator(self):
         base_it = range(10)  # type: Iterator[int]
         it = AsyncIteratorWrapper(base_it)
-        assert isinstance(it, typing.AsyncIterator)
+        self.assertIsInstance(it, typing.AsyncIterator)
         self.assertIsSubclass(typing.AsyncIterator[Manager],
                           typing.AsyncIterator[Employee])
-        assert not isinstance(42, typing.AsyncIterator)
+        self.assertNotIsInstance(42, typing.AsyncIterator)
 
     def test_sized(self):
-        assert isinstance([], typing.Sized)
-        assert not isinstance(42, typing.Sized)
+        self.assertIsInstance([], typing.Sized)
+        self.assertNotIsInstance(42, typing.Sized)
 
     def test_container(self):
-        assert isinstance([], typing.Container)
-        assert not isinstance(42, typing.Container)
+        self.assertIsInstance([], typing.Container)
+        self.assertNotIsInstance(42, typing.Container)
 
     def test_abstractset(self):
-        assert isinstance(set(), typing.AbstractSet)
-        assert not isinstance(42, typing.AbstractSet)
+        self.assertIsInstance(set(), typing.AbstractSet)
+        self.assertNotIsInstance(42, typing.AbstractSet)
 
     def test_mutableset(self):
-        assert isinstance(set(), typing.MutableSet)
-        assert not isinstance(frozenset(), typing.MutableSet)
+        self.assertIsInstance(set(), typing.MutableSet)
+        self.assertNotIsInstance(frozenset(), typing.MutableSet)
 
     def test_mapping(self):
-        assert isinstance({}, typing.Mapping)
-        assert not isinstance(42, typing.Mapping)
+        self.assertIsInstance({}, typing.Mapping)
+        self.assertNotIsInstance(42, typing.Mapping)
 
     def test_mutablemapping(self):
-        assert isinstance({}, typing.MutableMapping)
-        assert not isinstance(42, typing.MutableMapping)
+        self.assertIsInstance({}, typing.MutableMapping)
+        self.assertNotIsInstance(42, typing.MutableMapping)
 
     def test_sequence(self):
-        assert isinstance([], typing.Sequence)
-        assert not isinstance(42, typing.Sequence)
+        self.assertIsInstance([], typing.Sequence)
+        self.assertNotIsInstance(42, typing.Sequence)
 
     def test_mutablesequence(self):
-        assert isinstance([], typing.MutableSequence)
-        assert not isinstance((), typing.MutableSequence)
+        self.assertIsInstance([], typing.MutableSequence)
+        self.assertNotIsInstance((), typing.MutableSequence)
 
     def test_bytestring(self):
-        assert isinstance(b'', typing.ByteString)
-        assert isinstance(bytearray(b''), typing.ByteString)
+        self.assertIsInstance(b'', typing.ByteString)
+        self.assertIsInstance(bytearray(b''), typing.ByteString)
 
     def test_list(self):
         self.assertIsSubclass(list, typing.List)
@@ -1222,7 +1222,7 @@ class CollectionsAbcTests(TestCase):
             pass
 
         a = MyList()
-        assert isinstance(a, MyList)
+        self.assertIsInstance(a, MyList)
 
     def test_no_dict_instantiation(self):
         with self.assertRaises(TypeError):
@@ -1238,7 +1238,7 @@ class CollectionsAbcTests(TestCase):
             pass
 
         d = MyDict()
-        assert isinstance(d, MyDict)
+        self.assertIsInstance(d, MyDict)
 
     def test_no_defaultdict_instantiation(self):
         with self.assertRaises(TypeError):
@@ -1254,7 +1254,7 @@ class CollectionsAbcTests(TestCase):
             pass
 
         dd = MyDefDict()
-        assert isinstance(dd, MyDefDict)
+        self.assertIsInstance(dd, MyDefDict)
 
     def test_no_set_instantiation(self):
         with self.assertRaises(TypeError):
@@ -1270,7 +1270,7 @@ class CollectionsAbcTests(TestCase):
             pass
 
         d = MySet()
-        assert isinstance(d, MySet)
+        self.assertIsInstance(d, MySet)
 
     def test_no_frozenset_instantiation(self):
         with self.assertRaises(TypeError):
@@ -1286,7 +1286,7 @@ class CollectionsAbcTests(TestCase):
             pass
 
         d = MyFrozenSet()
-        assert isinstance(d, MyFrozenSet)
+        self.assertIsInstance(d, MyFrozenSet)
 
     def test_no_tuple_instantiation(self):
         with self.assertRaises(TypeError):
@@ -1347,9 +1347,9 @@ class OtherABCTests(TestCase):
             yield 42
 
         cm = manager()
-        assert isinstance(cm, typing.ContextManager)
-        assert isinstance(cm, typing.ContextManager[int])
-        assert not isinstance(42, typing.ContextManager)
+        self.assertIsInstance(cm, typing.ContextManager)
+        self.assertIsInstance(cm, typing.ContextManager[int])
+        self.assertNotIsInstance(42, typing.ContextManager)
 
 
 class NamedTupleTests(TestCase):
@@ -1359,8 +1359,8 @@ class NamedTupleTests(TestCase):
         self.assertIsSubclass(Emp, tuple)
         joe = Emp('Joe', 42)
         jim = Emp(name='Jim', id=1)
-        assert isinstance(joe, Emp)
-        assert isinstance(joe, tuple)
+        self.assertIsInstance(joe, Emp)
+        self.assertIsInstance(joe, tuple)
         assert joe.name == 'Joe'
         assert joe.id == 42
         assert jim.name == 'Jim'

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -903,7 +903,7 @@ class ForwardRefTests(TestCase):
         self.assertEqual(both_hints['right'], Optional[Node[T]])
         self.assertEqual(both_hints['left'], both_hints['right'])
         self.assertEqual(both_hints['stuff'], Optional[int])
-        assert 'blah' not in both_hints
+        self.assertNotIn('blah', both_hints)
 
         left_hints = get_type_hints(t.add_left, globals(), locals())
         self.assertEqual(left_hints['node'], Optional[Node[T]])
@@ -1491,20 +1491,20 @@ class AllTests(TestCase):
     def test_all(self):
         from typing import __all__ as a
         # Just spot-check the first and last of every category.
-        assert 'AbstractSet' in a
-        assert 'ValuesView' in a
-        assert 'cast' in a
-        assert 'overload' in a
+        self.assertIn('AbstractSet', a)
+        self.assertIn('ValuesView', a)
+        self.assertIn('cast', a)
+        self.assertIn('overload', a)
         if hasattr(contextlib, 'AbstractContextManager'):
-            assert 'ContextManager' in a
+            self.assertIn('ContextManager', a)
         # Check that io and re are not exported.
-        assert 'io' not in a
-        assert 're' not in a
+        self.assertNotIn('io', a)
+        self.assertNotIn('re', a)
         # Spot-check that stdlib modules aren't exported.
-        assert 'os' not in a
-        assert 'sys' not in a
+        self.assertNotIn('os', a)
+        self.assertNotIn('sys', a)
         # Check that Text is defined.
-        assert 'Text' in a
+        self.assertIn('Text', a)
 
 
 if __name__ == '__main__':

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -632,8 +632,8 @@ class GenericTests(TestCase):
         self.assertNotEqual(Z, Y[int])
         self.assertNotEqual(Z, Y[T])
 
-        assert str(Z).endswith(
-            '.C<~T>[typing.Tuple[~S, ~T]]<~S, ~T>[~T, int]<~T>[str]')
+        self.assertTrue(str(Z).endswith(
+            '.C<~T>[typing.Tuple[~S, ~T]]<~S, ~T>[~T, int]<~T>[str]'))
 
     def test_dict(self):
         T = TypeVar('T')

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -2,7 +2,7 @@ import contextlib
 import pickle
 import re
 import sys
-from unittest import TestCase as _TestCase, main, skipUnless
+from unittest import TestCase, main, skipUnless
 
 from typing import Any
 from typing import TypeVar, AnyStr
@@ -20,9 +20,7 @@ from typing import Pattern, Match
 import typing
 
 
-class TestCase(_TestCase):
-
-    # vanilla TestCase doesn't have assert*Subclass, see bugs.python.org/14819
+class BaseTestCase(TestCase):
 
     def assertIsSubclass(self, cls, class_or_tuple, msg=None):
         if not issubclass(cls, class_or_tuple):
@@ -55,7 +53,7 @@ class ManagingFounder(Manager, Founder):
     pass
 
 
-class AnyTests(TestCase):
+class AnyTests(BaseTestCase):
 
     def test_any_instance_type_error(self):
         with self.assertRaises(TypeError):
@@ -119,7 +117,7 @@ class AnyTests(TestCase):
         typing.IO[Any]
 
 
-class TypeVarTests(TestCase):
+class TypeVarTests(BaseTestCase):
 
     def test_basic_plain(self):
         T = TypeVar('T')
@@ -224,7 +222,7 @@ class TypeVarTests(TestCase):
             TypeVar('X', str, float, bound=Employee)
 
 
-class UnionTests(TestCase):
+class UnionTests(BaseTestCase):
 
     def test_basics(self):
         u = Union[int, float]
@@ -340,7 +338,7 @@ class UnionTests(TestCase):
         A
 
 
-class TypeVarUnionTests(TestCase):
+class TypeVarUnionTests(BaseTestCase):
 
     def test_simpler(self):
         A = TypeVar('A', int, str, float)
@@ -366,7 +364,7 @@ class TypeVarUnionTests(TestCase):
         self.assertIsSubclass(float, TU)
 
 
-class TupleTests(TestCase):
+class TupleTests(BaseTestCase):
 
     def test_basics(self):
         self.assertTrue(issubclass(Tuple[int, str], Tuple))
@@ -421,7 +419,7 @@ class TupleTests(TestCase):
             issubclass(42, Tuple[int])
 
 
-class CallableTests(TestCase):
+class CallableTests(BaseTestCase):
 
     def test_self_subclass(self):
         self.assertTrue(issubclass(Callable[[int], int], Callable))
@@ -532,7 +530,7 @@ class MySimpleMapping(SimpleMapping[XK, XV]):
             return default
 
 
-class ProtocolTests(TestCase):
+class ProtocolTests(BaseTestCase):
 
     def test_supports_int(self):
         self.assertIsSubclass(int, typing.SupportsInt)
@@ -582,7 +580,7 @@ class ProtocolTests(TestCase):
             isinstance(0, typing.SupportsAbs)
 
 
-class GenericTests(TestCase):
+class GenericTests(BaseTestCase):
 
     def test_basics(self):
         X = SimpleMapping[str, Any]
@@ -809,7 +807,7 @@ class GenericTests(TestCase):
             D[T]
 
 
-class VarianceTests(TestCase):
+class VarianceTests(BaseTestCase):
 
     def test_invariance(self):
         # Because of invariance, List[subclass of X] is not a subclass
@@ -855,7 +853,7 @@ class VarianceTests(TestCase):
                               typing.Mapping[Manager, Manager])
 
 
-class CastTests(TestCase):
+class CastTests(BaseTestCase):
 
     def test_basics(self):
         self.assertEqual(cast(int, 42), 42)
@@ -873,7 +871,7 @@ class CastTests(TestCase):
         cast('hello', 42)
 
 
-class ForwardRefTests(TestCase):
+class ForwardRefTests(BaseTestCase):
 
     def test_basics(self):
 
@@ -1035,7 +1033,7 @@ class ForwardRefTests(TestCase):
         self.assertEqual(hints, {'a': ns['C'], 'return': ns['D']})
 
 
-class OverloadTests(TestCase):
+class OverloadTests(BaseTestCase):
 
     def test_overload_exists(self):
         from typing import overload
@@ -1101,7 +1099,7 @@ if PY35:
     exec(PY35_TESTS)
 
 
-class CollectionsAbcTests(TestCase):
+class CollectionsAbcTests(BaseTestCase):
 
     def test_hashable(self):
         self.assertIsInstance(42, typing.Hashable)
@@ -1341,7 +1339,7 @@ class CollectionsAbcTests(TestCase):
         self.assertEqual(len(MMB[KT, VT]()), 0)
 
 
-class OtherABCTests(TestCase):
+class OtherABCTests(BaseTestCase):
 
     @skipUnless(hasattr(typing, 'ContextManager'),
                 'requires typing.ContextManager')
@@ -1356,7 +1354,7 @@ class OtherABCTests(TestCase):
         self.assertNotIsInstance(42, typing.ContextManager)
 
 
-class NamedTupleTests(TestCase):
+class NamedTupleTests(BaseTestCase):
 
     def test_basics(self):
         Emp = NamedTuple('Emp', [('name', str), ('id', int)])
@@ -1383,7 +1381,7 @@ class NamedTupleTests(TestCase):
             self.assertEqual(jane2, jane)
 
 
-class IOTests(TestCase):
+class IOTests(BaseTestCase):
 
     def test_io(self):
 
@@ -1418,7 +1416,7 @@ class IOTests(TestCase):
         self.assertEqual(__name__, 'typing.io')
 
 
-class RETests(TestCase):
+class RETests(BaseTestCase):
     # Much of this is really testing _TypeAlias.
 
     def test_basics(self):
@@ -1485,7 +1483,7 @@ class RETests(TestCase):
                          "A type alias cannot be subclassed")
 
 
-class AllTests(TestCase):
+class AllTests(BaseTestCase):
     """Tests for __all__."""
 
     def test_all(self):

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -781,9 +781,9 @@ class GenericTests(TestCase):
             a = Node(x)
             b = Node[T](x)
             c = Node[Any](x)
-            assert type(a) is Node
-            assert type(b) is Node
-            assert type(c) is Node
+            self.assertIs(type(a), Node)
+            self.assertIs(type(b), Node)
+            self.assertIs(type(c), Node)
             self.assertEqual(a.label, x)
             self.assertEqual(b.label, x)
             self.assertEqual(c.label, x)
@@ -860,7 +860,7 @@ class CastTests(TestCase):
     def test_basics(self):
         self.assertEqual(cast(int, 42), 42)
         self.assertEqual(cast(float, 42), 42)
-        assert type(cast(float, 42)) is int
+        self.assertIs(type(cast(float, 42)), int)
         self.assertEqual(cast(Any, 42), 42)
         self.assertEqual(cast(list, 42), 42)
         self.assertEqual(cast(Union[str, float], 42), 42)
@@ -1411,9 +1411,9 @@ class IOTests(TestCase):
 
     def test_io_submodule(self):
         from typing.io import IO, TextIO, BinaryIO, __all__, __name__
-        assert IO is typing.IO
-        assert TextIO is typing.TextIO
-        assert BinaryIO is typing.BinaryIO
+        self.assertIs(IO, typing.IO)
+        self.assertIs(TextIO, typing.TextIO)
+        self.assertIs(BinaryIO, typing.BinaryIO)
         self.assertEqual(set(__all__), set(['IO', 'TextIO', 'BinaryIO']))
         self.assertEqual(__name__, 'typing.io')
 
@@ -1470,8 +1470,8 @@ class RETests(TestCase):
 
     def test_re_submodule(self):
         from typing.re import Match, Pattern, __all__, __name__
-        assert Match is typing.Match
-        assert Pattern is typing.Pattern
+        self.assertIs(Match, typing.Match)
+        self.assertIs(Pattern, typing.Pattern)
         self.assertEqual(set(__all__), set(['Match', 'Pattern']))
         self.assertEqual(__name__, 'typing.re')
 

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -157,18 +157,18 @@ class TypeVarTests(TestCase):
     def test_union_unique(self):
         X = TypeVar('X')
         Y = TypeVar('Y')
-        assert X != Y
+        self.assertNotEqual(X, Y)
         self.assertEqual(Union[X], X)
-        assert Union[X] != Union[X, Y]
+        self.assertNotEqual(Union[X], Union[X, Y])
         self.assertEqual(Union[X, X], X)
-        assert Union[X, int] != Union[X]
-        assert Union[X, int] != Union[int]
+        self.assertNotEqual(Union[X, int], Union[X])
+        self.assertNotEqual(Union[X, int], Union[int])
         self.assertEqual(Union[X, int].__union_params__, (X, int))
         self.assertEqual(Union[X, int].__union_set_params__, {X, int})
 
     def test_union_constrained(self):
         A = TypeVar('A', str, bytes)
-        assert Union[A, str] != Union[A]
+        self.assertNotEqual(Union[A, str], Union[A])
 
     def test_repr(self):
         self.assertEqual(repr(T), '~T')
@@ -381,8 +381,8 @@ class TupleTests(TestCase):
     def test_equality(self):
         self.assertEqual(Tuple[int], Tuple[int])
         self.assertEqual(Tuple[int, ...], Tuple[int, ...])
-        assert Tuple[int] != Tuple[int, int]
-        assert Tuple[int] != Tuple[int, ...]
+        self.assertNotEqual(Tuple[int], Tuple[int, int])
+        self.assertNotEqual(Tuple[int], Tuple[int, ...])
 
     def test_tuple_subclass(self):
         class MyTuple(tuple):
@@ -620,17 +620,17 @@ class GenericTests(TestCase):
 
         X = C[Tuple[S, T]]
         self.assertEqual(X, C[Tuple[S, T]])
-        assert X != C[Tuple[T, S]]
+        self.assertNotEqual(X, C[Tuple[T, S]])
 
         Y = X[T, int]
         self.assertEqual(Y, X[T, int])
-        assert Y != X[S, int]
-        assert Y != X[T, str]
+        self.assertNotEqual(Y, X[S, int])
+        self.assertNotEqual(Y, X[T, str])
 
         Z = Y[str]
         self.assertEqual(Z, Y[str])
-        assert Z != Y[int]
-        assert Z != Y[T]
+        self.assertNotEqual(Z, Y[int])
+        self.assertNotEqual(Z, Y[T])
 
         assert str(Z).endswith(
             '.C<~T>[typing.Tuple[~S, ~T]]<~S, ~T>[~T, int]<~T>[str]')
@@ -708,7 +708,7 @@ class GenericTests(TestCase):
     def test_eq_1(self):
         self.assertEqual(Generic, Generic)
         self.assertEqual(Generic[T], Generic[T])
-        assert Generic[KT] != Generic[VT]
+        self.assertNotEqual(Generic[KT], Generic[VT])
 
     def test_eq_2(self):
 
@@ -719,9 +719,9 @@ class GenericTests(TestCase):
             pass
 
         self.assertEqual(A, A)
-        assert A != B
+        self.assertNotEqual(A, B)
         self.assertEqual(A[T], A[T])
-        assert A[T] != B[T]
+        self.assertNotEqual(A[T], B[T])
 
     def test_multiple_inheritance(self):
 

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -127,7 +127,7 @@ class TypeVarTests(TestCase):
         self.assertIsSubclass(int, T)
         self.assertIsSubclass(str, T)
         # T equals itself.
-        assert T == T
+        self.assertEqual(T, T)
         # T is a subclass of itself.
         self.assertIsSubclass(T, T)
         # T is an instance of TypeVar
@@ -145,7 +145,7 @@ class TypeVarTests(TestCase):
         self.assertIsSubclass(bytes, A)
         self.assertNotIsSubclass(int, A)
         # A equals itself.
-        assert A == A
+        self.assertEqual(A, A)
         # A is a subclass of itself.
         self.assertIsSubclass(A, A)
 
@@ -158,13 +158,13 @@ class TypeVarTests(TestCase):
         X = TypeVar('X')
         Y = TypeVar('Y')
         assert X != Y
-        assert Union[X] == X
+        self.assertEqual(Union[X], X)
         assert Union[X] != Union[X, Y]
-        assert Union[X, X] == X
+        self.assertEqual(Union[X, X], X)
         assert Union[X, int] != Union[X]
         assert Union[X, int] != Union[int]
-        assert Union[X, int].__union_params__ == (X, int)
-        assert Union[X, int].__union_set_params__ == {X, int}
+        self.assertEqual(Union[X, int].__union_params__, (X, int))
+        self.assertEqual(Union[X, int].__union_set_params__, {X, int})
 
     def test_union_constrained(self):
         A = TypeVar('A', str, bytes)
@@ -379,8 +379,8 @@ class TupleTests(TestCase):
         self.assertFalse(issubclass(Tuple, tuple))  # Can't have it both ways.
 
     def test_equality(self):
-        assert Tuple[int] == Tuple[int]
-        assert Tuple[int, ...] == Tuple[int, ...]
+        self.assertEqual(Tuple[int], Tuple[int])
+        self.assertEqual(Tuple[int, ...], Tuple[int, ...])
         assert Tuple[int] != Tuple[int, int]
         assert Tuple[int] != Tuple[int, ...]
 
@@ -586,13 +586,13 @@ class GenericTests(TestCase):
 
     def test_basics(self):
         X = SimpleMapping[str, Any]
-        assert X.__parameters__ == ()
+        self.assertEqual(X.__parameters__, ())
         with self.assertRaises(TypeError):
             X[str]
         with self.assertRaises(TypeError):
             X[str, str]
         Y = SimpleMapping[XK, str]
-        assert Y.__parameters__ == (XK,)
+        self.assertEqual(Y.__parameters__, (XK,))
         Y[str]
         with self.assertRaises(TypeError):
             Y[str, str]
@@ -619,16 +619,16 @@ class GenericTests(TestCase):
             pass
 
         X = C[Tuple[S, T]]
-        assert X == C[Tuple[S, T]]
+        self.assertEqual(X, C[Tuple[S, T]])
         assert X != C[Tuple[T, S]]
 
         Y = X[T, int]
-        assert Y == X[T, int]
+        self.assertEqual(Y, X[T, int])
         assert Y != X[S, int]
         assert Y != X[T, str]
 
         Z = Y[str]
-        assert Z == Y[str]
+        self.assertEqual(Z, Y[str])
         assert Z != Y[int]
         assert Z != Y[T]
 
@@ -685,27 +685,29 @@ class GenericTests(TestCase):
         class C(Generic[T]):
             pass
 
-        assert C.__module__ == __name__
+        self.assertEqual(C.__module__, __name__)
         if not PY32:
-            assert C.__qualname__ == 'GenericTests.test_repr_2.<locals>.C'
-        assert repr(C).split('.')[-1] == 'C<~T>'
+            self.assertEqual(C.__qualname__,
+                             'GenericTests.test_repr_2.<locals>.C')
+        self.assertEqual(repr(C).split('.')[-1], 'C<~T>')
         X = C[int]
-        assert X.__module__ == __name__
+        self.assertEqual(X.__module__, __name__)
         if not PY32:
-            assert X.__qualname__ == 'C'
-        assert repr(X).split('.')[-1] == 'C<~T>[int]'
+            self.assertEqual(X.__qualname__, 'C')
+        self.assertEqual(repr(X).split('.')[-1], 'C<~T>[int]')
 
         class Y(C[int]):
             pass
 
-        assert Y.__module__ == __name__
+        self.assertEqual(Y.__module__, __name__)
         if not PY32:
-            assert Y.__qualname__ == 'GenericTests.test_repr_2.<locals>.Y'
-        assert repr(Y).split('.')[-1] == 'Y'
+            self.assertEqual(Y.__qualname__,
+                             'GenericTests.test_repr_2.<locals>.Y')
+        self.assertEqual(repr(Y).split('.')[-1], 'Y')
 
     def test_eq_1(self):
-        assert Generic == Generic
-        assert Generic[T] == Generic[T]
+        self.assertEqual(Generic, Generic)
+        self.assertEqual(Generic[T], Generic[T])
         assert Generic[KT] != Generic[VT]
 
     def test_eq_2(self):
@@ -716,9 +718,9 @@ class GenericTests(TestCase):
         class B(Generic[T]):
             pass
 
-        assert A == A
+        self.assertEqual(A, A)
         assert A != B
-        assert A[T] == A[T]
+        self.assertEqual(A[T], A[T])
         assert A[T] != B[T]
 
     def test_multiple_inheritance(self):
@@ -732,7 +734,7 @@ class GenericTests(TestCase):
         class C(A[T, VT], Generic[VT, T, KT], B[KT, T]):
             pass
 
-        assert C.__parameters__ == (VT, T, KT)
+        self.assertEqual(C.__parameters__, (VT, T, KT))
 
     def test_nested(self):
 
@@ -762,7 +764,7 @@ class GenericTests(TestCase):
         a.set([])
         a.append(1)
         a.append(42)
-        assert a.get() == [1, 42]
+        self.assertEqual(a.get(), [1, 42])
 
     def test_type_erasure(self):
         T = TypeVar('T')
@@ -782,9 +784,9 @@ class GenericTests(TestCase):
             assert type(a) is Node
             assert type(b) is Node
             assert type(c) is Node
-            assert a.label == x
-            assert b.label == x
-            assert c.label == x
+            self.assertEqual(a.label, x)
+            self.assertEqual(b.label, x)
+            self.assertEqual(c.label, x)
 
         foo(42)
 
@@ -797,7 +799,7 @@ class GenericTests(TestCase):
         class D(C):
             pass
 
-        assert D.__parameters__ == ()
+        self.assertEqual(D.__parameters__, ())
 
         with self.assertRaises(Exception):
             D[int]
@@ -856,14 +858,14 @@ class VarianceTests(TestCase):
 class CastTests(TestCase):
 
     def test_basics(self):
-        assert cast(int, 42) == 42
-        assert cast(float, 42) == 42
+        self.assertEqual(cast(int, 42), 42)
+        self.assertEqual(cast(float, 42), 42)
         assert type(cast(float, 42)) is int
-        assert cast(Any, 42) == 42
-        assert cast(list, 42) == 42
-        assert cast(Union[str, float], 42) == 42
-        assert cast(AnyStr, 42) == 42
-        assert cast(None, 42) == 42
+        self.assertEqual(cast(Any, 42), 42)
+        self.assertEqual(cast(list, 42), 42)
+        self.assertEqual(cast(Union[str, float], 42), 42)
+        self.assertEqual(cast(AnyStr, 42), 42)
+        self.assertEqual(cast(None, 42), 42)
 
     def test_errors(self):
         # Bogus calls are not expected to fail.
@@ -897,15 +899,17 @@ class ForwardRefTests(TestCase):
 
         t = Node[int]
         both_hints = get_type_hints(t.add_both, globals(), locals())
-        assert both_hints['left'] == both_hints['right'] == Optional[Node[T]]
-        assert both_hints['stuff'] == Optional[int]
+        self.assertEqual(both_hints['left'], Optional[Node[T]])
+        self.assertEqual(both_hints['right'], Optional[Node[T]])
+        self.assertEqual(both_hints['left'], both_hints['right'])
+        self.assertEqual(both_hints['stuff'], Optional[int])
         assert 'blah' not in both_hints
 
         left_hints = get_type_hints(t.add_left, globals(), locals())
-        assert left_hints['node'] == Optional[Node[T]]
+        self.assertEqual(left_hints['node'], Optional[Node[T]])
 
         right_hints = get_type_hints(t.add_right, globals(), locals())
-        assert right_hints['node'] == Optional[Node[T]]
+        self.assertEqual(right_hints['node'], Optional[Node[T]])
 
     def test_forwardref_instance_type_error(self):
         fr = typing._ForwardRef('int')
@@ -1028,7 +1032,7 @@ class ForwardRefTests(TestCase):
         ns = {}
         exec(code, ns)
         hints = get_type_hints(ns['C'].foo)
-        assert hints == {'a': ns['C'], 'return': ns['D']}
+        self.assertEqual(hints, {'a': ns['C'], 'return': ns['D']})
 
 
 class OverloadTests(TestCase):
@@ -1326,15 +1330,15 @@ class CollectionsAbcTests(TestCase):
             def __len__(self):
                 return 0
 
-        assert len(MMC()) == 0
+        self.assertEqual(len(MMC()), 0)
 
         class MMB(typing.MutableMapping[KT, VT]):
             def __len__(self):
                 return 0
 
-        assert len(MMB()) == 0
-        assert len(MMB[str, str]()) == 0
-        assert len(MMB[KT, VT]()) == 0
+        self.assertEqual(len(MMB()), 0)
+        self.assertEqual(len(MMB[str, str]()), 0)
+        self.assertEqual(len(MMB[KT, VT]()), 0)
 
 
 class OtherABCTests(TestCase):
@@ -1361,13 +1365,13 @@ class NamedTupleTests(TestCase):
         jim = Emp(name='Jim', id=1)
         self.assertIsInstance(joe, Emp)
         self.assertIsInstance(joe, tuple)
-        assert joe.name == 'Joe'
-        assert joe.id == 42
-        assert jim.name == 'Jim'
-        assert jim.id == 1
-        assert Emp.__name__ == 'Emp'
-        assert Emp._fields == ('name', 'id')
-        assert Emp._field_types == dict(name=str, id=int)
+        self.assertEqual(joe.name, 'Joe')
+        self.assertEqual(joe.id, 42)
+        self.assertEqual(jim.name, 'Jim')
+        self.assertEqual(jim.id, 1)
+        self.assertEqual(Emp.__name__, 'Emp')
+        self.assertEqual(Emp._fields, ('name', 'id'))
+        self.assertEqual(Emp._field_types, dict(name=str, id=int))
 
     def test_pickle(self):
         global Emp  # pickle wants to reference the class by name
@@ -1387,7 +1391,7 @@ class IOTests(TestCase):
             return a.readline()
 
         a = stuff.__annotations__['a']
-        assert a.__parameters__ == (AnyStr,)
+        self.assertEqual(a.__parameters__, (AnyStr,))
 
     def test_textio(self):
 
@@ -1395,7 +1399,7 @@ class IOTests(TestCase):
             return a.readline()
 
         a = stuff.__annotations__['a']
-        assert a.__parameters__ == ()
+        self.assertEqual(a.__parameters__, ())
 
     def test_binaryio(self):
 
@@ -1403,15 +1407,15 @@ class IOTests(TestCase):
             return a.readline()
 
         a = stuff.__annotations__['a']
-        assert a.__parameters__ == ()
+        self.assertEqual(a.__parameters__, ())
 
     def test_io_submodule(self):
         from typing.io import IO, TextIO, BinaryIO, __all__, __name__
         assert IO is typing.IO
         assert TextIO is typing.TextIO
         assert BinaryIO is typing.BinaryIO
-        assert set(__all__) == set(['IO', 'TextIO', 'BinaryIO'])
-        assert __name__ == 'typing.io'
+        self.assertEqual(set(__all__), set(['IO', 'TextIO', 'BinaryIO']))
+        self.assertEqual(__name__, 'typing.io')
 
 
 class RETests(TestCase):
@@ -1457,19 +1461,19 @@ class RETests(TestCase):
             isinstance(42, Pattern[str])
 
     def test_repr(self):
-        assert repr(Pattern) == 'Pattern[~AnyStr]'
-        assert repr(Pattern[str]) == 'Pattern[str]'
-        assert repr(Pattern[bytes]) == 'Pattern[bytes]'
-        assert repr(Match) == 'Match[~AnyStr]'
-        assert repr(Match[str]) == 'Match[str]'
-        assert repr(Match[bytes]) == 'Match[bytes]'
+        self.assertEqual(repr(Pattern), 'Pattern[~AnyStr]')
+        self.assertEqual(repr(Pattern[str]), 'Pattern[str]')
+        self.assertEqual(repr(Pattern[bytes]), 'Pattern[bytes]')
+        self.assertEqual(repr(Match), 'Match[~AnyStr]')
+        self.assertEqual(repr(Match[str]), 'Match[str]')
+        self.assertEqual(repr(Match[bytes]), 'Match[bytes]')
 
     def test_re_submodule(self):
         from typing.re import Match, Pattern, __all__, __name__
         assert Match is typing.Match
         assert Pattern is typing.Pattern
-        assert set(__all__) == set(['Match', 'Pattern'])
-        assert __name__ == 'typing.re'
+        self.assertEqual(set(__all__), set(['Match', 'Pattern']))
+        self.assertEqual(__name__, 'typing.re')
 
     def test_cannot_subclass(self):
         with self.assertRaises(TypeError) as ex:
@@ -1477,7 +1481,8 @@ class RETests(TestCase):
             class A(typing.Match):
                 pass
 
-        assert str(ex.exception) == "A type alias cannot be subclassed"
+        self.assertEqual(str(ex.exception),
+                         "A type alias cannot be subclassed")
 
 
 class AllTests(TestCase):


### PR DESCRIPTION
This PR converts the tests from simple `assert` statements to `TestCase.assert*` calls.  This ensures that the tests actually test something even if Python is run with -O, and makes the tests fit the style of the rest of the standard library tests.

Most of the changes were made by simple `s/assert .../self.assert.../` replacements, with a few manual touchups.