### PR TITLE
Allow keyword syntax for NamedTuple

### DIFF
--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -1848,6 +1848,20 @@ class NamedTupleTests(BaseTestCase):
         self.assertEqual(CoolEmployee._fields, ('name', 'cool'))
         self.assertEqual(CoolEmployee._field_types, dict(name=str, cool=int))
 
+    @skipUnless(PY36, 'Python 3.6 required')
+    def test_namedtuple_keyword_usage(self):
+        LocalEmployee = NamedTuple("LocalEmployee", name=str, age=int)
+        nick = LocalEmployee('Nick', 25)
+        self.assertIsInstance(nick, tuple)
+        self.assertEqual(nick.name, 'Nick')
+        self.assertEqual(LocalEmployee.__name__, 'LocalEmployee')
+        self.assertEqual(LocalEmployee._fields, ('name', 'age'))
+        self.assertEqual(LocalEmployee._field_types, dict(name=str, age=int))
+        with self.assertRaises(TypeError):
+            NamedTuple('Name', [('x', int)], y=str)
+        with self.assertRaises(TypeError):
+            NamedTuple('Name', x=1, y='a')
+
     def test_pickle(self):
         global Emp  # pickle wants to reference the class by name
         Emp = NamedTuple('Emp', [('name', str), ('id', int)])

--- a/src/typing.py
+++ b/src/typing.py
@@ -1987,7 +1987,11 @@ if sys.version_info[:2] >= (3, 6):
         The resulting class has one extra attribute: _field_types,
         giving a dict mapping field names to types.  (The field names
         are in the _fields attribute, which is part of the namedtuple
-        API.) Backward-compatible usage::
+        API.) Alternative equivalent keyword syntax is also accepted::
+
+            Employee = NamedTuple('Employee', name=str, id=int)
+
+        Backward-compatible usage::
 
             Employee = NamedTuple('Employee', [('name', str), ('id', int)])
         """

--- a/src/typing.py
+++ b/src/typing.py
@@ -1951,6 +1951,8 @@ class Type(Generic[CT_co], extra=type):
 
 
 def _make_nmtuple(name, types):
+    msg = "NamedTuple('Name', [(f0, t0), (f1, t1), ...]); each t must be a type"
+    types = [(n, _type_check(t, msg)) for n, t in types]
     nm_tpl = collections.namedtuple(name, [n for n, t in types])
     nm_tpl._field_types = dict(types)
     try:
@@ -1990,7 +1992,12 @@ if sys.version_info[:2] >= (3, 6):
             Employee = NamedTuple('Employee', [('name', str), ('id', int)])
         """
 
-        def __new__(self, typename, fields):
+        def __new__(self, typename, fields=None, **kwargs):
+            if fields is None:
+                fields = kwargs.items()
+            elif kwargs:
+                raise TypeError("Either list of fields or keywords"
+                                " can be provided to NamedTuple, not both")
             return _make_nmtuple(typename, fields)
 else:
     def NamedTuple(typename, fields):
@@ -1998,7 +2005,7 @@ else:
 
         Usage::
 
-            Employee = typing.NamedTuple('Employee', [('name', str), 'id', int)])
+            Employee = typing.NamedTuple('Employee', [('name', str), ('id', int)])
 
         This is equivalent to::
 

--- a/src/typing.py
+++ b/src/typing.py
@@ -1991,7 +1991,8 @@ if sys.version_info[:2] >= (3, 6):
 
             Employee = NamedTuple('Employee', name=str, id=int)
 
-        Backward-compatible usage::
+        The above two forms are only supported in Python 3.6+, in other
+        versions use::
 
             Employee = NamedTuple('Employee', [('name', str), ('id', int)])
         """


### PR DESCRIPTION
Fixes #302 
@gvanrossum Here is a simple implementation for keyword syntax that you proposed:
```python
Employee = NamedTuple('Employee', name=str, id=int)
```
Note that this requires 3.6+ since order of kwargs should be preserved.