### PR TITLE
Kill __subclasscheck__

### DIFF
--- a/python2/test_typing.py
+++ b/python2/test_typing.py
@@ -178,8 +178,16 @@ class UnionTests(BaseTestCase):
     def test_basics(self):
         u = Union[int, float]
         self.assertNotEqual(u, Union)
-        self.assertTrue(issubclass(int, u))
-        self.assertTrue(issubclass(float, u))
+
+    def test_subclass_error(self):
+        with self.assertRaises(TypeError):
+            issubclass(int, Union)
+        with self.assertRaises(TypeError):
+            issubclass(Union, int)
+        with self.assertRaises(TypeError):
+            issubclass(int, Union[int, str])
+        with self.assertRaises(TypeError):
+            issubclass(Union[int, str], int)
 
     def test_union_any(self):
         u = Union[Any]
@@ -208,18 +216,6 @@ class UnionTests(BaseTestCase):
         u2 = Union[float, int]
         self.assertEqual(u1, u2)
 
-    def test_subclass(self):
-        u = Union[int, Employee]
-        self.assertTrue(issubclass(Manager, u))
-
-    def test_self_subclass(self):
-        self.assertTrue(issubclass(Union[KT, VT], Union))
-        self.assertFalse(issubclass(Union, Union[KT, VT]))
-
-    def test_multiple_inheritance(self):
-        u = Union[int, Employee]
-        self.assertTrue(issubclass(ManagingFounder, u))
-
     def test_single_class_disappears(self):
         t = Union[Employee]
         self.assertIs(t, Employee)
@@ -231,13 +227,6 @@ class UnionTests(BaseTestCase):
         self.assertEqual(u, Union[int, Employee])
         u = Union[Employee, Manager]
         self.assertIs(u, Employee)
-
-    def test_weird_subclasses(self):
-        u = Union[Employee, int, float]
-        v = Union[int, float]
-        self.assertTrue(issubclass(v, u))
-        w = Union[int, Manager]
-        self.assertTrue(issubclass(w, u))
 
     def test_union_union(self):
         u = Union[int, float]
@@ -274,10 +263,6 @@ class UnionTests(BaseTestCase):
     def test_empty(self):
         with self.assertRaises(TypeError):
             Union[()]
-
-    def test_issubclass_union(self):
-        self.assertIsSubclass(Union[int, str], Union)
-        self.assertNotIsSubclass(int, Union)
 
     def test_union_instance_type_error(self):
         with self.assertRaises(TypeError):

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -145,9 +145,8 @@ class Final(TypingBase):
     __slots__ = ()
 
     def __init__(self, _root=False):
-        cls = type(self)
         if _root is not True:
-            raise TypeError('Cannot instantiate {}'.format(cls.__name__[1:]))
+            raise TypeError('Cannot instantiate or subclass %r' % self)
 
 
 class _ForwardRef(TypingBase):
@@ -353,8 +352,8 @@ class _ClassVar(Final):
     __metaclass__ = ClassVarMeta
 
     def __init__(self, tp=None, _root=False):
-        super(_ClassVar, self).__init__(_root)
         self.__type__ = tp
+        super(_ClassVar, self).__init__(_root)
 
     def __getitem__(self, item):
         cls = type(self)
@@ -731,16 +730,16 @@ class _Tuple(Final):
     to type variables T1 and T2.  Tuple[int, float, str] is a tuple
     of an int, a float and a string.
 
-    To specify a variable-length tuple of homogeneous type, use Sequence[T].
+    To specify a variable-length tuple of homogeneous type, use Tuple[T, ...].
     """
 
     __metaclass__ = TupleMeta
 
     def __init__(self, parameters=None,
                 use_ellipsis=False, _root=False):
-        super(_Tuple, self).__init__(_root)
         self.__tuple_params__ = parameters
         self.__tuple_use_ellipsis__ = use_ellipsis
+        super(_Tuple, self).__init__(_root)
 
     def _get_type_vars(self, tvars):
         if self.__tuple_params__:

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -410,6 +410,7 @@ class _Any(TypingBase):
     __slots__ = ()
 
     def __init__(self, _root=False):
+        cls = type(self)
         if not _root:
             raise TypeError('Cannot instantiate {}'.format(cls.__name__[1:]))
 
@@ -536,124 +537,12 @@ AnyStr = TypeVar('AnyStr', bytes, unicode)
 
 
 class UnionMeta(TypingMeta):
-    """Metaclass for Union."""
-
-    def __new__(cls, name, bases, namespace, parameters=None):
+    def __new__(cls, name, bases, namespace):
         cls.assert_no_subclassing(bases)
-        if parameters is None:
-            return super(UnionMeta, cls).__new__(cls, name, bases, namespace)
-        if not isinstance(parameters, tuple):
-            raise TypeError("Expected parameters=<tuple>")
-        # Flatten out Union[Union[...], ...] and type-check non-Union args.
-        params = []
-        msg = "Union[arg, ...]: each arg must be a type."
-        for p in parameters:
-            if isinstance(p, UnionMeta):
-                params.extend(p.__union_params__)
-            else:
-                params.append(_type_check(p, msg))
-        # Weed out strict duplicates, preserving the first of each occurrence.
-        all_params = set(params)
-        if len(all_params) < len(params):
-            new_params = []
-            for t in params:
-                if t in all_params:
-                    new_params.append(t)
-                    all_params.remove(t)
-            params = new_params
-            assert not all_params, all_params
-        # Weed out subclasses.
-        # E.g. Union[int, Employee, Manager] == Union[int, Employee].
-        # If Any or object is present it will be the sole survivor.
-        # If both Any and object are present, Any wins.
-        # Never discard type variables, except against Any.
-        # (In particular, Union[str, AnyStr] != AnyStr.)
-        all_params = set(params)
-        for t1 in params:
-            if t1 is Any:
-                return Any
-            if isinstance(t1, TypeVar):
-                continue
-            if isinstance(t1, _TypeAlias):
-                # _TypeAlias is not a real class.
-                continue
-            if not isinstance(t1, type):
-                assert callable(t1)  # A callable might sneak through.
-                continue
-            if any(isinstance(t2, type) and issubclass(t1, t2)
-                   for t2 in all_params - {t1} if not isinstance(t2, TypeVar)):
-                all_params.remove(t1)
-        # It's not a union if there's only one type left.
-        if len(all_params) == 1:
-            return all_params.pop()
-        # Create a new class with these params.
-        self = super(UnionMeta, cls).__new__(cls, name, bases, {})
-        self.__union_params__ = tuple(t for t in params if t in all_params)
-        self.__union_set_params__ = frozenset(self.__union_params__)
-        return self
-
-    def _eval_type(self, globalns, localns):
-        p = tuple(_eval_type(t, globalns, localns)
-                  for t in self.__union_params__)
-        if p == self.__union_params__:
-            return self
-        else:
-            return self.__class__(self.__name__, self.__bases__, {},
-                                  p)
-
-    def _get_type_vars(self, tvars):
-        if self.__union_params__:
-            _get_type_vars(self.__union_params__, tvars)
-
-    def __repr__(self):
-        r = super(UnionMeta, self).__repr__()
-        if self.__union_params__:
-            r += '[%s]' % (', '.join(_type_repr(t)
-                                     for t in self.__union_params__))
-        return r
-
-    def __getitem__(self, parameters):
-        if self.__union_params__ is not None:
-            raise TypeError(
-                "Cannot subscript an existing Union. Use Union[u, t] instead.")
-        if parameters == ():
-            raise TypeError("Cannot take a Union of no types.")
-        if not isinstance(parameters, tuple):
-            parameters = (parameters,)
-        return self.__class__(self.__name__, self.__bases__,
-                              dict(self.__dict__), parameters)
-
-    def __eq__(self, other):
-        if not isinstance(other, UnionMeta):
-            return NotImplemented
-        return self.__union_set_params__ == other.__union_set_params__
-
-    def __hash__(self):
-        return hash(self.__union_set_params__)
-
-    def __instancecheck__(self, obj):
-        raise TypeError("Unions cannot be used with isinstance().")
-
-    def __subclasscheck__(self, cls):
-        if cls is Any:
-            return True
-        if self.__union_params__ is None:
-            return isinstance(cls, UnionMeta)
-        elif isinstance(cls, UnionMeta):
-            if cls.__union_params__ is None:
-                return False
-            return all(issubclass(c, self) for c in (cls.__union_params__))
-        elif isinstance(cls, TypeVar):
-            if cls in self.__union_params__:
-                return True
-            if cls.__constraints__:
-                return issubclass(Union[cls.__constraints__], self)
-            return False
-        else:
-            return any(issubclass(cls, t) for t in self.__union_params__)
+        return super(UnionMeta, cls).__new__(cls, name, bases, namespace)
 
 
-class Union(Final):
+class _Union(TypingBase):
     """Union type; Union[X, Y] means either X or Y.
 
     To define a union, use e.g. Union[int, str].  Details:
@@ -707,9 +596,104 @@ class Union(Final):
 
     __metaclass__ = UnionMeta
 
-    # Unsubscripted Union type has params set to None.
-    __union_params__ = None
-    __union_set_params__ = None
+    def __new__(cls, parameters=None, _root=False):
+        if not _root:
+            raise TypeError('Cannot instantiate {}'.format(cls.__name__[1:]))
+        self = super(_Union, cls).__new__(cls)
+        if parameters is None:
+            self.__union_params__ = None
+            self.__union_set_params__ = None
+            return self
+        if not isinstance(parameters, tuple):
+            raise TypeError("Expected parameters=<tuple>")
+        # Flatten out Union[Union[...], ...] and type-check non-Union args.
+        params = []
+        msg = "Union[arg, ...]: each arg must be a type."
+        for p in parameters:
+            if isinstance(p, _Union):
+                params.extend(p.__union_params__)
+            else:
+                params.append(_type_check(p, msg))
+        # Weed out strict duplicates, preserving the first of each occurrence.
+        all_params = set(params)
+        if len(all_params) < len(params):
+            new_params = []
+            for t in params:
+                if t in all_params:
+                    new_params.append(t)
+                    all_params.remove(t)
+            params = new_params
+            assert not all_params, all_params
+        # Weed out subclasses.
+        # E.g. Union[int, Employee, Manager] == Union[int, Employee].
+        # If Any or object is present it will be the sole survivor.
+        # If both Any and object are present, Any wins.
+        # Never discard type variables, except against Any.
+        # (In particular, Union[str, AnyStr] != AnyStr.)
+        all_params = set(params)
+        for t1 in params:
+            if t1 is Any:
+                return Any
+            if not isinstance(t1, type):
+                continue
+            if any(isinstance(t2, type) and issubclass(t1, t2)
+                   for t2 in all_params - {t1}
+                   if not (isinstance(t2, GenericMeta) and
+                           t2.__origin__ is not None)):
+                all_params.remove(t1)
+        # It's not a union if there's only one type left.
+        if len(all_params) == 1:
+            return all_params.pop()
+        self.__union_params__ = tuple(t for t in params if t in all_params)
+        self.__union_set_params__ = frozenset(self.__union_params__)
+        return self
+
+    def _eval_type(self, globalns, localns):
+        p = tuple(_eval_type(t, globalns, localns)
+                  for t in self.__union_params__)
+        if p == self.__union_params__:
+            return self
+        else:
+            return self.__class__(p, _root=True)
+
+    def _get_type_vars(self, tvars):
+        if self.__union_params__:
+            _get_type_vars(self.__union_params__, tvars)
+
+    def __repr__(self):
+        cls = type(self)
+        r = '{}.{}'.format(cls.__module__, cls.__name__[1:])
+        if self.__union_params__:
+            r += '[%s]' % (', '.join(_type_repr(t)
+                                     for t in self.__union_params__))
+        return r
+
+    def __getitem__(self, parameters):
+        if self.__union_params__ is not None:
+            raise TypeError(
+                "Cannot subscript an existing Union. Use Union[u, t] instead.")
+        if parameters == ():
+            raise TypeError("Cannot take a Union of no types.")
+        if not isinstance(parameters, tuple):
+            parameters = (parameters,)
+        return self.__class__(parameters, _root=True)
+
+    def __eq__(self, other):
+        if not isinstance(other, _Union):
+            return NotImplemented
+        return self.__union_set_params__ == other.__union_set_params__
+
+    def __hash__(self):
+        return hash(self.__union_set_params__)
+
+    def __instancecheck__(self, obj):
+        raise TypeError("Unions cannot be used with isinstance().")
+
+    def __subclasscheck__(self, cls):
+        raise TypeError("Unions cannot be used with issubclass().")
+
+
+Union = _Union(_root=True)
 
 
 class OptionalMeta(TypingMeta):
@@ -719,12 +703,8 @@ class OptionalMeta(TypingMeta):
         cls.assert_no_subclassing(bases)
         return super(OptionalMeta, cls).__new__(cls, name, bases, namespace)
 
-    def __getitem__(self, arg):
-        arg = _type_check(arg, "Optional[t] requires a single type.")
-        return Union[arg, type(None)]
 
-
-class Optional(Final):
+class _Optional(TypingBase):
     """Optional type.
 
     Optional[X] is equivalent to Union[X, type(None)].
@@ -732,6 +712,18 @@ class Optional(Final):
 
     __metaclass__ = OptionalMeta
     __slots__ = ()
+
+    def __init__(self, _root=False):
+        cls = type(self)
+        if not _root:
+            raise TypeError('Cannot instantiate {}'.format(cls.__name__[1:]))
+
+    def __getitem__(self, arg):
+        arg = _type_check(arg, "Optional[t] requires a single type.")
+        return Union[arg, type(None)]
+
+
+Optional = _Optional(_root=True)
 
 
 class TupleMeta(TypingMeta):

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -1114,13 +1114,8 @@ class CollectionsAbcTests(BaseTestCase):
             globals(), ns)
         foo = ns['foo']
         g = foo()
-        self.assertIsSubclass(type(g), typing.Awaitable[int])
         self.assertIsInstance(g, typing.Awaitable)
         self.assertNotIsInstance(foo, typing.Awaitable)
-        self.assertIsSubclass(typing.Awaitable[Manager],
-                          typing.Awaitable[Employee])
-        self.assertNotIsSubclass(typing.Awaitable[Employee],
-                              typing.Awaitable[Manager])
         g.send(None)  # Run foo() till completion, to avoid warning.
 
     @skipUnless(PY35, 'Python 3.5 required')
@@ -1129,8 +1124,6 @@ class CollectionsAbcTests(BaseTestCase):
         it = AsyncIteratorWrapper(base_it)
         self.assertIsInstance(it, typing.AsyncIterable)
         self.assertIsInstance(it, typing.AsyncIterable)
-        self.assertIsSubclass(typing.AsyncIterable[Manager],
-                          typing.AsyncIterable[Employee])
         self.assertNotIsInstance(42, typing.AsyncIterable)
 
     @skipUnless(PY35, 'Python 3.5 required')
@@ -1138,8 +1131,6 @@ class CollectionsAbcTests(BaseTestCase):
         base_it = range(10)  # type: Iterator[int]
         it = AsyncIteratorWrapper(base_it)
         self.assertIsInstance(it, typing.AsyncIterator)
-        self.assertIsSubclass(typing.AsyncIterator[Manager],
-                          typing.AsyncIterator[Employee])
         self.assertNotIsInstance(42, typing.AsyncIterator)
 
     def test_sized(self):

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -1601,7 +1601,7 @@ class RETests(BaseTestCase):
                 pass
 
         self.assertEqual(str(ex.exception),
-                         "A type alias cannot be subclassed")
+                         "Cannot subclass typing._TypeAlias")
 
 
 class AllTests(BaseTestCase):

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -9,7 +9,7 @@ from typing import Any
 from typing import TypeVar, AnyStr
 from typing import T, KT, VT  # Not in __all__.
 from typing import Union, Optional
-from typing import Tuple, List
+from typing import Tuple, List, MutableMapping
 from typing import Callable
 from typing import Generic, ClassVar
 from typing import cast
@@ -21,6 +21,10 @@ from typing import NamedTuple
 from typing import IO, TextIO, BinaryIO
 from typing import Pattern, Match
 import typing
+try:
+    import collections.abc as collections_abc
+except ImportError:
+    import collections as collections_abc  # Fallback for PY3.2.
 
 
 class BaseTestCase(TestCase):
@@ -81,10 +85,15 @@ class AnyTests(BaseTestCase):
         with self.assertRaises(TypeError):
             class A(Any):
                 pass
+        with self.assertRaises(TypeError):
+            class A(type(Any)):
+                pass
 
     def test_cannot_instantiate(self):
         with self.assertRaises(TypeError):
             Any()
+        with self.assertRaises(TypeError):
+            type(Any)()
 
     def test_cannot_subscript(self):
         with self.assertRaises(TypeError):
@@ -246,15 +255,27 @@ class UnionTests(BaseTestCase):
             class C(Union):
                 pass
         with self.assertRaises(TypeError):
+            class C(type(Union)):
+                pass
+        with self.assertRaises(TypeError):
             class C(Union[int, str]):
                 pass
 
     def test_cannot_instantiate(self):
         with self.assertRaises(TypeError):
             Union()
+        with self.assertRaises(TypeError):
+            type(Union)()
         u = Union[int, float]
         with self.assertRaises(TypeError):
             u()
+        with self.assertRaises(TypeError):
+            type(u)()
+
+    def test_union_generalization(self):
+        self.assertFalse(Union[str, typing.Iterable[int]] == str)
+        self.assertFalse(Union[str, typing.Iterable[int]] == typing.Iterable[int])
+        self.assertTrue(Union[str, typing.Iterable] == typing.Iterable)
 
     def test_optional(self):
         o = Optional[int]
@@ -356,15 +377,24 @@ class CallableTests(BaseTestCase):
 
         with self.assertRaises(TypeError):
 
+            class C(type(Callable)):
+                pass
+
+        with self.assertRaises(TypeError):
+
             class C(Callable[[int], int]):
                 pass
 
     def test_cannot_instantiate(self):
         with self.assertRaises(TypeError):
             Callable()
+        with self.assertRaises(TypeError):
+            type(Callable)()
         c = Callable[[int], str]
         with self.assertRaises(TypeError):
             c()
+        with self.assertRaises(TypeError):
+            type(c)()
 
     def test_callable_instance_works(self):
         def f():
@@ -565,6 +595,42 @@ class GenericTests(BaseTestCase):
         c.bar = 'abc'
         self.assertEqual(c.__dict__, {'bar': 'abc'})
 
+    def test_false_subclasses(self):
+        class MyMapping(MutableMapping[str, str]): pass
+        self.assertNotIsInstance({}, MyMapping)
+        self.assertNotIsSubclass(dict, MyMapping)
+
+    def test_multiple_abc_bases(self):
+        class MM1(MutableMapping[str, str], collections_abc.MutableMapping):
+            def __getitem__(self, k):
+                return None
+            def __setitem__(self, k, v):
+                pass
+            def __delitem__(self, k):
+                pass
+            def __iter__(self):
+                return iter(())
+            def __len__(self):
+                return 0
+        class MM2(collections_abc.MutableMapping, MutableMapping[str, str]):
+            def __getitem__(self, k):
+                return None
+            def __setitem__(self, k, v):
+                pass
+            def __delitem__(self, k):
+                pass
+            def __iter__(self):
+                return iter(())
+            def __len__(self):
+                return 0
+        # these two should just work
+        MM1().update()
+        MM2().update()
+        self.assertIsInstance(MM1(), collections_abc.MutableMapping)
+        self.assertIsInstance(MM1(), MutableMapping)
+        self.assertIsInstance(MM2(), collections_abc.MutableMapping)
+        self.assertIsInstance(MM2(), MutableMapping)
+
     def test_pickle(self):
         global C  # pickle wants to reference the class by name
         T = TypeVar('T')
@@ -747,6 +813,8 @@ class ClassVarTests(BaseTestCase):
                 pass
 
     def test_cannot_init(self):
+        with self.assertRaises(TypeError):
+            ClassVar()
         with self.assertRaises(TypeError):
             type(ClassVar)()
         with self.assertRaises(TypeError):
@@ -1485,10 +1553,12 @@ class RETests(BaseTestCase):
         pat = re.compile('[a-z]+', re.I)
         self.assertIsSubclass(pat.__class__, Pattern)
         self.assertIsSubclass(type(pat), Pattern)
+        self.assertIsInstance(pat, Pattern)
 
         mat = pat.search('12345abcde.....')
         self.assertIsSubclass(mat.__class__, Match)
         self.assertIsSubclass(type(mat), Match)
+        self.assertIsInstance(mat, Match)
 
         # these should just work
         p = Pattern[Union[str, bytes]]

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -62,18 +62,11 @@ class AnyTests(BaseTestCase):
         with self.assertRaises(TypeError):
             isinstance(42, Any)
 
-    def test_any_subclass(self):
-        self.assertTrue(issubclass(Employee, Any))
-        self.assertTrue(issubclass(int, Any))
-        self.assertTrue(issubclass(type(None), Any))
-        self.assertTrue(issubclass(object, Any))
-
-    def test_others_any(self):
-        self.assertFalse(issubclass(Any, Employee))
-        self.assertFalse(issubclass(Any, int))
-        self.assertFalse(issubclass(Any, type(None)))
-        # However, Any is a subclass of object (this can't be helped).
-        self.assertTrue(issubclass(Any, object))
+    def test_any_subclass_type_error(self):
+        with self.assertRaises(TypeError):
+            self.assertTrue(issubclass(Employee, Any))
+        with self.assertRaises(TypeError):
+            self.assertFalse(issubclass(Any, Employee))
 
     def test_repr(self):
         self.assertEqual(repr(Any), 'typing.Any')
@@ -97,23 +90,7 @@ class AnyTests(BaseTestCase):
         with self.assertRaises(TypeError):
             Any[int]
 
-    def test_any_is_subclass(self):
-        # Any should be considered a subclass of everything.
-        self.assertIsSubclass(Any, Any)
-        self.assertIsSubclass(Any, typing.List)
-        self.assertIsSubclass(Any, typing.List[int])
-        self.assertIsSubclass(Any, typing.List[T])
-        self.assertIsSubclass(Any, typing.Mapping)
-        self.assertIsSubclass(Any, typing.Mapping[str, int])
-        self.assertIsSubclass(Any, typing.Mapping[KT, VT])
-        self.assertIsSubclass(Any, Generic)
-        self.assertIsSubclass(Any, Generic[T])
-        self.assertIsSubclass(Any, Generic[KT, VT])
-        self.assertIsSubclass(Any, AnyStr)
-        self.assertIsSubclass(Any, Union)
-        self.assertIsSubclass(Any, Union[int, str])
-        self.assertIsSubclass(Any, typing.Match)
-        self.assertIsSubclass(Any, typing.Match[str])
+    def test_any_works_with_alias(self):
         # These expressions must simply not fail.
         typing.Match[Any]
         typing.Pattern[Any]
@@ -124,13 +101,8 @@ class TypeVarTests(BaseTestCase):
 
     def test_basic_plain(self):
         T = TypeVar('T')
-        # Every class is a subclass of T.
-        self.assertIsSubclass(int, T)
-        self.assertIsSubclass(str, T)
         # T equals itself.
         self.assertEqual(T, T)
-        # T is a subclass of itself.
-        self.assertIsSubclass(T, T)
         # T is an instance of TypeVar
         self.assertIsInstance(T, TypeVar)
 
@@ -139,16 +111,12 @@ class TypeVarTests(BaseTestCase):
         with self.assertRaises(TypeError):
             isinstance(42, T)
 
-    def test_basic_constrained(self):
-        A = TypeVar('A', str, bytes)
-        # Only str and bytes are subclasses of A.
-        self.assertIsSubclass(str, A)
-        self.assertIsSubclass(bytes, A)
-        self.assertNotIsSubclass(int, A)
-        # A equals itself.
-        self.assertEqual(A, A)
-        # A is a subclass of itself.
-        self.assertIsSubclass(A, A)
+    def test_typevar_subclass_type_error(self):
+        T = TypeVar('T')
+        with self.assertRaises(TypeError):
+            issubclass(int, T)
+        with self.assertRaises(TypeError):
+            issubclass(T, int)
 
     def test_constrained_error(self):
         with self.assertRaises(TypeError):
@@ -185,19 +153,6 @@ class TypeVarTests(BaseTestCase):
         self.assertNotEqual(TypeVar('T'), TypeVar('T'))
         self.assertNotEqual(TypeVar('T', int, str), TypeVar('T', int, str))
 
-    def test_subclass_as_unions(self):
-        # None of these are true -- each type var is its own world.
-        self.assertFalse(issubclass(TypeVar('T', int, str),
-                                    TypeVar('T', int, str)))
-        self.assertFalse(issubclass(TypeVar('T', int, float),
-                                    TypeVar('T', int, float, str)))
-        self.assertFalse(issubclass(TypeVar('T', int, str),
-                                    TypeVar('T', str, int)))
-        A = TypeVar('A', int, str)
-        B = TypeVar('B', int, str, float)
-        self.assertFalse(issubclass(A, B))
-        self.assertFalse(issubclass(B, A))
-
     def test_cannot_subclass_vars(self):
         with self.assertRaises(TypeError):
             class V(TypeVar('T')):
@@ -211,12 +166,6 @@ class TypeVarTests(BaseTestCase):
     def test_cannot_instantiate_vars(self):
         with self.assertRaises(TypeError):
             TypeVar('A')()
-
-    def test_bound(self):
-        X = TypeVar('X', bound=Employee)
-        self.assertIsSubclass(Employee, X)
-        self.assertIsSubclass(Manager, X)
-        self.assertNotIsSubclass(int, X)
 
     def test_bound_errors(self):
         with self.assertRaises(TypeError):
@@ -357,28 +306,9 @@ class UnionTests(BaseTestCase):
 
 class TypeVarUnionTests(BaseTestCase):
 
-    def test_simpler(self):
-        A = TypeVar('A', int, str, float)
-        B = TypeVar('B', int, str)
-        self.assertIsSubclass(A, A)
-        self.assertIsSubclass(B, B)
-        self.assertNotIsSubclass(B, A)
-        self.assertIsSubclass(A, Union[int, str, float])
-        self.assertNotIsSubclass(Union[int, str, float], A)
-        self.assertNotIsSubclass(Union[int, str], B)
-        self.assertIsSubclass(B, Union[int, str])
-        self.assertNotIsSubclass(A, B)
-        self.assertNotIsSubclass(Union[int, str, float], B)
-        self.assertNotIsSubclass(A, Union[int, str])
-
     def test_var_union_subclass(self):
         self.assertTrue(issubclass(T, Union[int, T]))
         self.assertTrue(issubclass(KT, Union[KT, VT]))
-
-    def test_var_union(self):
-        TU = TypeVar('TU', Union[int, float], None)
-        self.assertIsSubclass(int, TU)
-        self.assertIsSubclass(float, TU)
 
 
 class TupleTests(BaseTestCase):
@@ -1653,22 +1583,14 @@ class RETests(BaseTestCase):
         pat = re.compile('[a-z]+', re.I)
         self.assertIsSubclass(pat.__class__, Pattern)
         self.assertIsSubclass(type(pat), Pattern)
-        self.assertIsSubclass(type(pat), Pattern[str])
 
         mat = pat.search('12345abcde.....')
         self.assertIsSubclass(mat.__class__, Match)
-        self.assertIsSubclass(mat.__class__, Match[str])
-        self.assertIsSubclass(mat.__class__, Match[bytes])  # Sad but true.
         self.assertIsSubclass(type(mat), Match)
-        self.assertIsSubclass(type(mat), Match[str])
 
+        # these should just work
         p = Pattern[Union[str, bytes]]
-        self.assertIsSubclass(Pattern[str], Pattern)
-        self.assertIsSubclass(Pattern[str], p)
-
         m = Match[Union[bytes, str]]
-        self.assertIsSubclass(Match[bytes], Match)
-        self.assertIsSubclass(Match[bytes], m)
 
     def test_errors(self):
         with self.assertRaises(TypeError):

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -1344,7 +1344,6 @@ class OtherABCTests(BaseTestCase):
 
         cm = manager()
         self.assertIsInstance(cm, typing.ContextManager)
-        self.assertIsInstance(cm, typing.ContextManager[int])
         self.assertNotIsInstance(42, typing.ContextManager)
 
 

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -1507,9 +1507,6 @@ class RETests(BaseTestCase):
             m[str]
         with self.assertRaises(TypeError):
             # We don't support isinstance().
-            isinstance(42, Pattern)
-        with self.assertRaises(TypeError):
-            # We don't support isinstance().
             isinstance(42, Pattern[str])
 
     def test_repr(self):

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -504,6 +504,12 @@ class GenericTests(BaseTestCase):
         with self.assertRaises(TypeError):
             Y[str, str]
 
+    def test_generic_errors(self):
+        with self.assertRaises(TypeError):
+            isinstance([], List[int])
+        with self.assertRaises(TypeError):
+            issubclass(list, List[int])
+
     def test_init(self):
         T = TypeVar('T')
         S = TypeVar('S')
@@ -751,39 +757,6 @@ class ClassVarTests(BaseTestCase):
             isinstance(1, ClassVar[int])
         with self.assertRaises(TypeError):
             issubclass(int, ClassVar)
-
-
-class VarianceTests(BaseTestCase):
-
-    def test_invariance(self):
-        # Because of invariance, List[subclass of X] is not a subclass
-        # of List[X], and ditto for MutableSequence.
-        self.assertNotIsSubclass(typing.List[Manager], typing.List[Employee])
-        self.assertNotIsSubclass(typing.MutableSequence[Manager],
-                              typing.MutableSequence[Employee])
-        # It's still reflexive.
-        self.assertIsSubclass(typing.List[Employee], typing.List[Employee])
-        self.assertIsSubclass(typing.MutableSequence[Employee],
-                          typing.MutableSequence[Employee])
-
-    def test_covariance_sequence(self):
-        # Check covariance for Sequence (which is just a generic class
-        # for this purpose, but using a type variable with covariant=True).
-        self.assertIsSubclass(typing.Sequence[Manager],
-                              typing.Sequence[Employee])
-        self.assertNotIsSubclass(typing.Sequence[Employee],
-                              typing.Sequence[Manager])
-
-    def test_covariance_mapping(self):
-        # Ditto for Mapping (covariant in the value, invariant in the key).
-        self.assertIsSubclass(typing.Mapping[Employee, Manager],
-                          typing.Mapping[Employee, Employee])
-        self.assertNotIsSubclass(typing.Mapping[Manager, Employee],
-                              typing.Mapping[Employee, Employee])
-        self.assertNotIsSubclass(typing.Mapping[Employee, Manager],
-                              typing.Mapping[Manager, Manager])
-        self.assertNotIsSubclass(typing.Mapping[Manager, Employee],
-                              typing.Mapping[Manager, Manager])
 
 
 class CastTests(BaseTestCase):
@@ -1122,7 +1095,6 @@ class CollectionsAbcTests(BaseTestCase):
         # path and could fail.  So call this a few times.
         self.assertIsInstance([], typing.Iterable)
         self.assertIsInstance([], typing.Iterable)
-        self.assertIsInstance([], typing.Iterable[int])
         self.assertNotIsInstance(42, typing.Iterable)
         # Just in case, also test issubclass() a few times.
         self.assertIsSubclass(list, typing.Iterable)
@@ -1131,7 +1103,6 @@ class CollectionsAbcTests(BaseTestCase):
     def test_iterator(self):
         it = iter([])
         self.assertIsInstance(it, typing.Iterator)
-        self.assertIsInstance(it, typing.Iterator[int])
         self.assertNotIsInstance(42, typing.Iterator)
 
     @skipUnless(PY35, 'Python 3.5 required')
@@ -1332,10 +1303,6 @@ class CollectionsAbcTests(BaseTestCase):
             yield 42
         g = foo()
         self.assertIsSubclass(type(g), typing.Generator)
-        self.assertIsSubclass(typing.Generator[Manager, Employee, Manager],
-                          typing.Generator[Employee, Manager, Employee])
-        self.assertNotIsSubclass(typing.Generator[Manager, Manager, Manager],
-                              typing.Generator[Employee, Employee, Employee])
 
     def test_no_generator_instantiation(self):
         with self.assertRaises(TypeError):

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -64,9 +64,9 @@ class AnyTests(BaseTestCase):
 
     def test_any_subclass_type_error(self):
         with self.assertRaises(TypeError):
-            self.assertTrue(issubclass(Employee, Any))
+            issubclass(Employee, Any)
         with self.assertRaises(TypeError):
-            self.assertFalse(issubclass(Any, Employee))
+            issubclass(Any, Employee)
 
     def test_repr(self):
         self.assertEqual(repr(Any), 'typing.Any')

--- a/src/typing.py
+++ b/src/typing.py
@@ -545,7 +545,6 @@ class _Union(Final, _root=True):
         # It's not a union if there's only one type left.
         if len(all_params) == 1:
             return all_params.pop()
-        # Create a new class with these params.
         self.__union_params__ = tuple(t for t in params if t in all_params)
         self.__union_set_params__ = frozenset(self.__union_params__)
         return self

--- a/src/typing.py
+++ b/src/typing.py
@@ -617,7 +617,7 @@ class _Tuple(Final, _root=True):
     to type variables T1 and T2.  Tuple[int, float, str] is a tuple
     of an int, a float and a string.
 
-    To specify a variable-length tuple of homogeneous type, use Sequence[T].
+    To specify a variable-length tuple of homogeneous type, use Tuple[T, ...].
     """
 
     def __init__(self, parameters=None,
@@ -1587,7 +1587,22 @@ class Set(set, MutableSet[T], extra=set):
         return set.__new__(cls, *args, **kwds)
 
 
-class FrozenSet(frozenset, AbstractSet[T_co], extra=frozenset):
+class _FrozenSetMeta(GenericMeta):
+    """This metaclass ensures set is not a subclass of FrozenSet.
+
+    Without this metaclass, set would be considered a subclass of
+    FrozenSet, because FrozenSet.__extra__ is collections.abc.Set, and
+    set is a subclass of that.
+    """
+
+    def __subclasscheck__(self, cls):
+        if issubclass(cls, Set):
+            return False
+        return super().__subclasscheck__(cls)
+
+
+class FrozenSet(frozenset, AbstractSet[T_co], metaclass=_FrozenSetMeta,
+                extra=frozenset):
     __slots__ = ()
 
     def __new__(cls, *args, **kwds):

--- a/src/typing.py
+++ b/src/typing.py
@@ -838,7 +838,6 @@ def tp_cache(func):
     wraps(func)
     def inner(*args, **kwargs):
         if any(not isinstance(arg, collections_abc.Hashable) for arg in args):
-            print("Not Hashable")
             return func(*args, **kwargs)
         else:
             return cached(*args, **kwargs)

--- a/src/typing.py
+++ b/src/typing.py
@@ -1,5 +1,6 @@
 import abc
 from abc import abstractmethod, abstractproperty
+from functools import lru_cache
 import collections
 import contextlib
 import functools
@@ -910,6 +911,7 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
     def __hash__(self):
         return hash((self.__name__, self.__parameters__))
 
+    @lru_cache(maxsize=25)
     def __getitem__(self, params):
         if not isinstance(params, tuple):
             params = (params,)

--- a/src/typing.py
+++ b/src/typing.py
@@ -844,7 +844,6 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
     def __new__(cls, name, bases, namespace,
                 tvars=None, args=None, origin=None, extra=None):
         self = super().__new__(cls, name, bases, namespace, _root=True)
-
         if tvars is not None:
             # Called from __getitem__() below.
             assert origin is not None
@@ -1600,7 +1599,7 @@ class _FrozenSetMeta(GenericMeta):
     def __subclasscheck__(self, cls):
         if issubclass(cls, Set):
             return False
-        return super().__subclasscheck__(cls)
+        return abc.ABCMeta.__subclasscheck__(self, cls)
 
 
 class FrozenSet(frozenset, AbstractSet[T_co], metaclass=_FrozenSetMeta,

--- a/src/typing.py
+++ b/src/typing.py
@@ -498,11 +498,11 @@ AnyStr = TypeVar('AnyStr', bytes, str)
 def _tp_cache(func):
     cached = functools.lru_cache()(func)
     @functools.wraps(func)
-    def inner(*args, **kwargs):
-        if any(not isinstance(arg, collections_abc.Hashable) for arg in args):
-            return func(*args, **kwargs)
-        else:
-            return cached(*args, **kwargs)
+    def inner(*args, **kwds):
+        try:
+            return cached(*args, **kwds)
+        except TypeError:
+            return func(*args, **kwds)
     return inner
 
 
@@ -666,6 +666,7 @@ class _Optional(_FinalTypingBase, _root=True):
 
     __slots__ = ()
 
+    @_tp_cache
     def __getitem__(self, arg):
         arg = _type_check(arg, "Optional[t] requires a single type.")
         return Union[arg, type(None)]
@@ -717,6 +718,7 @@ class _Tuple(_FinalTypingBase, _root=True):
                 ', '.join(params))
         return r
 
+    @_tp_cache
     def __getitem__(self, parameters):
         if self.__tuple_params__ is not None:
             raise TypeError("Cannot re-parameterize %r" % (self,))

--- a/src/typing.py
+++ b/src/typing.py
@@ -1589,22 +1589,7 @@ class Set(set, MutableSet[T], extra=set):
         return set.__new__(cls, *args, **kwds)
 
 
-class _FrozenSetMeta(GenericMeta):
-    """This metaclass ensures set is not a subclass of FrozenSet.
-
-    Without this metaclass, set would be considered a subclass of
-    FrozenSet, because FrozenSet.__extra__ is collections.abc.Set, and
-    set is a subclass of that.
-    """
-
-    def __subclasscheck__(self, cls):
-        if issubclass(cls, Set):
-            return False
-        return super().__subclasscheck__(cls)
-
-
-class FrozenSet(frozenset, AbstractSet[T_co], metaclass=_FrozenSetMeta,
-                extra=frozenset):
+class FrozenSet(frozenset, AbstractSet[T_co], extra=frozenset):
     __slots__ = ()
 
     def __new__(cls, *args, **kwds):

--- a/src/typing.py
+++ b/src/typing.py
@@ -832,7 +832,7 @@ def _next_in_mro(cls):
 
 
 def tp_cache(func):
-    cached = lru_cache(maxsize=25)(func)
+    cached = lru_cache(maxsize=50)(func)
     wraps(func)
     def inner(*args, **kwargs):
         if any(not isinstance(arg, collections_abc.Hashable) for arg in args):

--- a/src/typing.py
+++ b/src/typing.py
@@ -502,7 +502,8 @@ def _tp_cache(func):
         try:
             return cached(*args, **kwds)
         except TypeError:
-            return func(*args, **kwds)
+            pass  # Do not duplicate real errors.
+        return func(*args, **kwds)
     return inner
 
 

--- a/src/typing.py
+++ b/src/typing.py
@@ -1654,22 +1654,7 @@ class Set(set, MutableSet[T], extra=set):
         return set.__new__(cls, *args, **kwds)
 
 
-class _FrozenSetMeta(GenericMeta):
-    """This metaclass ensures set is not a subclass of FrozenSet.
-
-    Without this metaclass, set would be considered a subclass of
-    FrozenSet, because FrozenSet.__extra__ is collections.abc.Set, and
-    set is a subclass of that.
-    """
-
-    def __subclasscheck__(self, cls):
-        if issubclass(cls, Set):
-            return False
-        return super().__subclasscheck__(cls)
-
-
-class FrozenSet(frozenset, AbstractSet[T_co], metaclass=_FrozenSetMeta,
-                extra=frozenset):
+class FrozenSet(frozenset, AbstractSet[T_co], extra=frozenset):
     __slots__ = ()
 
     def __new__(cls, *args, **kwds):

--- a/src/typing.py
+++ b/src/typing.py
@@ -965,8 +965,10 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
         return self.__subclasscheck__(instance.__class__)
 
     def __subclasscheck__(self, cls):
+        if self is Generic:
+            raise TypeError("Class %r can't be used with class or instance checks" % self)
         if self.__origin__ is not None and sys._getframe(1).f_globals['__name__'] != 'abc':
-            raise TypeError('Parameterized Generic could not be used with class or instance checks')
+            raise TypeError("Parameterized generics can't be used with class or instance checks")
         if super().__subclasscheck__(cls):
             return True
         if self.__extra__ is not None:

--- a/src/typing.py
+++ b/src/typing.py
@@ -539,7 +539,9 @@ class _Union(Final, metaclass=TypingMeta, _root=True):
             if not isinstance(t1, type):
                 continue
             if any(isinstance(t2, type) and issubclass(t1, t2)
-                   for t2 in all_params - {t1} if not (isinstance(t2, GenericMeta) and t2.__origin__ is not None)):
+                   for t2 in all_params - {t1}
+                   if not (isinstance(t2, GenericMeta) and
+                           t2.__origin__ is not None)):
                 all_params.remove(t1)
         # It's not a union if there's only one type left.
         if len(all_params) == 1:
@@ -685,12 +687,14 @@ class _Tuple(Final, metaclass=TypingMeta, _root=True):
     def __instancecheck__(self, obj):
         if self.__tuple_params__ == None:
             return isinstance(obj, tuple)
-        raise TypeError("Parameterized Tuple cannot be used with isinstance().")
+        raise TypeError("Parameterized Tuple cannot be used "
+                        "with isinstance().")
 
     def __subclasscheck__(self, cls):
         if self.__tuple_params__ == None:
             return issubclass(cls, tuple)
-        raise TypeError("Parameterized Tuple cannot be used with issubclass().")
+        raise TypeError("Parameterized Tuple cannot be used "
+                        "with issubclass().")
 
 
 Tuple = _Tuple(_root=True)
@@ -777,13 +781,15 @@ class _Callable(Final, metaclass=TypingMeta, _root=True):
         if self.__args__ is None and self.__result__ is None:
             return isinstance(obj, collections_abc.Callable)
         else:
-            raise TypeError("Parameterized Callable cannot be used with isinstance().")
+            raise TypeError("Parameterized Callable cannot be used "
+                            "with isinstance().")
 
     def __subclasscheck__(self, cls):
         if self.__args__ is None and self.__result__ is None:
             return issubclass(cls, collections_abc.Callable)
         else:
-            raise TypeError("Parameterized Callable cannot be used with issubclass().")
+            raise TypeError("Parameterized Callable cannot be used "
+                            "with issubclass().")
 
 
 Callable = _Callable(_root=True)
@@ -980,9 +986,12 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
 
     def __subclasscheck__(self, cls):
         if self is Generic:
-            raise TypeError("Class %r can't be used with class or instance checks" % self)
-        if self.__origin__ is not None and sys._getframe(1).f_globals['__name__'] != 'abc':
-            raise TypeError("Parameterized generics can't be used with class or instance checks")
+            raise TypeError("Class %r cannot be used with class "
+                            "or instance checks" % self)
+        if (self.__origin__ is not None and
+            sys._getframe(1).f_globals['__name__'] != 'abc'):
+            raise TypeError("Parameterized generics cannot be used with class "
+                            "or instance checks")
         if super().__subclasscheck__(cls):
             return True
         if self.__extra__ is not None:

--- a/src/typing.py
+++ b/src/typing.py
@@ -844,6 +844,7 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
     def __new__(cls, name, bases, namespace,
                 tvars=None, args=None, origin=None, extra=None):
         self = super().__new__(cls, name, bases, namespace, _root=True)
+
         if tvars is not None:
             # Called from __getitem__() below.
             assert origin is not None
@@ -1599,7 +1600,7 @@ class _FrozenSetMeta(GenericMeta):
     def __subclasscheck__(self, cls):
         if issubclass(cls, Set):
             return False
-        return abc.ABCMeta.__subclasscheck__(self, cls)
+        return super().__subclasscheck__(cls)
 
 
 class FrozenSet(frozenset, AbstractSet[T_co], metaclass=_FrozenSetMeta,


### PR DESCRIPTION
This PR:
* Fixes #136 
* Fixes #133 
* Partially fixes #203 (fixes the ``isinstance`` part, and multiple inheritance, still ``typing.Something`` is not a drop-in replacement for ``collections.abc.Something`` in terms of *implementation*).
* Also fixes http://bugs.python.org/issue26075, http://bugs.python.org/issue25830, and http://bugs.python.org/issue26477
* Makes almost everything up to 10x faster.
* Is aimed to be a minimalistic change. I only removed ``issubclass`` tests from ``test_typing`` and main changes to ``typing`` are ``__new__`` and ``__getitem__``.

The idea is to make most things not classes. Now ``_ForwardRef()``, ``TypeVar()``, ``Union[]``, ``Tuple[]``, ``Callable[]`` are not classes (i.e. new class objects are almost never created by ``typing``).

Using ``isinstance()`` or ``issubclass()`` rises ``TypeError`` for almost everything. There are exceptions:
* Unsubscripted generics are still OK, e.g. ``issubclass({}, typing.Mapping)``. This is done to (a) not break existing code by addition of type information; (b) to allow using ``typing`` classes as a replacement for ``collections.abc`` in class and instance checks. Finally, there is an agreement that a generic without parameters assumes ``Any``, and ``Any`` means fallback to *dynamic* typing.
* ``isinstance(lambda x: x, typing.Callable)`` is also OK. Although ``Callable`` is not a generic class, when unsubscribed, it could be also used as a replacement for ``collections.abc.Callable``.
* The first rule for generics makes ``isinstance([], typing.List)`` possible, for consistency I also allowed ``isinstance((), typing.Tuple)``.

Finally, generics should be classes, to allow subclassing, but now the outcome of ``__getitem__`` on classes is cached. I use an extended version of ``functools.lru_cache`` that allows fallback to non-cached version for unhashable arguments.

This is still WIP, since I did this only for Python 3.

@gvanrossum @JukkaL Please take a look.