### PR TITLE
Add 'FrozenSet' to __all__

### DIFF
--- a/python2/typing.py
+++ b/python2/typing.py
@@ -54,6 +54,7 @@ __all__ = [
     'DefaultDict',
     'List',
     'Set',
+    'FrozenSet',
     'NamedTuple',  # Not really a type.
     'Generator',
 

--- a/src/typing.py
+++ b/src/typing.py
@@ -57,6 +57,7 @@ __all__ = [
     'DefaultDict',
     'List',
     'Set',
+    'FrozenSet',
     'NamedTuple',  # Not really a type.
     'Generator',
 


### PR DESCRIPTION
Mypy would complain if importing 'FrozenSet', since it wasn't in `__all__`. It happily works now.

I can also submit a patch to b.p.o if needed.

Edit: Yep, I fail at testing, and mypy still complains. Is there something else to do for mypy to recognize `FrozenSet` is in typing?