### PR TITLE
Fix generics inheritance and drop __subclasscheck__

### DIFF
--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -1,4 +1,5 @@
 import contextlib
+import collections
 import pickle
 import re
 import sys
@@ -1195,13 +1196,17 @@ class CollectionsAbcTests(TestCase):
         with self.assertRaises(TypeError):
             typing.List[int]()
 
-    def test_list_subclass_instantiation(self):
+    def test_list_subclass(self):
 
         class MyList(typing.List[int]):
             pass
 
         a = MyList()
         assert isinstance(a, MyList)
+        assert isinstance(a, typing.Sequence)
+
+        assert issubclass(MyList, list)
+        assert not issubclass(list, MyList)
 
     def test_no_dict_instantiation(self):
         with self.assertRaises(TypeError):
@@ -1211,13 +1216,17 @@ class CollectionsAbcTests(TestCase):
         with self.assertRaises(TypeError):
             typing.Dict[str, int]()
 
-    def test_dict_subclass_instantiation(self):
+    def test_dict_subclass(self):
 
         class MyDict(typing.Dict[str, int]):
             pass
 
         d = MyDict()
         assert isinstance(d, MyDict)
+        assert isinstance(d, typing.MutableMapping)
+
+        assert issubclass(MyDict, dict)
+        assert not issubclass(dict, MyDict)
 
     def test_no_defaultdict_instantiation(self):
         with self.assertRaises(TypeError):
@@ -1227,13 +1236,16 @@ class CollectionsAbcTests(TestCase):
         with self.assertRaises(TypeError):
             typing.DefaultDict[str, int]()
 
-    def test_defaultdict_subclass_instantiation(self):
+    def test_defaultdict_subclass(self):
 
         class MyDefDict(typing.DefaultDict[str, int]):
             pass
 
         dd = MyDefDict()
         assert isinstance(dd, MyDefDict)
+
+        assert issubclass(MyDefDict, collections.defaultdict)
+        assert not issubclass(collections.defaultdict, MyDefDict)
 
     def test_no_set_instantiation(self):
         with self.assertRaises(TypeError):
@@ -1314,6 +1326,13 @@ class CollectionsAbcTests(TestCase):
         assert len(MMB()) == 0
         assert len(MMB[str, str]()) == 0
         assert len(MMB[KT, VT]()) == 0
+
+        assert not issubclass(dict, MMA)
+        assert not issubclass(dict, MMB)
+
+        assert issubclass(MMA, typing.Mapping)
+        assert issubclass(MMB, typing.Mapping)
+        assert issubclass(MMC, typing.Mapping)
 
 
 class OtherABCTests(TestCase):

--- a/src/typing.py
+++ b/src/typing.py
@@ -894,8 +894,6 @@ def _next_in_mro(cls):
 class GenericMeta(TypingMeta, abc.ABCMeta):
     """Metaclass for generic types."""
 
-    __extra__ = None
-
     def __new__(cls, name, bases, namespace,
                 tvars=None, args=None, origin=None, extra=None):
         self = super().__new__(cls, name, bases, namespace, _root=True)
@@ -943,10 +941,7 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
         self.__parameters__ = tvars
         self.__args__ = args
         self.__origin__ = origin
-        if extra is not None:
-            self.__extra__ = extra
-        # Else __extra__ is inherited, eventually from the
-        # (meta-)class default above.
+        self.__extra__ = extra
         # Speed hack (https://github.com/python/typing/issues/196).
         self.__next_in_mro__ = _next_in_mro(self)
         return self
@@ -1307,6 +1302,7 @@ class _ProtocolMeta(GenericMeta):
                             attr != '__next_in_mro__' and
                             attr != '__parameters__' and
                             attr != '__origin__' and
+                            attr != '__extra__' and
                             attr != '__module__'):
                         attrs.add(attr)
 
@@ -1470,7 +1466,7 @@ class ByteString(Sequence[int], extra=collections_abc.ByteString):
 ByteString.register(type(memoryview(b'')))
 
 
-class List(list, MutableSequence[T]):
+class List(list, MutableSequence[T], extra=list):
 
     def __new__(cls, *args, **kwds):
         if _geqv(cls, List):
@@ -1479,7 +1475,7 @@ class List(list, MutableSequence[T]):
         return list.__new__(cls, *args, **kwds)
 
 
-class Set(set, MutableSet[T]):
+class Set(set, MutableSet[T], extra=set):
 
     def __new__(cls, *args, **kwds):
         if _geqv(cls, Set):
@@ -1502,7 +1498,8 @@ class _FrozenSetMeta(GenericMeta):
         return super().__subclasscheck__(cls)
 
 
-class FrozenSet(frozenset, AbstractSet[T_co], metaclass=_FrozenSetMeta):
+class FrozenSet(frozenset, AbstractSet[T_co], metaclass=_FrozenSetMeta,
+                extra=frozenset):
     __slots__ = ()
 
     def __new__(cls, *args, **kwds):
@@ -1538,7 +1535,7 @@ if hasattr(contextlib, 'AbstractContextManager'):
     __all__.append('ContextManager')
 
 
-class Dict(dict, MutableMapping[KT, VT]):
+class Dict(dict, MutableMapping[KT, VT], extra=dict):
 
     def __new__(cls, *args, **kwds):
         if _geqv(cls, Dict):
@@ -1546,7 +1543,8 @@ class Dict(dict, MutableMapping[KT, VT]):
                             "use dict() instead")
         return dict.__new__(cls, *args, **kwds)
 
-class DefaultDict(collections.defaultdict, MutableMapping[KT, VT]):
+class DefaultDict(collections.defaultdict, MutableMapping[KT, VT],
+                  extra=collections.defaultdict):
 
     def __new__(cls, *args, **kwds):
         if _geqv(cls, DefaultDict):


### PR DESCRIPTION
I don't expect this to be reviewed anytime soon, but the effort is now fairly complete, so might as well put it out there for comments.

Resolves #136
Resolves #202
Resolves #203

At the heart of #136 is a conflation between type compatibility and subtype relationships. Even though `Sequence[Manager]` is compatible with `Sequence[Employee]`, it's not a subclass of it. Rather, both derive from `Sequence[+T_co]`.

To address this, the PR introduces a new helper `is_compatible()`, which implements the "is consistent with or a subtype of" relation. In short, it does what `issubclass()` has been doing until now.

The practical end result is that

* `issubclass()` is no longer applicable to the special types `Any`, `Union`, etc.

* `is_compatible()` always works — if neither argument is a special type, `is_compatible(T1, T2)` reduces to `issubclass(T1, T2)`

* `issubclass()` acquires its normal semantics w.r.t. generics:

    ```python
    >>> issubclass(Sequence[Manager], Sequence[Employee])
    False
    >>> issubclass(Sequence[Manager], Sequence)
    True
    ```

   whereas:

    ```python
    >>> is_compatible(Sequence[Manager], Sequence[Employee])
    True
    ```


#### Commit summary

There are three commits:

* The first simply stops the `__extra__` linkage from leaking down to generics' subclasses. This fixes the bug where `issubclass(dict, CustomMapping) == True`. [[Diff](a22b68e...2ef2a50)]

* The second adds the `__extra__` ABCs as actual base classes of their `typing` twins. It also refactors `GenericMeta.__subclasscheck__` into a compatibility check and a `__subclasshook__` dedicated to handling the `__extra__` connection. [[Diff](2ef2a50...0ec4dd2)] This achieves a few things:

  * User-defined generics become recognized as subclasses of the associated `collections` ABCs.
  * Abstract and mixin methods from `collections.abc` become available.
  * `issubclass(list, Iterable[X])` no longer returns true for arbitrary `X` (#136).

* The final commit is largely a mechanical change: the special types are made to raise a `TypeError` in response to `issubclass()`. Every type metaclass gets a method named `__is_compatible__` to host the prior `__subclasscheck__` logic. [[Diff]](0ec4dd2...fd4a1b0)


#### Notes

* Full parity is preserved in using unparameterized types in place of the corresponding `collections.abc` classes in `isinstance()` and `issubclass()` calls:

    ```python
    issubclass(type, typing.Callable) == issubclass(type, collections.Callable) == True
    issubclass(list, typing.Iterable) == issubclass(list, collections.Iterable) == True
    ...
    ```

* The intent has been not to mess with the types' behavior. That said, the introduction of `is_compatible()` yields a couple of automatic improvements regarding `Any`:

    * The relation evaluates to true when either argument is `Any`; previously `issubclass(Any, C)` would return false for some arbitrary class `C` but true for a `typing` type.
    * `is_compatible(Iterable[Any], Iterable[int])` correctly returns true.

* The merging of #205 caused a huge conflict in the tests. I will look into it eventually if there's interest in merging this.

* The proposal is compatible with the plan to convert some of the collection types to protocols, if that's still on the table.

