### PR TITLE
Include __extra__ base in generics MRO

### DIFF
--- a/python2/test_typing.py
+++ b/python2/test_typing.py
@@ -573,36 +573,32 @@ class GenericTests(BaseTestCase):
         self.assertNotIsInstance({}, MyMapping)
         self.assertNotIsSubclass(dict, MyMapping)
 
-    def test_multiple_abc_bases(self):
+    def test_abc_bases(self):
+        class MM(MutableMapping[str, str]):
+            def __getitem__(self, k):
+                return None
+            def __setitem__(self, k, v):
+                pass
+            def __delitem__(self, k):
+                pass
+            def __iter__(self):
+                return iter(())
+            def __len__(self):
+                return 0
+        # this should just work
+        MM().update()
+        self.assertIsInstance(MM(), collections_abc.MutableMapping)
+        self.assertIsInstance(MM(), MutableMapping)
+        self.assertNotIsInstance(MM(), List)
+        self.assertNotIsInstance({}, MM)
+
+    def test_multiple_bases(self):
         class MM1(MutableMapping[str, str], collections_abc.MutableMapping):
-            def __getitem__(self, k):
-                return None
-            def __setitem__(self, k, v):
+            pass
+        with self.assertRaises(TypeError):
+            # consistent MRO not possible
+            class MM2(collections_abc.MutableMapping, MutableMapping[str, str]):
                 pass
-            def __delitem__(self, k):
-                pass
-            def __iter__(self):
-                return iter(())
-            def __len__(self):
-                return 0
-        class MM2(collections_abc.MutableMapping, MutableMapping[str, str]):
-            def __getitem__(self, k):
-                return None
-            def __setitem__(self, k, v):
-                pass
-            def __delitem__(self, k):
-                pass
-            def __iter__(self):
-                return iter(())
-            def __len__(self):
-                return 0
-        # these two should just work
-        MM1().update()
-        MM2().update()
-        self.assertIsInstance(MM1(), collections_abc.MutableMapping)
-        self.assertIsInstance(MM1(), MutableMapping)
-        self.assertIsInstance(MM2(), collections_abc.MutableMapping)
-        self.assertIsInstance(MM2(), MutableMapping)
 
     def test_pickle(self):
         global C  # pickle wants to reference the class by name
@@ -1054,12 +1050,28 @@ class CollectionsAbcTests(BaseTestCase):
             MMA()
 
         class MMC(MMA):
+            def __getitem__(self, k):
+                return None
+            def __setitem__(self, k, v):
+                pass
+            def __delitem__(self, k):
+                pass
+            def __iter__(self):
+                return iter(())
             def __len__(self):
                 return 0
 
         self.assertEqual(len(MMC()), 0)
 
         class MMB(typing.MutableMapping[KT, VT]):
+            def __getitem__(self, k):
+                return None
+            def __setitem__(self, k, v):
+                pass
+            def __delitem__(self, k):
+                pass
+            def __iter__(self):
+                return iter(())
             def __len__(self):
                 return 0
 

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -974,11 +974,55 @@ def _next_in_mro(cls):
     return next_in_mro
 
 
+def _valid_for_check(cls):
+    if cls is Generic:
+        raise TypeError("Class %r cannot be used with class "
+                        "or instance checks" % cls)
+    if (cls.__origin__ is not None and
+        sys._getframe(3).f_globals['__name__'] != 'abc'):
+        raise TypeError("Parameterized generics cannot be used with class "
+                        "or instance checks")
+
+
+def _make_subclasshook(cls):
+    """Construct a __subclasshook__ callable that incorporates
+    the associated __extra__ class in subclass checks performed
+    against cls.
+    """
+    if isinstance(cls.__extra__, abc.ABCMeta):
+        # The logic mirrors that of ABCMeta.__subclasscheck__.
+        # Registered classes need not be checked here because
+        # cls and its extra share the same _abc_registry.
+        def __extrahook__(cls, subclass):
+            _valid_for_check(cls)
+            res = cls.__extra__.__subclasshook__(subclass)
+            if res is not NotImplemented:
+                return res
+            if cls.__extra__ in subclass.__mro__:
+                return True
+            for scls in cls.__extra__.__subclasses__():
+                if isinstance(scls, GenericMeta):
+                    continue
+                if issubclass(subclass, scls):
+                    return True
+            return NotImplemented
+    else:
+        # For non-ABC extras we'll just call issubclass().
+        def __extrahook__(cls, subclass):
+            _valid_for_check(cls)
+            if cls.__extra__ and issubclass(subclass, cls.__extra__):
+                return True
+            return NotImplemented
+    return classmethod(__extrahook__)
+
+
 class GenericMeta(TypingMeta, abc.ABCMeta):
     """Metaclass for generic types."""
 
     def __new__(cls, name, bases, namespace,
                 tvars=None, args=None, origin=None, extra=None):
+        if extra is not None and type(extra) is abc.ABCMeta and extra not in bases:
+            bases = (extra,) + bases
         self = super(GenericMeta, cls).__new__(cls, name, bases, namespace)
 
         if tvars is not None:
@@ -1027,6 +1071,13 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
         self.__extra__ = namespace.get('__extra__')
         # Speed hack (https://github.com/python/typing/issues/196).
         self.__next_in_mro__ = _next_in_mro(self)
+
+        # This allows unparameterized generic collections to be used
+        # with issubclass() and isinstance() in the same way as their
+        # collections.abc counterparts (e.g., isinstance([], Iterable)).
+        self.__subclasshook__ = _make_subclasshook(self)
+        if isinstance(extra, abc.ABCMeta):
+            self._abc_registry = extra._abc_registry
         return self
 
     def _get_type_vars(self, tvars):
@@ -1111,20 +1162,8 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
         # latter, we must extend __instancecheck__ too. For simplicity
         # we just skip the cache check -- instance checks for generic
         # classes are supposed to be rare anyways.
-        return self.__subclasscheck__(instance.__class__)
-
-    def __subclasscheck__(self, cls):
-        if self is Generic:
-            raise TypeError("Class %r cannot be used with class "
-                            "or instance checks" % self)
-        if (self.__origin__ is not None and
-            sys._getframe(1).f_globals['__name__'] != 'abc'):
-            raise TypeError("Parameterized generics cannot be used with class "
-                            "or instance checks")
-        if super(GenericMeta, self).__subclasscheck__(cls):
-            return True
-        if self.__extra__ is not None:
-            return issubclass(cls, self.__extra__)
+        if not isinstance(instance, type):
+            return issubclass(instance.__class__, self)
         return False
 
 

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -600,8 +600,8 @@ class GenericTests(BaseTestCase):
         self.assertNotIsInstance({}, MyMapping)
         self.assertNotIsSubclass(dict, MyMapping)
 
-    def test_multiple_abc_bases(self):
-        class MM1(MutableMapping[str, str], collections_abc.MutableMapping):
+    def test_abc_bases(self):
+        class MM(MutableMapping[str, str]):
             def __getitem__(self, k):
                 return None
             def __setitem__(self, k, v):
@@ -612,24 +612,12 @@ class GenericTests(BaseTestCase):
                 return iter(())
             def __len__(self):
                 return 0
-        class MM2(collections_abc.MutableMapping, MutableMapping[str, str]):
-            def __getitem__(self, k):
-                return None
-            def __setitem__(self, k, v):
-                pass
-            def __delitem__(self, k):
-                pass
-            def __iter__(self):
-                return iter(())
-            def __len__(self):
-                return 0
-        # these two should just work
-        MM1().update()
-        MM2().update()
-        self.assertIsInstance(MM1(), collections_abc.MutableMapping)
-        self.assertIsInstance(MM1(), MutableMapping)
-        self.assertIsInstance(MM2(), collections_abc.MutableMapping)
-        self.assertIsInstance(MM2(), MutableMapping)
+        # this should just work
+        MM().update()
+        self.assertIsInstance(MM(), collections_abc.MutableMapping)
+        self.assertIsInstance(MM(), MutableMapping)
+        self.assertNotIsInstance(MM(), List)
+        self.assertNotIsInstance({}, MM)
 
     def test_pickle(self):
         global C  # pickle wants to reference the class by name
@@ -1380,12 +1368,28 @@ class CollectionsAbcTests(BaseTestCase):
             MMA()
 
         class MMC(MMA):
+            def __getitem__(self, k):
+                return None
+            def __setitem__(self, k, v):
+                pass
+            def __delitem__(self, k):
+                pass
+            def __iter__(self):
+                return iter(())
             def __len__(self):
                 return 0
 
         self.assertEqual(len(MMC()), 0)
 
         class MMB(typing.MutableMapping[KT, VT]):
+            def __getitem__(self, k):
+                return None
+            def __setitem__(self, k, v):
+                pass
+            def __delitem__(self, k):
+                pass
+            def __iter__(self):
+                return iter(())
             def __len__(self):
                 return 0
 

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -619,6 +619,14 @@ class GenericTests(BaseTestCase):
         self.assertNotIsInstance(MM(), List)
         self.assertNotIsInstance({}, MM)
 
+    def test_multiple_bases(self):
+        class MM1(MutableMapping[str, str], collections_abc.MutableMapping):
+            pass
+        with self.assertRaises(TypeError):
+            # consistent MRO not possible
+            class MM2(collections_abc.MutableMapping, MutableMapping[str, str]):
+                pass
+
     def test_pickle(self):
         global C  # pickle wants to reference the class by name
         T = TypeVar('T')


### PR DESCRIPTION
Fixes #203 
@gvanrossum 
This is a simple-minded fix. Basically, I just copied some parts from #207 + small tweaks + backport to Python 2. Note that this makes classes inherited from ``typing.Mapping`` etc. real ABCs, i.e. they could not be instantiated without implementing all the abstract methods (in this sense ``typing.X`` and ``collections.abc.X`` are identical).

Please take a look.