### PR TITLE
Re-evaluate forward references if non-trivial localns is given

### DIFF
--- a/python2/typing.py
+++ b/python2/typing.py
@@ -214,7 +214,7 @@ class _ForwardRef(_TypingBase):
         self.__forward_frame__ = frame
 
     def _eval_type(self, globalns, localns):
-        if not self.__forward_evaluated__:
+        if not self.__forward_evaluated__ or localns is not globalns:
             if globalns is None and localns is None:
                 globalns = localns = {}
             elif globalns is None:

--- a/src/typing.py
+++ b/src/typing.py
@@ -225,7 +225,7 @@ class _ForwardRef(_TypingBase, _root=True):
         self.__forward_frame__ = frame
 
     def _eval_type(self, globalns, localns):
-        if not self.__forward_evaluated__:
+        if not self.__forward_evaluated__ or localns is not globalns:
             if globalns is None and localns is None:
                 globalns = localns = {}
             elif globalns is None:


### PR DESCRIPTION
@gvanrossum This fixes problems with forward references to locally defined classes. In particular this avoids test failures in refleak hunting mode.