### PR TITLE
New backward-compatible NamedTuple

### DIFF
--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -1169,6 +1169,9 @@ class CSub(B):
     z: ClassVar['CSub'] = B()
 class G(Generic[T]):
     lst: ClassVar[List[T]] = []
+class CoolEmployee(NamedTuple):
+    name: str
+    cool: int
 """
 
 if PY36:
@@ -1585,6 +1588,17 @@ class NamedTupleTests(BaseTestCase):
         self.assertEqual(Emp.__name__, 'Emp')
         self.assertEqual(Emp._fields, ('name', 'id'))
         self.assertEqual(Emp._field_types, dict(name=str, id=int))
+
+    @skipUnless(PY36, 'Python 3.6 required')
+    def test_annotation_usage(self):
+        tim = CoolEmployee('Tim', 9000)
+        self.assertIsInstance(tim, CoolEmployee)
+        self.assertIsInstance(tim, tuple)
+        self.assertEqual(tim.name, 'Tim')
+        self.assertEqual(tim.cool, 9000)
+        self.assertEqual(CoolEmployee.__name__, 'CoolEmployee')
+        self.assertEqual(CoolEmployee._fields, ('name', 'cool'))
+        self.assertEqual(CoolEmployee._field_types, dict(name=str, cool=int))
 
     def test_pickle(self):
         global Emp  # pickle wants to reference the class by name

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -1169,6 +1169,7 @@ class CSub(B):
     z: ClassVar['CSub'] = B()
 class G(Generic[T]):
     lst: ClassVar[List[T]] = []
+
 class CoolEmployee(NamedTuple):
     name: str
     cool: int

--- a/src/typing.py
+++ b/src/typing.py
@@ -1802,7 +1802,7 @@ class Type(Generic[CT_co], extra=type):
 
 
 def _make_nmtuple(name, types):
-    nm_tpl = collections.namedtuple(name, [n for n in types])
+    nm_tpl = collections.namedtuple(name, [n for n, t in types])
     nm_tpl._field_types = types
     try:
         nm_tpl.__module__ = sys._getframe(2).f_globals.get('__name__', '__main__')
@@ -1818,7 +1818,7 @@ if sys.version_info[:2] >= (3, 6):
             if _root:
                 return super().__new__(cls, typename, bases, ns)
             types = ns.get('__annotations__', {})
-            return _make_nmtuple(typename, types)
+            return _make_nmtuple(typename, types.items())
 
     class NamedTuple(metaclass=NamedTupleMeta, _root=True):
         """Typed version of namedtuple.
@@ -1842,8 +1842,7 @@ if sys.version_info[:2] >= (3, 6):
         """
 
         def __new__(self, typename, fields):
-            types = dict(fields)
-            return _make_nmtuple(typename, types)
+            return _make_nmtuple(typename, fileds)
 else:
     def NamedTuple(typename, fields):
         """Typed version of namedtuple.
@@ -1861,7 +1860,7 @@ else:
         are in the _fields attribute, which is part of the namedtuple
         API.)
         """
-        return _make_nmtuple(typename, dict(fields))
+        return _make_nmtuple(typename, fields)
 
 
 def NewType(name, tp):

--- a/src/typing.py
+++ b/src/typing.py
@@ -1803,7 +1803,7 @@ class Type(Generic[CT_co], extra=type):
 
 def _make_nmtuple(name, types):
     nm_tpl = collections.namedtuple(name, [n for n, t in types])
-    nm_tpl._field_types = types
+    nm_tpl._field_types = dict(types)
     try:
         nm_tpl.__module__ = sys._getframe(2).f_globals.get('__name__', '__main__')
     except (AttributeError, ValueError):

--- a/src/typing.py
+++ b/src/typing.py
@@ -1842,7 +1842,7 @@ if sys.version_info[:2] >= (3, 6):
         """
 
         def __new__(self, typename, fields):
-            return _make_nmtuple(typename, fileds)
+            return _make_nmtuple(typename, fields)
 else:
     def NamedTuple(typename, fields):
         """Typed version of namedtuple.

--- a/src/typing.py
+++ b/src/typing.py
@@ -1811,7 +1811,7 @@ def _make_nmtuple(name, types):
     return nm_tpl
 
 
-if sys.version[:2] >= (3, 6):
+if sys.version_info[:2] >= (3, 6):
     class NamedTupleMeta(type):
 
         def __new__(cls, typename, bases, ns, *, _root=False):

--- a/src/typing.py
+++ b/src/typing.py
@@ -1801,19 +1801,23 @@ class Type(Generic[CT_co], extra=type):
     """
 
 
+def _make_nmtuple(name, types):
+    nm_tpl = collections.namedtuple(name, [n for n in types])
+    nm_tpl._field_types = types
+    try:
+        nm_tpl.__module__ = sys._getframe(2).f_globals.get('__name__', '__main__')
+    except (AttributeError, ValueError):
+        pass
+    return nm_tpl
+
+
 class NamedTupleMeta(type):
 
-    def __new__(cls, name, bases, ns, *, _root=False):
+    def __new__(cls, typename, bases, ns, *, _root=False):
         if _root:
-            return super().__new__(cls, name, bases, ns)
+            return super().__new__(cls, typename, bases, ns)
         types = ns.get('__annotations__', {})
-        nm_tpl = collections.namedtuple(name, [n for n in types])
-        nm_tpl._field_types = types
-        try:
-            nm_tpl.__module__ = sys._getframe(1).f_globals.get('__name__', '__main__')
-        except (AttributeError, ValueError):
-            pass
-        return nm_tpl
+        return _make_nmtuple(typename, types)
 
 
 class NamedTuple(metaclass=NamedTupleMeta, _root=True):
@@ -1838,14 +1842,8 @@ class NamedTuple(metaclass=NamedTupleMeta, _root=True):
     """
 
     def __new__(self, typename, fields):
-        cls = collections.namedtuple(typename, [n for n, t in fields])
-        cls._field_types = dict(fields)
-        # Set the module to the caller's module (otherwise it'd be 'typing').
-        try:
-            cls.__module__ = sys._getframe(1).f_globals.get('__name__', '__main__')
-        except (AttributeError, ValueError):
-            pass
-        return cls
+        types = dict(fields)
+        return _make_nmtuple(typename, types)
 
 
 def NewType(name, tp):


### PR DESCRIPTION
@gvanrossum 
I implemented your idea:
```python
class Employee(NamedTuple):
    name: str
    id: int
```
in a backward-compatible manner. Namely, the same code is triggered on instantiation and on subclassing, so that one can use the new form above as well as ``Employee = NamedTuple('Employee', [('name', str), ('id', int)])``. All old tests pass unmodified.

I didn't backport this to Python 2 since it is not possible to use the new form there anyway.