### PR TITLE
Prohibit Callable[[...], X]

### DIFF
--- a/python2/test_typing.py
+++ b/python2/test_typing.py
@@ -375,6 +375,14 @@ class CallableTests(BaseTestCase):
         with self.assertRaises(TypeError):
             type(c)()
 
+    def test_callable_wrong_forms(self):
+        with self.assertRaises(TypeError):
+            Callable[(), int]
+        with self.assertRaises(TypeError):
+            Callable[[()], int]
+        with self.assertRaises(TypeError):
+            Callable[[int, 1], 2]
+
     def test_callable_instance_works(self):
         def f():
             pass

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -1304,7 +1304,7 @@ class CallableMeta(GenericMeta):
         if args is Ellipsis:
             parameters = (Ellipsis, result)
         else:
-            if not isinstance(args, list) or Ellipsis in args or () in args:
+            if not isinstance(args, list):
                 raise TypeError("Callable[args, result]: args must be a list."
                                 " Got %.100r." % (args,))
             parameters = tuple(args), result

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -1307,7 +1307,7 @@ class CallableMeta(GenericMeta):
             if not isinstance(args, list):
                 raise TypeError("Callable[args, result]: args must be a list."
                                 " Got %.100r." % (args,))
-            parameters = tuple(args), result
+            parameters = (tuple(args), result)
         return self.__getitem_inner__(parameters)
 
     @_tp_cache
@@ -1315,7 +1315,7 @@ class CallableMeta(GenericMeta):
         args, result = parameters
         msg = "Callable[args, result]: result must be a type."
         result = _type_check(result, msg)
-        if args == Ellipsis:
+        if args is Ellipsis:
             return super(CallableMeta, self).__getitem__((_TypingEllipsis, result))
         msg = "Callable[[arg, ...], result]: each arg must be a type."
         args = tuple(_type_check(arg, msg) for arg in args)

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -1308,9 +1308,9 @@ class CallableMeta(GenericMeta):
         elif args == []:
             parameters = ((), result)
         else:
-            if not isinstance(args, list):
-                raise TypeError("Callable[args, result]: args must be a list."
-                                " Got %.100r." % (args,))
+            if not isinstance(args, list) or Ellipsis in args or () in args:
+                raise TypeError("Callable[args, result]: args must be"
+                                " a list of types. Got %.100r." % (args,))
             parameters = tuple(args) + (result,)
         return self.__getitem_inner__(parameters)
 

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -1281,14 +1281,12 @@ class CallableMeta(GenericMeta):
         # super(CallableMeta, self)._tree_repr() for nice formatting.
         arg_list = []
         for arg in tree[1:]:
-            if arg == ():
-                arg_list.append('[]')
-            elif not isinstance(arg, tuple):
+            if not isinstance(arg, tuple):
                 arg_list.append(_type_repr(arg))
             else:
                 arg_list.append(arg[0]._tree_repr(arg))
-        if len(arg_list) == 2:
-            return repr(tree[0]) + '[%s]' % ', '.join(arg_list)
+        if arg_list[0] == '...':
+            return repr(tree[0]) + '[..., %s]' % arg_list[1]
         return (repr(tree[0]) +
                 '[[%s], %s]' % (', '.join(arg_list[:-1]), arg_list[-1]))
 
@@ -1305,25 +1303,20 @@ class CallableMeta(GenericMeta):
         args, result = parameters
         if args is Ellipsis:
             parameters = (Ellipsis, result)
-        elif args == []:
-            parameters = ((), result)
         else:
             if not isinstance(args, list) or Ellipsis in args or () in args:
-                raise TypeError("Callable[args, result]: args must be"
-                                " a list of types. Got %.100r." % (args,))
-            parameters = tuple(args) + (result,)
+                raise TypeError("Callable[args, result]: args must be a list."
+                                " Got %.100r." % (args,))
+            parameters = tuple(args), result
         return self.__getitem_inner__(parameters)
 
     @_tp_cache
     def __getitem_inner__(self, parameters):
-        args = parameters[:-1]
-        result = parameters[-1]
+        args, result = parameters
         msg = "Callable[args, result]: result must be a type."
         result = _type_check(result, msg)
-        if args == (Ellipsis,):
+        if args == Ellipsis:
             return super(CallableMeta, self).__getitem__((_TypingEllipsis, result))
-        if args == ((),):
-            return super(CallableMeta, self).__getitem__((_TypingEmpty, result))
         msg = "Callable[[arg, ...], result]: each arg must be a type."
         args = tuple(_type_check(arg, msg) for arg in args)
         parameters = args + (result,)

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -378,6 +378,16 @@ class CallableTests(BaseTestCase):
         with self.assertRaises(TypeError):
             type(c)()
 
+    def test_callable_wrong_forms(self):
+        with self.assertRaises(TypeError):
+            Callable[[...], int]
+        with self.assertRaises(TypeError):
+            Callable[(), int]
+        with self.assertRaises(TypeError):
+            Callable[[()], int]
+        with self.assertRaises(TypeError):
+            Callable[[int, 1], 2]
+
     def test_callable_instance_works(self):
         def f():
             pass

--- a/src/typing.py
+++ b/src/typing.py
@@ -1214,13 +1214,13 @@ class CallableMeta(GenericMeta):
             raise TypeError("Callable must be used as "
                             "Callable[[arg, ...], result].")
         args, result = parameters
-        if args is ...:
-            parameters = (..., result)
+        if args is Ellipsis:
+            parameters = (Ellipsis, result)
         else:
             if not isinstance(args, list):
                 raise TypeError("Callable[args, result]: args must be a list."
                                 " Got %.100r." % (args,))
-            parameters = tuple(args), result
+            parameters = (tuple(args), result)
         return self.__getitem_inner__(parameters)
 
     @_tp_cache
@@ -1228,7 +1228,7 @@ class CallableMeta(GenericMeta):
         args, result = parameters
         msg = "Callable[args, result]: result must be a type."
         result = _type_check(result, msg)
-        if args == ...:
+        if args is Ellipsis:
             return super().__getitem__((_TypingEllipsis, result))
         msg = "Callable[[arg, ...], result]: each arg must be a type."
         args = tuple(_type_check(arg, msg) for arg in args)

--- a/src/typing.py
+++ b/src/typing.py
@@ -1218,23 +1218,21 @@ class CallableMeta(GenericMeta):
         args, result = parameters
         if args is ...:
             parameters = (..., result)
-        elif args == []:
-            parameters = ((), result)
         else:
-            if not isinstance(args, list) or ... in args or () in args:
+            if not isinstance(args, list):
                 raise TypeError("Callable[args, result]: args must be"
                                 " a list of types. Got %.100r." % (args,))
-            parameters = tuple(args) + (result,)
+            parameters = tuple(args), result
         return self.__getitem_inner__(parameters)
 
     @_tp_cache
     def __getitem_inner__(self, parameters):
-        *args, result = parameters
+        args, result = parameters
         msg = "Callable[args, result]: result must be a type."
         result = _type_check(result, msg)
-        if args == [...,]:
+        if args == ...:
             return super().__getitem__((_TypingEllipsis, result))
-        if args == [(),]:
+        if args == ():
             return super().__getitem__((_TypingEmpty, result))
         msg = "Callable[[arg, ...], result]: each arg must be a type."
         args = tuple(_type_check(arg, msg) for arg in args)

--- a/src/typing.py
+++ b/src/typing.py
@@ -1221,9 +1221,9 @@ class CallableMeta(GenericMeta):
         elif args == []:
             parameters = ((), result)
         else:
-            if not isinstance(args, list):
-                raise TypeError("Callable[args, result]: args must be a list."
-                                " Got %.100r." % (args,))
+            if not isinstance(args, list) or ... in args or () in args:
+                raise TypeError("Callable[args, result]: args must be"
+                                " a list of types. Got %.100r." % (args,))
             parameters = tuple(args) + (result,)
         return self.__getitem_inner__(parameters)
 

--- a/src/typing.py
+++ b/src/typing.py
@@ -1194,14 +1194,12 @@ class CallableMeta(GenericMeta):
         # super()._tree_repr() for nice formatting.
         arg_list = []
         for arg in tree[1:]:
-            if arg == ():
-                arg_list.append('[]')
-            elif not isinstance(arg, tuple):
+            if not isinstance(arg, tuple):
                 arg_list.append(_type_repr(arg))
             else:
                 arg_list.append(arg[0]._tree_repr(arg))
-        if len(arg_list) == 2:
-            return repr(tree[0]) + '[%s]' % ', '.join(arg_list)
+        if arg_list[0] == '...':
+            return repr(tree[0]) + '[..., %s]' % arg_list[1]
         return (repr(tree[0]) +
                 '[[%s], %s]' % (', '.join(arg_list[:-1]), arg_list[-1]))
 
@@ -1220,8 +1218,8 @@ class CallableMeta(GenericMeta):
             parameters = (..., result)
         else:
             if not isinstance(args, list):
-                raise TypeError("Callable[args, result]: args must be"
-                                " a list of types. Got %.100r." % (args,))
+                raise TypeError("Callable[args, result]: args must be a list."
+                                " Got %.100r." % (args,))
             parameters = tuple(args), result
         return self.__getitem_inner__(parameters)
 
@@ -1232,8 +1230,6 @@ class CallableMeta(GenericMeta):
         result = _type_check(result, msg)
         if args == ...:
             return super().__getitem__((_TypingEllipsis, result))
-        if args == ():
-            return super().__getitem__((_TypingEmpty, result))
         msg = "Callable[[arg, ...], result]: each arg must be a type."
         args = tuple(_type_check(arg, msg) for arg in args)
         parameters = args + (result,)


### PR DESCRIPTION
@gvanrossum 
Now ``Callable[[...], X]`` is accepted and treated as equivalent to ``Callable[..., X]`` (also ``Callable[[()], X]`` is treated as equivalent to ``Callable[[], X]``). PEP 484 does not specify the former forms, so that this PR makes them prohibited.

I do not have any preference on this, so please feel free to either merge or close this.