### PR TITLE
Runtime implementation of TypedDict

### DIFF
--- a/python2/test_typing.py
+++ b/python2/test_typing.py
@@ -1435,7 +1435,9 @@ class NewTypeTests(BaseTestCase):
 class TypedDictTests(BaseTestCase):
 
     def test_basics_fields_syntax(self):
+        # Check that two iterables allowed
         Emp = TypedDict('Emp', [('name', str), ('id', int)])
+        Emp = TypedDict('Emp', {'name': str, 'id': int})
         self.assertIsSubclass(Emp, dict)
         jim = Emp(name='Jim', id=1)
         self.assertIsInstance(jim, Emp)

--- a/python2/test_typing.py
+++ b/python2/test_typing.py
@@ -17,7 +17,7 @@ from typing import Generic, ClassVar
 from typing import cast
 from typing import Type
 from typing import NewType
-from typing import NamedTuple
+from typing import NamedTuple, TypedDict
 from typing import IO, TextIO, BinaryIO
 from typing import Pattern, Match
 import abc
@@ -1430,6 +1430,51 @@ class NewTypeTests(BaseTestCase):
         with self.assertRaises(TypeError):
             class D(UserName):
                 pass
+
+
+class TypedDictTests(BaseTestCase):
+
+    def test_basics_fields_syntax(self):
+        Emp = TypedDict('Emp', [('name', str), ('id', int)])
+        self.assertIsSubclass(Emp, dict)
+        jim = Emp(name='Jim', id=1)
+        self.assertIsInstance(jim, Emp)
+        self.assertIsInstance(jim, dict)
+        self.assertEqual(jim['name'], 'Jim')
+        self.assertEqual(jim['id'], 1)
+        self.assertEqual(Emp.__name__, 'Emp')
+        self.assertEqual(Emp.__bases__, (dict,))
+        self.assertEqual(Emp.__annotations__, {'name': str, 'id': int})
+
+    def test_basics_keywords_syntax(self):
+        Emp = TypedDict('Emp', name=str, id=int)
+        self.assertIsSubclass(Emp, dict)
+        jim = Emp(name='Jim', id=1)
+        self.assertIsInstance(jim, Emp)
+        self.assertIsInstance(jim, dict)
+        self.assertEqual(jim['name'], 'Jim')
+        self.assertEqual(jim['id'], 1)
+        self.assertEqual(Emp.__name__, 'Emp')
+        self.assertEqual(Emp.__bases__, (dict,))
+        self.assertEqual(Emp.__annotations__, {'name': str, 'id': int})
+
+    def test_typeddict_errors(self):
+        with self.assertRaises(TypeError):
+            TypedDict('Hi', x=1)
+        with self.assertRaises(TypeError):
+            TypedDict('Hi', [('x', int), ('y', 1)])
+        with self.assertRaises(TypeError):
+            TypedDict('Hi', [('x', int)], y=int)
+
+    def test_pickle(self):
+        global EmpD  # pickle wants to reference the class by name
+        EmpD = TypedDict('EmpD', name=str, id=int)
+        jane = EmpD({'name': 'jane', 'id': 37})
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            z = pickle.dumps(jane, proto)
+            jane2 = pickle.loads(z)
+            self.assertEqual(jane2, jane)
+            self.assertEqual(jane2, {'name': 'jane', 'id': 37})
 
 
 class NamedTupleTests(BaseTestCase):

--- a/python2/test_typing.py
+++ b/python2/test_typing.py
@@ -1461,6 +1461,11 @@ class TypedDictTests(BaseTestCase):
         self.assertEqual(Emp.__annotations__, {'name': str, 'id': int})
 
     def test_typeddict_errors(self):
+        Emp = TypedDict('Emp', {'name': str, 'id': int})
+        with self.assertRaises(TypeError):
+            isinstance({}, Emp)
+        with self.assertRaises(TypeError):
+            issubclass(dict, Emp)
         with self.assertRaises(TypeError):
             TypedDict('Hi', x=1)
         with self.assertRaises(TypeError):

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -57,6 +57,7 @@ __all__ = [
     'Set',
     'FrozenSet',
     'NamedTuple',  # Not really a type.
+    'TypedDict',
     'Generator',
 
     # One-off things.
@@ -1822,7 +1823,7 @@ class TypedDictMeta(type):
         except (AttributeError, ValueError):
             pass
         anns = ns.get('__annotations__', {})
-        msg = "TypedDict('Name', [(f0, t0), (f1, t1), ...]); each t must be a type"
+        msg = "TypedDict('Name', {f0: t0, f1: t1, ...}); each t must be a type"
         anns = {n: _type_check(tp, msg) for n, tp in anns.items()}
         for base in bases:
             anns.update(base.__dict__.get('__annotations__', {}))
@@ -1834,7 +1835,7 @@ class TypedDict(object):
     """A simple typed name space. At runtime it is equivalent to a plain dict.
     Usage::
 
-        Point2D = TypedDict('Point2D', [('x', int), ('y', int), ('label', str)])
+        Point2D = TypedDict('Point2D', {'x': int, 'y': int, 'label': str})
         assert Point2D(x=1, y=2, label='first') == dict(x=1, y=2, label='first')
 
     The type info could be accessed via Point2D.__annotations__. TypedDict supports

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -1813,6 +1813,46 @@ def NamedTuple(typename, fields):
     return cls
 
 
+class TypedDictMeta(type):
+
+    def __new__(cls, name, bases, ns):
+        tp_dict = super(TypedDictMeta, cls).__new__(cls, str(name), (dict,), ns)
+        try:
+            tp_dict.__module__ = sys._getframe(2).f_globals.get('__name__', '__main__')
+        except (AttributeError, ValueError):
+            pass
+        anns = ns.get('__annotations__', {})
+        msg = "TypedDict('Name', [(f0, t0), (f1, t1), ...]); each t must be a type"
+        anns = {n: _type_check(tp, msg) for n, tp in anns.items()}
+        for base in bases:
+            anns.update(base.__dict__.get('__annotations__', {}))
+        tp_dict.__annotations__ = anns
+        return tp_dict
+
+
+class TypedDict(object):
+    """A simple typed name space. At runtime it is equivalent to a plain dict.
+    Usage::
+
+        Point2D = TypedDict('Point2D', [('x', int), ('y', int), ('label', str)])
+        assert Point2D(x=1, y=2, label='first') == dict(x=1, y=2, label='first')
+
+    The type info could be accessed via Point2D.__annotations__. TypedDict supports
+    one additional equivalent form::
+
+        Point2D = TypedDict('Point2D', x=int, y=int, label=str)
+    """
+    __metaclass__ = TypedDictMeta
+
+    def __new__(cls, _typename, fields=None, **kwargs):
+        if fields is None:
+            fields = kwargs
+        elif kwargs:
+            raise TypeError("Either list of fields or keywords"
+                            " can be provided to TypedDict, not both")
+        return cls.__class__(_typename, (), {'__annotations__': dict(fields)})
+
+
 def NewType(name, tp):
     """NewType creates simple unique types with almost zero
     runtime overhead. NewType(name, tp) is considered a subtype of tp

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -1814,6 +1814,11 @@ def NamedTuple(typename, fields):
     return cls
 
 
+def _check_fails(cls, other):
+    if sys._getframe(1).f_globals['__name__'] not in ['abc', 'functools']:
+        raise TypeError('TypedDict does not support instance and class checks')
+
+
 class TypedDictMeta(type):
 
     def __new__(cls, name, bases, ns):
@@ -1829,6 +1834,8 @@ class TypedDictMeta(type):
             anns.update(base.__dict__.get('__annotations__', {}))
         tp_dict.__annotations__ = anns
         return tp_dict
+
+    __instancecheck__ = __subclasscheck__ = _check_fails
 
 
 class TypedDict(object):

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -1855,7 +1855,7 @@ class TypedDictTests(BaseTestCase):
         self.assertEqual(not_origin['x'], 0)
         self.assertEqual(not_origin['y'], 1)
         other = LabelPoint2D(x=0, y=1, label='hi')
-        self.assertEqual(not_origin['label'], 'hi')
+        self.assertEqual(other['label'], 'hi')
 
     def test_pickle(self):
         global EmpD  # pickle wants to reference the class by name

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -1815,8 +1815,10 @@ class NewTypeTests(BaseTestCase):
 
 class TypedDictTests(BaseTestCase):
 
-    def test_basics_fields_syntax(self):
+    def test_basics_iterable_syntax(self):
+        # Check that two iterables allowed
         Emp = TypedDict('Emp', [('name', str), ('id', int)])
+        Emp = TypedDict('Emp', {'name': str, 'id': int})
         self.assertIsSubclass(Emp, dict)
         jim = Emp(name='Jim', id=1)
         self.assertIsInstance(jim, Emp)

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -18,7 +18,7 @@ from typing import get_type_hints
 from typing import no_type_check, no_type_check_decorator
 from typing import Type
 from typing import NewType
-from typing import NamedTuple
+from typing import NamedTuple, TypedDict
 from typing import IO, TextIO, BinaryIO
 from typing import Pattern, Match
 import abc
@@ -1309,6 +1309,14 @@ class G(Generic[T]):
 class CoolEmployee(NamedTuple):
     name: str
     cool: int
+
+Label = TypedDict('Label', [('label', str)])
+
+class Point2D(TypedDict):
+    x: int
+    y: int
+
+class LabelPoint2D(Point2D, Label): ...
 """
 
 if PY36:
@@ -1803,6 +1811,60 @@ class NewTypeTests(BaseTestCase):
         with self.assertRaises(TypeError):
             class D(UserName):
                 pass
+
+
+class TypedDictTests(BaseTestCase):
+
+    def test_basics_fields_syntax(self):
+        Emp = TypedDict('Emp', [('name', str), ('id', int)])
+        self.assertIsSubclass(Emp, dict)
+        jim = Emp(name='Jim', id=1)
+        self.assertIsInstance(jim, Emp)
+        self.assertIsInstance(jim, dict)
+        self.assertEqual(jim['name'], 'Jim')
+        self.assertEqual(jim['id'], 1)
+        self.assertEqual(Emp.__name__, 'Emp')
+        self.assertEqual(Emp.__bases__, (dict,))
+        self.assertEqual(Emp.__annotations__, {'name': str, 'id': int})
+
+    def test_basics_keywords_syntax(self):
+        Emp = TypedDict('Emp', name=str, id=int)
+        self.assertIsSubclass(Emp, dict)
+        jim = Emp(name='Jim', id=1)
+        self.assertIsInstance(jim, Emp)
+        self.assertIsInstance(jim, dict)
+        self.assertEqual(jim['name'], 'Jim')
+        self.assertEqual(jim['id'], 1)
+        self.assertEqual(Emp.__name__, 'Emp')
+        self.assertEqual(Emp.__bases__, (dict,))
+        self.assertEqual(Emp.__annotations__, {'name': str, 'id': int})
+
+    def test_typeddict_errors(self):
+        with self.assertRaises(TypeError):
+            TypedDict('Hi', x=1)
+        with self.assertRaises(TypeError):
+            TypedDict('Hi', [('x', int), ('y', 1)])
+        with self.assertRaises(TypeError):
+            TypedDict('Hi', [('x', int)], y=int)
+
+    @skipUnless(PY36, 'Python 3.6 required')
+    def test_class_syntax_usage(self):
+        self.assertEqual(LabelPoint2D.__annotations__, {'x': int, 'y': int, 'label': str})
+        self.assertEqual(LabelPoint2D.__bases__, (dict,))
+        not_origin = Point2D(x=0, y=1)
+        self.assertEqual(not_origin['x'], 0)
+        self.assertEqual(not_origin['y'], 1)
+        other = LabelPoint2D(x=0, y=1, label='hi')
+        self.assertEqual(not_origin['label'], 'hi')
+
+    def test_pickle(self):
+        global EmpD  # pickle wants to reference the class by name
+        EmpD = TypedDict('EmpD', name=str, id=int)
+        jane = EmpD({'name': 'jane', 'id': 37})
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            z = pickle.dumps(jane, proto)
+            jane2 = pickle.loads(z)
+            self.assertEqual(jane2, jane)
 
 
 class NamedTupleTests(BaseTestCase):

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -1865,7 +1865,7 @@ class TypedDictTests(BaseTestCase):
             z = pickle.dumps(jane, proto)
             jane2 = pickle.loads(z)
             self.assertEqual(jane2, jane)
-
+            self.assertEqual(jane2, {'name': 'jane', 'id': 37})
 
 class NamedTupleTests(BaseTestCase):
 

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -1842,6 +1842,11 @@ class TypedDictTests(BaseTestCase):
         self.assertEqual(Emp.__annotations__, {'name': str, 'id': int})
 
     def test_typeddict_errors(self):
+        Emp = TypedDict('Emp', {'name': str, 'id': int})
+        with self.assertRaises(TypeError):
+            isinstance({}, Emp)
+        with self.assertRaises(TypeError):
+            issubclass(dict, Emp)
         with self.assertRaises(TypeError):
             TypedDict('Hi', x=1)
         with self.assertRaises(TypeError):

--- a/src/typing.py
+++ b/src/typing.py
@@ -2002,6 +2002,11 @@ else:
         return _make_nmtuple(typename, fields)
 
 
+def _check_fails(cls, other):
+    if sys._getframe(1).f_globals['__name__'] not in ['abc', 'functools']:
+        raise TypeError('TypedDict does not support instance and class checks')
+
+
 class TypedDictMeta(type):
 
     def __new__(cls, name, bases, ns):
@@ -2017,6 +2022,8 @@ class TypedDictMeta(type):
             anns.update(base.__dict__.get('__annotations__', {}))
         tp_dict.__annotations__ = anns
         return tp_dict
+
+    __instancecheck__ = __subclasscheck__ = _check_fails
 
 
 class TypedDict(metaclass=TypedDictMeta):

--- a/src/typing.py
+++ b/src/typing.py
@@ -2005,8 +2005,6 @@ else:
 class TypedDictMeta(type):
 
     def __new__(cls, name, bases, ns):
-        if ns.get('_root', False):
-            return super().__new__(cls, name, bases, ns)
         tp_dict = super().__new__(cls, name, (dict,), ns)
         try:
             tp_dict.__module__ = sys._getframe(2).f_globals.get('__name__', '__main__')
@@ -2029,7 +2027,7 @@ class TypedDict(metaclass=TypedDictMeta):
         assert Point2D(x=1, y=2, label='first') == dict(x=1, y=2, label='first')
 
     The type info could be accessed via Point2D.__annotations__. TypedDict supports
-    two equivalent forms::
+    two additional equivalent forms::
 
         Point2D = TypedDict('Point2D', x=int, y=int, label=str)
 
@@ -2040,7 +2038,6 @@ class TypedDict(metaclass=TypedDictMeta):
 
     The latter syntax is only supported in Python 3.6+
     """
-    _root = True
 
     def __new__(cls, _typename, fields=None, **kwargs):
         if fields is None:

--- a/src/typing.py
+++ b/src/typing.py
@@ -2011,7 +2011,7 @@ class TypedDictMeta(type):
         except (AttributeError, ValueError):
             pass
         anns = ns.get('__annotations__', {})
-        msg = "TypedDict('Name', [(f0, t0), (f1, t1), ...]); each t must be a type"
+        msg = "TypedDict('Name', {f0: t0, f1: t1, ...}); each t must be a type"
         anns = {n: _type_check(tp, msg) for n, tp in anns.items()}
         for base in bases:
             anns.update(base.__dict__.get('__annotations__', {}))
@@ -2023,7 +2023,7 @@ class TypedDict(metaclass=TypedDictMeta):
     """A simple typed name space. At runtime it is equivalent to a plain dict.
     Usage::
 
-        Point2D = TypedDict('Point2D', [('x', int), ('y', int), ('label', str)])
+        Point2D = TypedDict('Point2D', {'x': int, 'y': int, 'label': str})
         assert Point2D(x=1, y=2, label='first') == dict(x=1, y=2, label='first')
 
     The type info could be accessed via Point2D.__annotations__. TypedDict supports

--- a/src/typing.py
+++ b/src/typing.py
@@ -2001,6 +2001,20 @@ else:
         return _make_nmtuple(typename, fields)
 
 
+class TypedDictMeta(type):
+    def __new__(cls, typename, bases, ns):
+        if ns.get('_root') is True:
+            del ns['_root']
+            return super().__new__(cls, typename, bases, ns)
+        return make_typed_dict
+
+
+class TypedDict(metaclass=TypedDictMeta):
+    _root = True
+    def __new__(cls, *args, **kwargs):
+        return dict(*args, **kwargs)
+
+
 def NewType(name, tp):
     """NewType creates simple unique types with almost zero
     runtime overhead. NewType(name, tp) is considered a subtype of tp


### PR DESCRIPTION
Fixes #28 

@gvanrossum I think it is time to consider the runtime implementation of ``TypedDict`` (mypy counterpart seems to be ready soon). Here is a simple (but quite flexible) implementation that supports three forms (iterable, keywords, class for 3.6+). In all forms type info for runtime introspection is accessible via ``__annotations__``, multiple inheritance is supported. Some examples:
```python
class Point1D(TypedDict):
    x: float
class Point2D(Point1D):
    y: float

Grid2D = TypedDict('Grid2D', [('x', int), ('y', int)])
Grid3D = TypedDict('Grid3D', {'x': int, 'y': int, 'z': int})
Info = TypedDict('Info', color=str, size=int)

class CoolPoint2D(Point2D, Info):
    pass

assert Point2D(x=1, y=2) == dict(x=1, y=2)
assert CoolPoint2D.__bases__ == (dict,)
assert CoolPoint2D.__annotations__ == {'x': float, 'y': float, 'size': int, 'color': str}
```
Everything is implemented to be ``pickle``able and fast. I have measured and ``Point2D(x=1, y=2)`` is slower that ``dict(x=1, y=2)`` by only 3% to 11% depending on Python version.

Please, don't be scared by the size of diff. more than half of it is tests and implementations for Python 2 and Python 3 are identical.