### PR TITLE
Fix the problem with copy and deepcopy; also improve pickling a bit

### DIFF
--- a/python2/test_typing.py
+++ b/python2/test_typing.py
@@ -5,6 +5,7 @@ import pickle
 import re
 import sys
 from unittest import TestCase, main, SkipTest
+from copy import copy, deepcopy
 
 from typing import Any
 from typing import TypeVar, AnyStr
@@ -803,6 +804,24 @@ class GenericTests(BaseTestCase):
             self.assertEqual(x.foo, 42)
             self.assertEqual(x.bar, 'abc')
             self.assertEqual(x.__dict__, {'foo': 42, 'bar': 'abc'})
+        simples = [Any, Union, Tuple, Callable, ClassVar, List, typing.Iterable]
+        for s in simples:
+            for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+                z = pickle.dumps(s, proto)
+                x = pickle.loads(z)
+                self.assertEqual(s, x)
+
+    def test_copy_and_deepcopy(self):
+        T = TypeVar('T')
+        class Node(Generic[T]): pass
+        things = [Any, Union[T, int], Tuple[T, int], Callable[..., T], Callable[[int], int],
+                  Tuple[Any, Any], Node[T], Node[int], Node[Any], typing.Iterable[T],
+                  typing.Iterable[Any], typing.Iterable[int], typing.Dict[int, str],
+                  typing.Dict[T, Any], ClassVar[int], ClassVar[List[T]], Tuple['T', 'T'],
+                  Union['T', int], List['T'], typing.Mapping['T', int]]
+        for t in things:
+            self.assertEqual(t, deepcopy(t))
+            self.assertEqual(t, copy(t))
 
     def test_errors(self):
         with self.assertRaises(TypeError):

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -182,6 +182,9 @@ class _FinalTypingBase(_TypingBase):
             return self
         raise TypeError("Cannot instantiate %r" % cls)
 
+    def __reduce__(self):
+        return _trim_name(type(self).__name__)
+
 
 class _ForwardRef(_TypingBase):
     """Wrapper to hold a forward reference."""
@@ -1139,6 +1142,11 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
         if not isinstance(instance, type):
             return issubclass(instance.__class__, self)
         return False
+
+    def __copy__(self):
+        return self.__class__(self.__name__, self.__bases__, dict(self.__dict__),
+                              self.__parameters__, self.__args__, self.__origin__,
+                              self.__extra__, self.__orig_bases__)
 
 
 # Prevent checks for Generic to crash when defining Generic.

--- a/src/typing.py
+++ b/src/typing.py
@@ -190,6 +190,9 @@ class _FinalTypingBase(_TypingBase, _root=True):
             return self
         raise TypeError("Cannot instantiate %r" % cls)
 
+    def __reduce__(self):
+        return _trim_name(type(self).__name__)
+
 
 class _ForwardRef(_TypingBase, _root=True):
     """Wrapper to hold a forward reference."""

--- a/src/typing.py
+++ b/src/typing.py
@@ -1054,6 +1054,11 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
         # classes are supposed to be rare anyways.
         return issubclass(instance.__class__, self)
 
+    def __copy__(self):
+        return self.__class__(self.__name__, self.__bases__, dict(self.__dict__),
+                              self.__parameters__, self.__args__, self.__origin__,
+                              self.__extra__, self.__orig_bases__)
+
 
 # Prevent checks for Generic to crash when defining Generic.
 Generic = None


### PR DESCRIPTION
Fixes #306 
@gvanrossum Here is the PR that I promised. I also improved pickling a bit, but as you could see from tests, the list of things that could be pickled is much shorter than list of those that can be copied/deepcopied (note that ``copy`` module in Python 3 treats classes as immutable, and therefore return the class unchanged)