### PR TITLE
Alternative (simpler) repr for generics

### DIFF
--- a/python2/test_typing.py
+++ b/python2/test_typing.py
@@ -521,9 +521,9 @@ class GenericTests(BaseTestCase):
 
     def test_repr(self):
         self.assertEqual(repr(SimpleMapping),
-                         __name__ + '.' + 'SimpleMapping[~XK, ~XV]')
+                         __name__ + '.' + 'SimpleMapping')
         self.assertEqual(repr(MySimpleMapping),
-                         __name__ + '.' + 'MySimpleMapping[~XK, ~XV]')
+                         __name__ + '.' + 'MySimpleMapping')
 
     def test_chain_repr(self):
         T = TypeVar('T')
@@ -554,7 +554,7 @@ class GenericTests(BaseTestCase):
         U = TypeVar('U', covariant=True)
         S = TypeVar('S')
 
-        self.assertEqual(repr(List), 'typing.List[~T]')
+        self.assertEqual(repr(List), 'typing.List')
         self.assertEqual(repr(List[T]), 'typing.List[~T]')
         self.assertEqual(repr(List[U]), 'typing.List[+U]')
         self.assertEqual(repr(List[S][T][int]), 'typing.List[int]')
@@ -664,7 +664,7 @@ class GenericTests(BaseTestCase):
         if not PY32:
             self.assertEqual(C.__qualname__,
                              'GenericTests.test_repr_2.<locals>.C')
-        self.assertEqual(repr(C).split('.')[-1], 'C[~T]')
+        self.assertEqual(repr(C).split('.')[-1], 'C')
         X = C[int]
         self.assertEqual(X.__module__, __name__)
         if not PY32:

--- a/python2/test_typing.py
+++ b/python2/test_typing.py
@@ -570,6 +570,14 @@ class GenericTests(BaseTestCase):
         self.assertEqual(repr(List[Tuple[T, T]][List[int]]),
                  'typing.List[typing.Tuple[typing.List[int], typing.List[int]]]')
 
+    def test_new_repr_bare(self):
+        T = TypeVar('T')
+        self.assertEqual(repr(Generic[T]), 'typing.Generic[~T]')
+        self.assertEqual(repr(typing._Protocol[T]), 'typing.Protocol[~T]')
+        class C(typing.Dict[Any, Any]): pass
+        # this line should just work
+        repr(C.__mro__)
+
     def test_dict(self):
         T = TypeVar('T')
 

--- a/python2/test_typing.py
+++ b/python2/test_typing.py
@@ -521,9 +521,9 @@ class GenericTests(BaseTestCase):
 
     def test_repr(self):
         self.assertEqual(repr(SimpleMapping),
-                         __name__ + '.' + 'SimpleMapping<~XK, ~XV>')
+                         __name__ + '.' + 'SimpleMapping[~XK, ~XV]')
         self.assertEqual(repr(MySimpleMapping),
-                         __name__ + '.' + 'MySimpleMapping<~XK, ~XV>')
+                         __name__ + '.' + 'MySimpleMapping[~XK, ~XV]')
 
     def test_chain_repr(self):
         T = TypeVar('T')
@@ -547,7 +547,28 @@ class GenericTests(BaseTestCase):
         self.assertNotEqual(Z, Y[T])
 
         self.assertTrue(str(Z).endswith(
-            '.C<~T>[typing.Tuple[~S, ~T]]<~S, ~T>[~T, int]<~T>[str]'))
+            '.C[typing.Tuple[str, int]]'))
+
+    def test_new_repr(self):
+        T = TypeVar('T')
+        U = TypeVar('U', covariant=True)
+        S = TypeVar('S')
+
+        self.assertEqual(repr(List), 'typing.List[~T]')
+        self.assertEqual(repr(List[T]), 'typing.List[~T]')
+        self.assertEqual(repr(List[U]), 'typing.List[+U]')
+        self.assertEqual(repr(List[S][T][int]), 'typing.List[int]')
+        self.assertEqual(repr(List[int]), 'typing.List[int]')
+
+    def test_new_repr_complex(self):
+        T = TypeVar('T')
+        TS = TypeVar('TS')
+
+        self.assertEqual(repr(typing.Mapping[T, TS][TS, T]), 'typing.Mapping[~TS, ~T]')
+        self.assertEqual(repr(List[Tuple[T, TS]][int, T]),
+                         'typing.List[typing.Tuple[int, ~T]]')
+        self.assertEqual(repr(List[Tuple[T, T]][List[int]]),
+                 'typing.List[typing.Tuple[typing.List[int], typing.List[int]]]')
 
     def test_dict(self):
         T = TypeVar('T')
@@ -635,12 +656,12 @@ class GenericTests(BaseTestCase):
         if not PY32:
             self.assertEqual(C.__qualname__,
                              'GenericTests.test_repr_2.<locals>.C')
-        self.assertEqual(repr(C).split('.')[-1], 'C<~T>')
+        self.assertEqual(repr(C).split('.')[-1], 'C[~T]')
         X = C[int]
         self.assertEqual(X.__module__, __name__)
         if not PY32:
             self.assertEqual(X.__qualname__, 'C')
-        self.assertEqual(repr(X).split('.')[-1], 'C<~T>[int]')
+        self.assertEqual(repr(X).split('.')[-1], 'C[int]')
 
         class Y(C[int]):
             pass

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -1119,15 +1119,13 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
 
     def _argrepr(self):
         if self.__origin__ is None:
-            if self.__parameters__:
-                return '[%s]' % (
-                    ', '.join(_type_repr(p) for p in self.__parameters__))
-            return ''
+            if not self.__parameters__:
+                return ''
+            return '[%s]' % (', '.join(map(_type_repr, self.__parameters__)))
         r = self.__origin__._argrepr()
-        for i, arg in enumerate(self.__args__):
-            r = stdlib_re.sub(stdlib_re.escape(
-                              _type_repr(self.__origin__.__parameters__[i]))
-                              + '(?=[,\]])', '{%r}' % i, r)
+        for i in range(len(self.__args__)):  # replace free parameters with args
+            par = stdlib_re.escape(_type_repr(self.__origin__.__parameters__[i]))
+            r = stdlib_re.sub(par + '(?=[,\]])', '{%r}' % i, r)
         return r.format(*map(_type_repr, self.__args__))
 
     def __eq__(self, other):

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -276,8 +276,8 @@ class _TypeAlias(_TypingBase):
             if not issubclass(parameter, self.type_var.__constraints__):
                 raise TypeError("%s is not a valid substitution for %s." %
                                 (parameter, self.type_var))
-        if isinstance(parameter, TypeVar):
-            raise TypeError("%s cannot be re-parameterized." % self.type_var)
+        if isinstance(parameter, TypeVar) and parameter is not self.type_var:
+            raise TypeError("%s cannot be re-parameterized." % self)
         return self.__class__(self.name, parameter,
                               self.impl_type, self.type_checker)
 
@@ -398,12 +398,15 @@ class _ClassVar(_FinalTypingBase):
 
     def _get_type_vars(self, tvars):
         if self.__type__:
-            _get_type_vars(self.__type__, tvars)
+            _get_type_vars([self.__type__], tvars)
 
     def __repr__(self):
+        return self._subs_repr([], [])
+
+    def _subs_repr(self, tvars, args):
         r = super(_ClassVar, self).__repr__()
         if self.__type__ is not None:
-            r += '[{}]'.format(_type_repr(self.__type__))
+            r += '[{}]'.format(_replace_arg(self.__type__, tvars, args))
         return r
 
     def __hash__(self):
@@ -703,9 +706,12 @@ class _Union(_FinalTypingBase):
             _get_type_vars(self.__union_params__, tvars)
 
     def __repr__(self):
+        return self._subs_repr([], [])
+
+    def _subs_repr(self, tvars, args):
         r = super(_Union, self).__repr__()
         if self.__union_params__:
-            r += '[%s]' % (', '.join(_type_repr(t)
+            r += '[%s]' % (', '.join(_replace_arg(t, tvars, args)
                                      for t in self.__union_params__))
         return r
 
@@ -805,9 +811,12 @@ class _Tuple(_FinalTypingBase):
             return self.__class__(p, _root=True)
 
     def __repr__(self):
+        return self._subs_repr([], [])
+
+    def _subs_repr(self, tvars, args):
         r = super(_Tuple, self).__repr__()
         if self.__tuple_params__ is not None:
-            params = [_type_repr(p) for p in self.__tuple_params__]
+            params = [_replace_arg(p, tvars, args) for p in self.__tuple_params__]
             if self.__tuple_use_ellipsis__:
                 params.append('...')
             if not params:
@@ -898,6 +907,8 @@ class _Callable(_FinalTypingBase):
     def _get_type_vars(self, tvars):
         if self.__args__ and self.__args__ is not Ellipsis:
             _get_type_vars(self.__args__, tvars)
+        if self.__result__:
+            _get_type_vars([self.__result__], tvars)
 
     def _eval_type(self, globalns, localns):
         if self.__args__ is None and self.__result__ is None:
@@ -913,14 +924,17 @@ class _Callable(_FinalTypingBase):
             return self.__class__(args=args, result=result, _root=True)
 
     def __repr__(self):
+        return self._subs_repr([], [])
+
+    def _subs_repr(self, tvars, args):
         r = super(_Callable, self).__repr__()
         if self.__args__ is not None or self.__result__ is not None:
             if self.__args__ is Ellipsis:
                 args_r = '...'
             else:
-                args_r = '[%s]' % ', '.join(_type_repr(t)
+                args_r = '[%s]' % ', '.join(_replace_arg(t, tvars, args)
                                             for t in self.__args__)
-            r += '[%s, %s]' % (args_r, _type_repr(self.__result__))
+            r += '[%s, %s]' % (args_r, _replace_arg(self.__result__, tvars, args))
         return r
 
     def __getitem__(self, parameters):
@@ -983,6 +997,16 @@ def _geqv(a, b):
     assert isinstance(a, GenericMeta) and isinstance(b, GenericMeta)
     # Reduce each to its origin.
     return _gorg(a) is _gorg(b)
+
+
+def _replace_arg(arg, tvars, args):
+    if hasattr(arg, '_subs_repr'):
+        return arg._subs_repr(tvars, args)
+    if isinstance(arg, TypeVar):
+       for i, tvar in enumerate(tvars):
+           if arg.__name__ == tvar.__name__:
+               return args[i]
+    return _type_repr(arg)
 
 
 def _next_in_mro(cls):
@@ -1115,29 +1139,29 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
             _get_type_vars(self.__parameters__, tvars)
 
     def __repr__(self):
-        return super(GenericMeta, self).__repr__() + self._arg_repr()
-
-    def _arg_repr(self):
-        par_repr = '[%s]' % (', '.join(map(_type_repr, self.__parameters__)))
-        if self.__origin__ in [Generic, _Protocol]:
-            return par_repr
         if self.__origin__ is None:
-            if not self.__parameters__:
-                return ''
-            return par_repr
+            return super(GenericMeta, self).__repr__()
+        return self._subs_repr([], [])
 
-        current = self
+    def _subs_repr(self, tvars, args):
+        assert len(tvars) == len(args)
+        # Construct the chain of __origin__'s.
+        current = self.__origin__
         orig_chain = []
         while current.__origin__ is not None:
             orig_chain.append(current)
             current = current.__origin__
-        r = '[%s]' % (', '.join(map(_type_repr, orig_chain[-1].__origin__.__parameters__)))
-        for tp in reversed(orig_chain):
-            for i in range(len(tp.__args__)):  # replace free parameters with args
-                par = stdlib_re.escape(_type_repr(tp.__origin__.__parameters__[i]))
-                r = stdlib_re.sub(par + '(?=[,\]])', '{%r}' % i, r)
-            r = r.format(*map(_type_repr, tp.__args__))
-        return r
+        # Replace type variables in __args__ if asked ...
+        str_args = []
+        for arg in self.__args__:
+            str_args.append(_replace_arg(arg, tvars, args))
+        # ... then continue replacing down the origin chain.
+        for cls in orig_chain:
+            new_str_args = []
+            for i, arg in enumerate(cls.__args__):
+                new_str_args.append(_replace_arg(arg, cls.__parameters__, str_args))
+            str_args = new_str_args
+        return super(GenericMeta, self).__repr__() + '[%s]' % ', '.join(str_args)
 
     def __eq__(self, other):
         if not isinstance(other, GenericMeta):
@@ -1170,11 +1194,11 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
                 raise TypeError(
                     "Parameters to Generic[...] must all be unique")
             tvars = params
-            args = None
+            args = params
         elif self is _Protocol:
             # _Protocol is internal, don't check anything.
             tvars = params
-            args = None
+            args = params
         elif self.__origin__ in (Generic, _Protocol):
             # Can't subscript Generic[...] or _Protocol[...].
             raise TypeError("Cannot subscript already-subscripted %s" %

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -1119,8 +1119,10 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
 
     def _argrepr(self):
         if self.__origin__ is None:
-            return '[%s]' % (
-                ', '.join(_type_repr(p) for p in self.__parameters__))
+            if self.__parameters__:
+                return '[%s]' % (
+                    ', '.join(_type_repr(p) for p in self.__parameters__))
+            return ''
         r = self.__origin__._argrepr()
         for i, arg in enumerate(self.__args__):
             r = stdlib_re.sub(stdlib_re.escape(

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -1115,14 +1115,17 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
             _get_type_vars(self.__parameters__, tvars)
 
     def __repr__(self):
-        return super(GenericMeta, self).__repr__() + self._argrepr()
+        return super(GenericMeta, self).__repr__() + self._arg_repr()
 
-    def _argrepr(self):
+    def _arg_repr(self):
+        par_repr = '[%s]' % (', '.join(map(_type_repr, self.__parameters__)))
+        if self.__origin__ in [Generic, _Protocol]:
+            return par_repr
         if self.__origin__ is None:
             if not self.__parameters__:
                 return ''
-            return '[%s]' % (', '.join(map(_type_repr, self.__parameters__)))
-        r = self.__origin__._argrepr()
+            return par_repr
+        r = self.__origin__._arg_repr()
         for i in range(len(self.__args__)):  # replace free parameters with args
             par = stdlib_re.escape(_type_repr(self.__origin__.__parameters__[i]))
             r = stdlib_re.sub(par + '(?=[,\]])', '{%r}' % i, r)

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -1128,7 +1128,7 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
             r = stdlib_re.sub(stdlib_re.escape(
                               _type_repr(self.__origin__.__parameters__[i]))
                               + '(?=[,\]])', '{%r}' % i, r)
-        return r.format(*(_type_repr(arg) for arg in self.__args__))
+        return r.format(*map(_type_repr, self.__args__))
 
     def __eq__(self, other):
         if not isinstance(other, GenericMeta):

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -1115,17 +1115,18 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
             _get_type_vars(self.__parameters__, tvars)
 
     def __repr__(self):
-        if self.__origin__ is not None:
-            r = repr(self.__origin__)
-        else:
-            r = super(GenericMeta, self).__repr__()
-        if self.__args__:
-            r += '[%s]' % (
-                ', '.join(_type_repr(p) for p in self.__args__))
-        if self.__parameters__:
-            r += '<%s>' % (
+        return super(GenericMeta, self).__repr__() + self._argrepr()
+
+    def _argrepr(self):
+        if self.__origin__ is None:
+            return '[%s]' % (
                 ', '.join(_type_repr(p) for p in self.__parameters__))
-        return r
+        r = self.__origin__._argrepr()
+        for i, arg in enumerate(self.__args__):
+            r = stdlib_re.sub(stdlib_re.escape(
+                              _type_repr(self.__origin__.__parameters__[i]))
+                              + '(?=[,\]])', '{%r}' % i, r)
+        return r.format(*(_type_repr(arg) for arg in self.__args__))
 
     def __eq__(self, other):
         if not isinstance(other, GenericMeta):

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -597,6 +597,14 @@ class GenericTests(BaseTestCase):
         self.assertEqual(repr(List[Tuple[T, T]][List[int]]),
                  'typing.List[typing.Tuple[typing.List[int], typing.List[int]]]')
 
+    def test_new_repr_bare(self):
+        T = TypeVar('T')
+        self.assertEqual(repr(Generic[T]), 'typing.Generic[~T]')
+        self.assertEqual(repr(typing._Protocol[T]), 'typing.Protocol[~T]')
+        class C(typing.Dict[Any, Any]): ...
+        # this line should just work
+        repr(C.__mro__)
+
     def test_dict(self):
         T = TypeVar('T')
 

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -548,9 +548,9 @@ class GenericTests(BaseTestCase):
 
     def test_repr(self):
         self.assertEqual(repr(SimpleMapping),
-                         __name__ + '.' + 'SimpleMapping[~XK, ~XV]')
+                         __name__ + '.' + 'SimpleMapping')
         self.assertEqual(repr(MySimpleMapping),
-                         __name__ + '.' + 'MySimpleMapping[~XK, ~XV]')
+                         __name__ + '.' + 'MySimpleMapping')
 
     def test_chain_repr(self):
         T = TypeVar('T')
@@ -581,7 +581,7 @@ class GenericTests(BaseTestCase):
         U = TypeVar('U', covariant=True)
         S = TypeVar('S')
 
-        self.assertEqual(repr(List), 'typing.List[~T]')
+        self.assertEqual(repr(List), 'typing.List')
         self.assertEqual(repr(List[T]), 'typing.List[~T]')
         self.assertEqual(repr(List[U]), 'typing.List[+U]')
         self.assertEqual(repr(List[S][T][int]), 'typing.List[int]')
@@ -691,7 +691,7 @@ class GenericTests(BaseTestCase):
         if not PY32:
             self.assertEqual(C.__qualname__,
                              'GenericTests.test_repr_2.<locals>.C')
-        self.assertEqual(repr(C).split('.')[-1], 'C[~T]')
+        self.assertEqual(repr(C).split('.')[-1], 'C')
         X = C[int]
         self.assertEqual(X.__module__, __name__)
         if not PY32:

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -548,9 +548,9 @@ class GenericTests(BaseTestCase):
 
     def test_repr(self):
         self.assertEqual(repr(SimpleMapping),
-                         __name__ + '.' + 'SimpleMapping<~XK, ~XV>')
+                         __name__ + '.' + 'SimpleMapping[~XK, ~XV]')
         self.assertEqual(repr(MySimpleMapping),
-                         __name__ + '.' + 'MySimpleMapping<~XK, ~XV>')
+                         __name__ + '.' + 'MySimpleMapping[~XK, ~XV]')
 
     def test_chain_repr(self):
         T = TypeVar('T')
@@ -574,7 +574,28 @@ class GenericTests(BaseTestCase):
         self.assertNotEqual(Z, Y[T])
 
         self.assertTrue(str(Z).endswith(
-            '.C<~T>[typing.Tuple[~S, ~T]]<~S, ~T>[~T, int]<~T>[str]'))
+            '.C[typing.Tuple[str, int]]'))
+
+    def test_new_repr(self):
+        T = TypeVar('T')
+        U = TypeVar('U', covariant=True)
+        S = TypeVar('S')
+
+        self.assertEqual(repr(List), 'typing.List[~T]')
+        self.assertEqual(repr(List[T]), 'typing.List[~T]')
+        self.assertEqual(repr(List[U]), 'typing.List[+U]')
+        self.assertEqual(repr(List[S][T][int]), 'typing.List[int]')
+        self.assertEqual(repr(List[int]), 'typing.List[int]')
+
+    def test_new_repr_complex(self):
+        T = TypeVar('T')
+        TS = TypeVar('TS')
+
+        self.assertEqual(repr(typing.Mapping[T, TS][TS, T]), 'typing.Mapping[~TS, ~T]')
+        self.assertEqual(repr(List[Tuple[T, TS]][int, T]),
+                         'typing.List[typing.Tuple[int, ~T]]')
+        self.assertEqual(repr(List[Tuple[T, T]][List[int]]),
+                 'typing.List[typing.Tuple[typing.List[int], typing.List[int]]]')
 
     def test_dict(self):
         T = TypeVar('T')
@@ -662,12 +683,12 @@ class GenericTests(BaseTestCase):
         if not PY32:
             self.assertEqual(C.__qualname__,
                              'GenericTests.test_repr_2.<locals>.C')
-        self.assertEqual(repr(C).split('.')[-1], 'C<~T>')
+        self.assertEqual(repr(C).split('.')[-1], 'C[~T]')
         X = C[int]
         self.assertEqual(X.__module__, __name__)
         if not PY32:
             self.assertEqual(X.__qualname__, 'C')
-        self.assertEqual(repr(X).split('.')[-1], 'C<~T>[int]')
+        self.assertEqual(repr(X).split('.')[-1], 'C[int]')
 
         class Y(C[int]):
             pass

--- a/src/typing.py
+++ b/src/typing.py
@@ -1019,7 +1019,7 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
             r = stdlib_re.sub(stdlib_re.escape(
                               _type_repr(self.__origin__.__parameters__[i]))
                               + '(?=[,\]])', '{%r}' % i, r)
-        return r.format(*(_type_repr(arg) for arg in self.__args__))
+        return r.format(*map(_type_repr, self.__args__))
 
     def __eq__(self, other):
         if not isinstance(other, GenericMeta):

--- a/src/typing.py
+++ b/src/typing.py
@@ -1010,15 +1010,13 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
 
     def _argrepr(self):
         if self.__origin__ is None:
-            if self.__parameters__:
-                return '[%s]' % (
-                    ', '.join(_type_repr(p) for p in self.__parameters__))
-            return ''
+            if not self.__parameters__:
+                return ''
+            return '[%s]' % (', '.join(map(_type_repr, self.__parameters__)))
         r = self.__origin__._argrepr()
-        for i, arg in enumerate(self.__args__):
-            r = stdlib_re.sub(stdlib_re.escape(
-                              _type_repr(self.__origin__.__parameters__[i]))
-                              + '(?=[,\]])', '{%r}' % i, r)
+        for i in range(len(self.__args__)):  # replace free parameters with args
+            par = stdlib_re.escape(_type_repr(self.__origin__.__parameters__[i]))
+            r = stdlib_re.sub(par + '(?=[,\]])', '{%r}' % i, r)
         return r.format(*map(_type_repr, self.__args__))
 
     def __eq__(self, other):

--- a/src/typing.py
+++ b/src/typing.py
@@ -1010,8 +1010,10 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
 
     def _argrepr(self):
         if self.__origin__ is None:
-            return '[%s]' % (
-                ', '.join(_type_repr(p) for p in self.__parameters__))
+            if self.__parameters__:
+                return '[%s]' % (
+                    ', '.join(_type_repr(p) for p in self.__parameters__))
+            return ''
         r = self.__origin__._argrepr()
         for i, arg in enumerate(self.__args__):
             r = stdlib_re.sub(stdlib_re.escape(

--- a/src/typing.py
+++ b/src/typing.py
@@ -1006,14 +1006,17 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
             _get_type_vars(self.__parameters__, tvars)
 
     def __repr__(self):
-        return super().__repr__() + self._argrepr()
+        return super().__repr__() + self._arg_repr()
 
-    def _argrepr(self):
+    def _arg_repr(self):
+        par_repr = '[%s]' % (', '.join(map(_type_repr, self.__parameters__)))
+        if self.__origin__ in [Generic, _Protocol]:
+            return par_repr
         if self.__origin__ is None:
             if not self.__parameters__:
                 return ''
-            return '[%s]' % (', '.join(map(_type_repr, self.__parameters__)))
-        r = self.__origin__._argrepr()
+            return par_repr
+        r = self.__origin__._arg_repr()
         for i in range(len(self.__args__)):  # replace free parameters with args
             par = stdlib_re.escape(_type_repr(self.__origin__.__parameters__[i]))
             r = stdlib_re.sub(par + '(?=[,\]])', '{%r}' % i, r)

--- a/src/typing.py
+++ b/src/typing.py
@@ -1006,17 +1006,18 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
             _get_type_vars(self.__parameters__, tvars)
 
     def __repr__(self):
-        if self.__origin__ is not None:
-            r = repr(self.__origin__)
-        else:
-            r = super().__repr__()
-        if self.__args__:
-            r += '[%s]' % (
-                ', '.join(_type_repr(p) for p in self.__args__))
-        if self.__parameters__:
-            r += '<%s>' % (
+        return super().__repr__() + self._argrepr()
+
+    def _argrepr(self):
+        if self.__origin__ is None:
+            return '[%s]' % (
                 ', '.join(_type_repr(p) for p in self.__parameters__))
-        return r
+        r = self.__origin__._argrepr()
+        for i, arg in enumerate(self.__args__):
+            r = stdlib_re.sub(stdlib_re.escape(
+                              _type_repr(self.__origin__.__parameters__[i]))
+                              + '(?=[,\]])', '{%r}' % i, r)
+        return r.format(*(_type_repr(arg) for arg in self.__args__))
 
     def __eq__(self, other):
         if not isinstance(other, GenericMeta):


### PR DESCRIPTION
@gvanrossum 
Currently, ``repr`` for generics acts in naive way, so that sometimes this leads to cumbersome representations. For example,
```python
class C(Generic[T]):
    ...

C[Tuple[S, T]][T, int][str]
```
prints the "whole history" ``C<~T>[typing.Tuple[~S, ~T]]<~S, ~T>[~T, int]<~T>[str]``. While the new ``repr`` will print simply the "final result" ``C[typing.Tuple[str, int]]``. Also for simpler cases, ``repr(List[T])`` would be simply ``typing.List[~T]``, not ``typing.List<~T>[~T]<~T>``.

The new ``repr`` does not use angular brackets in addition to square brackets (free parameters are anyway marked with ``~``, ``+`` or ``-``), see added tests.

The implementation might look a bit hacky, but this is done in order to be sure that the ``repr`` will not interfere with those of ``super()`` and will treat correctly complex cases with repeated occurrences of type variables.