### PR TITLE
Make no_type_check apply on classes too

### DIFF
--- a/python2/test_typing.py
+++ b/python2/test_typing.py
@@ -1353,6 +1353,15 @@ class AllTests(BaseTestCase):
         # Check that Text is defined.
         self.assertIn('Text', a)
 
+    def test_respect_no_type_check(self):
+        @no_type_check
+        class NoTpCheck(object):
+            class Inn(object):
+                def __init__(self, x): pass
+                    # type: (this is not actualy a type) -> None
+        self.assertTrue(NoTpCheck.__no_type_check__)
+        self.assertTrue(NoTpCheck.Inn.__init__.__no_type_check__)
+
     def test_get_type_hints_dummy(self):
 
         def foo(x):

--- a/python2/test_typing.py
+++ b/python2/test_typing.py
@@ -1354,7 +1354,7 @@ class AllTests(BaseTestCase):
         self.assertIn('Text', a)
 
     def test_respect_no_type_check(self):
-        @no_type_check
+        @typing.no_type_check
         class NoTpCheck(object):
             class Inn(object):
                 def __init__(self, x): pass

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -1241,17 +1241,25 @@ def no_type_check(arg):
     """Decorator to indicate that annotations are not type hints.
 
     The argument must be a class or function; if it is a class, it
-    applies recursively to all methods defined in that class (but not
-    to methods defined in its superclasses or subclasses).
+    applies recursively to all methods and classes defined in that class
+    (but not to methods defined in its superclasses or subclasses).
 
-    This mutates the function(s) in place.
+    This mutates the function(s) or class(es) in place.
     """
     if isinstance(arg, type):
-        for obj in arg.__dict__.values():
+        arg_attrs = arg.__dict__.copy()
+        for attr, val in arg.__dict__.items():
+            if val in arg.__bases__:
+                arg_attrs.pop(attr)
+        for obj in arg_attrs.values():
             if isinstance(obj, types.FunctionType):
                 obj.__no_type_check__ = True
-    else:
+            if isinstance(obj, type):
+                no_type_check(obj)
+    try:
         arg.__no_type_check__ = True
+    except TypeError: # built-in classes
+        pass
     return arg
 
 

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -1209,6 +1209,12 @@ class GetTypeHintTests(BaseTestCase):
         self.assertTrue(NoTpCheck.__no_type_check__)
         self.assertTrue(NoTpCheck.Inn.__init__.__no_type_check__)
         self.assertEqual(gth(ann_module2.NTC.meth), {})
+        class ABase(Generic[T]):
+            def meth(x: int): ...
+        @no_type_check
+        class Der(ABase): ...
+        self.assertEqual(gth(ABase.meth), {'x':int})
+
 
     def test_previous_behavior(self):
         def testf(x, y): ...

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -1202,6 +1202,12 @@ class GetTypeHintTests(BaseTestCase):
 
     @skipUnless(PY36, 'Python 3.6 required')
     def test_respect_no_type_check(self):
+        @no_type_check
+        class NoTpCheck:
+            class Inn:
+                def __init__(self, x: 'not a type'): ...
+        self.assertTrue(NoTpCheck.__no_type_check__)
+        self.assertTrue(NoTpCheck.Inn.__init__.__no_type_check__)
         self.assertEqual(gth(ann_module2.NTC.meth), {})
 
     def test_previous_behavior(self):

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -1213,7 +1213,7 @@ class GetTypeHintTests(BaseTestCase):
             def meth(x: int): ...
         @no_type_check
         class Der(ABase): ...
-        self.assertEqual(gth(ABase.meth), {'x':int})
+        self.assertEqual(gth(ABase.meth), {'x': int})
 
 
     def test_previous_behavior(self):

--- a/src/typing.py
+++ b/src/typing.py
@@ -1347,17 +1347,18 @@ def no_type_check(arg):
     """Decorator to indicate that annotations are not type hints.
 
     The argument must be a class or function; if it is a class, it
-    applies recursively to all methods defined in that class (but not
-    to methods defined in its superclasses or subclasses).
+    applies recursively to all methods and classes defined in that class
+    (but not to methods defined in its superclasses or subclasses).
 
-    This mutates the function(s) in place.
+    This mutates the function(s) or class(es) in place.
     """
     if isinstance(arg, type):
         for obj in arg.__dict__.values():
             if isinstance(obj, types.FunctionType):
                 obj.__no_type_check__ = True
-    else:
-        arg.__no_type_check__ = True
+            if isinstance(obj, type):
+                no_type_check(obj)
+    arg.__no_type_check__ = True
     return arg
 
 

--- a/src/typing.py
+++ b/src/typing.py
@@ -1353,12 +1353,19 @@ def no_type_check(arg):
     This mutates the function(s) or class(es) in place.
     """
     if isinstance(arg, type):
-        for obj in arg.__dict__.values():
+        arg_attrs = arg.__dict__.copy()
+        for attr, val in arg.__dict__.items():
+            if val in arg.__bases__:
+                arg_attrs.pop(attr)
+        for obj in arg_attrs.values():
             if isinstance(obj, types.FunctionType):
                 obj.__no_type_check__ = True
             if isinstance(obj, type):
                 no_type_check(obj)
-    arg.__no_type_check__ = True
+    try:
+        arg.__no_type_check__ = True
+    except TypeError: # built-in classes
+        pass
     return arg
 
 


### PR DESCRIPTION
@gvanrossum 
Since we now have variable annotations, no_type_check should attach ``__no_type_check__`` also to classes (not only to functions/methods as before). I think it also should be recursive on classes so that here:
```python
@no_type_check
class C:
    class Inn:
        def __init__(self, x: 'not a type'): ...
```
we will have ``C.Inn.__init__.__no_type_check__ == True``