### PR TITLE
Two minor fixes

### DIFF
--- a/python2/typing.py
+++ b/python2/typing.py
@@ -1004,7 +1004,7 @@ def _replace_arg(arg, tvars, args):
         return arg._subs_repr(tvars, args)
     if isinstance(arg, TypeVar):
         for i, tvar in enumerate(tvars):
-            if arg.__name__ == tvar.__name__:
+            if arg == tvar:
                 return args[i]
     return _type_repr(arg)
 

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -1179,7 +1179,7 @@ gth = get_type_hints
 class GetTypeHintTests(BaseTestCase):
     @skipUnless(PY36, 'Python 3.6 required')
     def test_get_type_hints_modules(self):
-        self.assertEqual(gth(ann_module), {'x': int, 'y': str})
+        self.assertEqual(gth(ann_module), {1: 2, 'f': Tuple[int, int], 'x': int, 'y': str})
         self.assertEqual(gth(ann_module2), {})
         self.assertEqual(gth(ann_module3), {})
 

--- a/src/typing.py
+++ b/src/typing.py
@@ -894,7 +894,7 @@ def _replace_arg(arg, tvars, args):
         return arg._subs_repr(tvars, args)
     if isinstance(arg, TypeVar):
         for i, tvar in enumerate(tvars):
-            if arg.__name__ == tvar.__name__:
+            if arg == tvar:
                 return args[i]
     return _type_repr(arg)
 
@@ -1322,10 +1322,6 @@ if sys.version_info[:2] >= (3, 3):
                 hints = obj.__annotations__
             except AttributeError:
                 return {}
-            # we keep only those annotations that can be accessed on module
-            members = obj.__dict__
-            hints = {name: value for name, value in hints.items()
-                                              if name in members}
             for name, value in hints.items():
                 if value is None:
                     value = type(None)


### PR DESCRIPTION
Here are two minor fixes for things that I have found in ``typing.py``:
* Type variables should be compared by ``id`` not by name (in one of recent PRs I compared them by ``__name__``, but after reading discussions at mypy tracker I think it was not right, for example two variables with the same name defined in different modules should be considered different).
* All names should be included in ``get_type_hints`` for modules. Initially, only names that could be accessed on modules (i.e. those annotated as ``x: int = 5`` with initial values) were included in ``get_type_hints``. This was done to sync the behaviour with behaviour of ``inspect.getannotations`` (it discards manually added items to ``__annotations__``). Now we don't use ``inspect``, so that we no longer should exclude the undefined names.

@gvanrossum Please take a look.