### PR TITLE
Fix an indentation error in the rST for NewType

### DIFF
--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -1191,9 +1191,9 @@ simple unique types with almost zero runtime overhead. For a static type
 checker ``Derived = NewType('Derived', Base)`` is roughly equivalent
 to a definition::
 
-class Derived(Base):
-    def __init__(self, _x: Base) -> None:
-        ...
+  class Derived(Base):
+      def __init__(self, _x: Base) -> None:
+          ...
 
 While at runtime, ``NewType('Derived', Base)`` returns a dummy function
 that simply returns its argument. Type checkers require explicit casts


### PR DESCRIPTION
In the version of [PEP 484 on python.org](https://www.python.org/dev/peps/pep-0484/#newtype-helper-function), this causes:

> System Message: WARNING/2 ( `pep-0484.txt` , line 1194)
> 
> Literal block expected; none found.
