### PR TITLE
Fix exception for invalid objects in get_type_hints

### DIFF
--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -1318,11 +1318,6 @@ gth = get_type_hints
 
 class GetTypeHintTests(BaseTestCase):
     def test_get_type_hints_from_various_objects(self):
-        # Should not fail for buil-in classes and functions.
-        self.assertEqual(gth(int), {})
-        self.assertEqual(gth(type), {})
-        self.assertEqual(gth(dir), {})
-        self.assertEqual(gth(len), {})
         # For invalid objects should fail with TypeError (not AttributeError etc).
         with self.assertRaises(TypeError):
             gth(123)

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -1317,6 +1317,20 @@ if PY36:
 gth = get_type_hints
 
 class GetTypeHintTests(BaseTestCase):
+    def test_get_type_hints_from_various_objects(self):
+        # Should not fail for buil-in classes and functions.
+        self.assertEqual(gth(int), {})
+        self.assertEqual(gth(type), {})
+        self.assertEqual(gth(dir), {})
+        self.assertEqual(gth(len), {})
+        # For invalid objects should fail with TypeError (not AttributeError etc).
+        with self.assertRaises(TypeError):
+            gth(123)
+        with self.assertRaises(TypeError):
+            gth('abc')
+        with self.assertRaises(TypeError):
+            gth(None)
+
     @skipUnless(PY36, 'Python 3.6 required')
     def test_get_type_hints_modules(self):
         self.assertEqual(gth(ann_module), {1: 2, 'f': Tuple[int, int], 'x': int, 'y': str})

--- a/src/typing.py
+++ b/src/typing.py
@@ -1476,7 +1476,7 @@ else:
         elif localns is None:
             localns = globalns
         defaults = _get_defaults(obj)
-        hints = obj.__annotations__
+        hints = dict(obj.__annotations__)
         for name, value in hints.items():
             if isinstance(value, str):
                 value = _ForwardRef(value)

--- a/src/typing.py
+++ b/src/typing.py
@@ -1332,11 +1332,7 @@ def cast(typ, val):
 
 def _get_defaults(func):
     """Internal helper to extract the default arguments, by name."""
-    try:
-        code = func.__code__
-    except AttributeError:
-        # Some built-in functions don't have __code__, __defaults__, etc.
-        return {}
+    code = func.__code__
     pos_count = code.co_argcount
     arg_names = code.co_varnames
     arg_names = arg_names[:pos_count]
@@ -1394,7 +1390,7 @@ if sys.version_info[:2] >= (3, 3):
             isinstance(obj, types.BuiltinFunctionType) or
             isinstance(obj, types.MethodType)):
             defaults = _get_defaults(obj)
-            hints = dict(getattr(obj, '__annotations__', {}))
+            hints = obj.__annotations__
             for name, value in hints.items():
                 if value is None:
                     value = type(None)
@@ -1480,7 +1476,7 @@ else:
         elif localns is None:
             localns = globalns
         defaults = _get_defaults(obj)
-        hints = dict(getattr(obj, '__annotations__', {}))
+        hints = obj.__annotations__
         for name, value in hints.items():
             if isinstance(value, str):
                 value = _ForwardRef(value)

--- a/src/typing.py
+++ b/src/typing.py
@@ -1460,13 +1460,6 @@ else:
         - If two dict arguments are passed, they specify globals and
           locals, respectively.
         """
-        if not (isinstance(obj, types.FunctionType) or
-                isinstance(obj, types.BuiltinFunctionType) or
-                isinstance(obj, types.MethodType) or
-                isinstance(obj, types.ModuleType) or
-                isinstance(obj, type)):
-            raise TypeError('{!r} is not a module, class, method, '
-                            'or function.'.format(obj))
         if getattr(obj, '__no_type_check__', None):
             return {}
         if globalns is None:
@@ -1475,6 +1468,13 @@ else:
                 localns = globalns
         elif localns is None:
             localns = globalns
+        if not (isinstance(obj, types.FunctionType) or
+                isinstance(obj, types.BuiltinFunctionType) or
+                isinstance(obj, types.MethodType) or
+                isinstance(obj, types.ModuleType) or
+                isinstance(obj, type)):
+            raise TypeError('{!r} is not a module, class, method, '
+                            'or function.'.format(obj))
         defaults = _get_defaults(obj)
         hints = dict(obj.__annotations__)
         for name, value in hints.items():


### PR DESCRIPTION
Fixes #313 
@gvanrossum I did this only in Python 3 since ``get_type_hints`` is not supported in Python 2.