### PR TITLE
Add more tests for ABC behaviour of typing classes

### DIFF
--- a/python2/test_typing.py
+++ b/python2/test_typing.py
@@ -1120,8 +1120,10 @@ class CollectionsAbcTests(BaseTestCase):
 
         class C(Base): pass
         class Foo: pass
+        class Bar: pass
         self.assertIsSubclass(Foo, Base)
-        self.assertNotIsSubclass(Foo, C)
+        self.assertIsSubclass(Foo, C)
+        self.assertNotIsSubclass(Bar, C)
 
     def test_subclassing_register(self):
 

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -1102,8 +1102,8 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
         # This allows unparameterized generic collections to be used
         # with issubclass() and isinstance() in the same way as their
         # collections.abc counterparts (e.g., isinstance([], Iterable)).
-        if ('__subclasshook__' not in namespace or  # allow overriding
-            hasattr(self.__subclasshook__, '__name__') and
+        if ('__subclasshook__' not in namespace and extra  # allow overriding
+            or hasattr(self.__subclasshook__, '__name__') and
             self.__subclasshook__.__name__ == '__extrahook__'):
             self.__subclasshook__ = _make_subclasshook(self)
         if isinstance(extra, abc.ABCMeta):

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -1023,7 +1023,7 @@ def _make_subclasshook(cls):
             res = cls.__extra__.__subclasshook__(subclass)
             if res is not NotImplemented:
                 return res
-            if cls.__extra__ in subclass.__mro__:
+            if cls.__extra__ in getattr(subclass, '__mro__', ()):
                 return True
             for scls in cls.__extra__.__subclasses__():
                 if isinstance(scls, GenericMeta):
@@ -1046,6 +1046,8 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
 
     def __new__(cls, name, bases, namespace,
                 tvars=None, args=None, origin=None, extra=None):
+        if extra is None:
+            extra = namespace.get('__extra__')
         if extra is not None and type(extra) is abc.ABCMeta and extra not in bases:
             bases = (extra,) + bases
         self = super(GenericMeta, cls).__new__(cls, name, bases, namespace)
@@ -1093,14 +1095,17 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
         self.__parameters__ = tvars
         self.__args__ = args
         self.__origin__ = origin
-        self.__extra__ = namespace.get('__extra__')
+        self.__extra__ = extra
         # Speed hack (https://github.com/python/typing/issues/196).
         self.__next_in_mro__ = _next_in_mro(self)
 
         # This allows unparameterized generic collections to be used
         # with issubclass() and isinstance() in the same way as their
         # collections.abc counterparts (e.g., isinstance([], Iterable)).
-        self.__subclasshook__ = _make_subclasshook(self)
+        if ('__subclasshook__' not in namespace or  # allow overriding
+            hasattr(self.__subclasshook__, '__name__') and
+            self.__subclasshook__.__name__ == '__extrahook__'):
+            self.__subclasshook__ = _make_subclasshook(self)
         if isinstance(extra, abc.ABCMeta):
             self._abc_registry = extra._abc_registry
         return self

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -1446,8 +1446,10 @@ class CollectionsAbcTests(BaseTestCase):
 
         class C(Base): ...
         class Foo: ...
+        class Bar: ...
         self.assertIsSubclass(Foo, Base)
-        self.assertNotIsSubclass(Foo, C)
+        self.assertIsSubclass(Foo, C)
+        self.assertNotIsSubclass(Bar, C)
 
     def test_subclassing_register(self):
 

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -20,6 +20,7 @@ from typing import NewType
 from typing import NamedTuple
 from typing import IO, TextIO, BinaryIO
 from typing import Pattern, Match
+import abc
 import typing
 try:
     import collections.abc as collections_abc
@@ -1385,6 +1386,8 @@ class CollectionsAbcTests(BaseTestCase):
                 return 0
 
         self.assertEqual(len(MMC()), 0)
+        assert callable(MMC.update)
+        self.assertIsInstance(MMC(), typing.Mapping)
 
         class MMB(typing.MutableMapping[KT, VT]):
             def __getitem__(self, k):
@@ -1408,6 +1411,80 @@ class CollectionsAbcTests(BaseTestCase):
         self.assertIsSubclass(MMA, typing.Mapping)
         self.assertIsSubclass(MMB, typing.Mapping)
         self.assertIsSubclass(MMC, typing.Mapping)
+
+        self.assertIsInstance(MMB[KT, VT](), typing.Mapping)
+        self.assertIsInstance(MMB[KT, VT](), collections.Mapping)
+
+        self.assertIsSubclass(MMA, collections.Mapping)
+        self.assertIsSubclass(MMB, collections.Mapping)
+        self.assertIsSubclass(MMC, collections.Mapping)
+
+        self.assertIsSubclass(MMB[str, str], typing.Mapping)
+        self.assertIsSubclass(MMC, MMA)
+
+        class I(typing.Iterable): ...
+        self.assertNotIsSubclass(list, I)
+
+        class G(typing.Generator[int, int, int]): ...
+        def g(): yield 0
+        self.assertIsSubclass(G, typing.Generator)
+        self.assertIsSubclass(G, typing.Iterable)
+        if hasattr(collections, 'Generator'):
+            self.assertIsSubclass(G, collections.Generator)
+        self.assertIsSubclass(G, collections.Iterable)
+        self.assertNotIsSubclass(type(g), G)
+
+    def test_subclassing_subclasshook(self):
+
+        class Base(typing.Iterable):
+            @classmethod
+            def __subclasshook__(cls, other):
+                if other.__name__ == 'Foo':
+                    return True
+                else:
+                    return False
+
+        class C(Base): ...
+        class Foo: ...
+        self.assertIsSubclass(Foo, Base)
+        self.assertNotIsSubclass(Foo, C)
+
+    def test_subclassing_register(self):
+
+        class A(typing.Container): ...
+        class B(A): ...
+
+        class C: ...
+        A.register(C)
+        self.assertIsSubclass(C, A)
+        self.assertNotIsSubclass(C, B)
+
+        class D: ...
+        B.register(D)
+        self.assertIsSubclass(D, A)
+        self.assertIsSubclass(D, B)
+
+        class M(): ...
+        collections.MutableMapping.register(M)
+        self.assertIsSubclass(M, typing.Mapping)
+
+    def test_collections_as_base(self):
+
+        class M(collections.Mapping): ...
+        self.assertIsSubclass(M, typing.Mapping)
+        self.assertIsSubclass(M, typing.Iterable)
+
+        class S(collections.MutableSequence): ...
+        self.assertIsSubclass(S, typing.MutableSequence)
+        self.assertIsSubclass(S, typing.Iterable)
+
+        class I(collections.Iterable): ...
+        self.assertIsSubclass(I, typing.Iterable)
+
+        class A(collections.Mapping, metaclass=abc.ABCMeta): ...
+        class B: ...
+        A.register(B)
+        self.assertIsSubclass(B, typing.Mapping)
 
 
 class OtherABCTests(BaseTestCase):

--- a/src/typing.py
+++ b/src/typing.py
@@ -993,8 +993,8 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
         # This allows unparameterized generic collections to be used
         # with issubclass() and isinstance() in the same way as their
         # collections.abc counterparts (e.g., isinstance([], Iterable)).
-        if ('__subclasshook__' not in namespace or  # allow overriding
-            hasattr(self.__subclasshook__, '__name__') and
+        if ('__subclasshook__' not in namespace and extra  # allow overriding
+            or hasattr(self.__subclasshook__, '__name__') and
             self.__subclasshook__.__name__ == '__extrahook__'):
             self.__subclasshook__ = _make_subclasshook(self)
         if isinstance(extra, abc.ABCMeta):

--- a/src/typing.py
+++ b/src/typing.py
@@ -993,7 +993,10 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
         # This allows unparameterized generic collections to be used
         # with issubclass() and isinstance() in the same way as their
         # collections.abc counterparts (e.g., isinstance([], Iterable)).
-        self.__subclasshook__ = _make_subclasshook(self)
+        if ('__subclasshook__' not in namespace or  # allow overriding
+            hasattr(self.__subclasshook__, '__name__') and
+            self.__subclasshook__.__name__ == '__extrahook__'):
+            self.__subclasshook__ = _make_subclasshook(self)
         if isinstance(extra, abc.ABCMeta):
             self._abc_registry = extra._abc_registry
         return self


### PR DESCRIPTION
@gvanrossum 
Here I am adding tests as discussed with @bintoro.

These tests actually revealed three small bugs:
* Old style classes in Python don't have ``__mro__``.
* We should use ``__extra__`` instead of ``extra`` in Python2 (since no kwargs in classes).
* We should allow overriding ``__subclasshook__`` by subclasses.