### PR TITLE
Improve some tests using assertIs

### DIFF
--- a/python2/test_typing.py
+++ b/python2/test_typing.py
@@ -777,6 +777,7 @@ class GenericTests(BaseTestCase):
 
     def test_type_erasure_special(self):
         T = TypeVar('T')
+        # this is the only test that checks type caching
         self.clear_caches()
         class MyTup(Tuple[T, T]): pass
         self.assertIs(MyTup[int]().__class__, MyTup)

--- a/python2/test_typing.py
+++ b/python2/test_typing.py
@@ -44,6 +44,10 @@ class BaseTestCase(TestCase):
                 message += ' : %s' % msg
             raise self.failureException(message)
 
+    def clear_caches(self):
+        for f in typing._cleanups:
+            f()
+
 
 class Employee(object):
     pass
@@ -719,8 +723,10 @@ class GenericTests(BaseTestCase):
         class CC: pass
         self.assertEqual(typing._eval_type(LLT, globals(), locals()), List[List[CC]])
         T = TypeVar('T')
-        TTE = Tuple[T, ...]
-        self.assertIs(typing._eval_type(TTE, globals(), locals()), Tuple[T, ...])
+        AT = Tuple[T, ...]
+        self.assertIs(typing._eval_type(AT, globals(), locals()), AT)
+        CT = Callable[..., List[T]]
+        self.assertIs(typing._eval_type(CT, globals(), locals()), CT)
 
     def test_extended_generic_rules_subclassing(self):
         class T1(Tuple[T, KT]): pass
@@ -771,6 +777,7 @@ class GenericTests(BaseTestCase):
 
     def test_type_erasure_special(self):
         T = TypeVar('T')
+        self.clear_caches()
         class MyTup(Tuple[T, T]): pass
         self.assertIs(MyTup[int]().__class__, MyTup)
         self.assertIs(MyTup[int]().__orig_class__, MyTup[int])

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -808,6 +808,7 @@ class GenericTests(BaseTestCase):
 
     def test_type_erasure_special(self):
         T = TypeVar('T')
+        # this is the only test that checks type caching
         self.clear_caches()
         class MyTup(Tuple[T, T]): ...
         self.assertIs(MyTup[int]().__class__, MyTup)

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -45,6 +45,10 @@ class BaseTestCase(TestCase):
                 message += ' : %s' % msg
             raise self.failureException(message)
 
+    def clear_caches(self):
+        for f in typing._cleanups:
+            f()
+
 
 class Employee:
     pass
@@ -748,8 +752,12 @@ class GenericTests(BaseTestCase):
         class CC: ...
         self.assertEqual(get_type_hints(foobar, globals(), locals()), {'x': List[List[CC]]})
         T = TypeVar('T')
-        def barfoo(x: Tuple[T, ...]): ...
-        self.assertIs(get_type_hints(barfoo, globals(), locals())['x'], Tuple[T, ...])
+        AT = Tuple[T, ...]
+        def barfoo(x: AT): ...
+        self.assertIs(get_type_hints(barfoo, globals(), locals())['x'], AT)
+        CT = Callable[..., List[T]]
+        def barfoo2(x: CT): ...
+        self.assertIs(get_type_hints(barfoo2, globals(), locals())['x'], CT)
 
     def test_extended_generic_rules_subclassing(self):
         class T1(Tuple[T, KT]): ...
@@ -800,6 +808,7 @@ class GenericTests(BaseTestCase):
 
     def test_type_erasure_special(self):
         T = TypeVar('T')
+        self.clear_caches()
         class MyTup(Tuple[T, T]): ...
         self.assertIs(MyTup[int]().__class__, MyTup)
         self.assertIs(MyTup[int]().__orig_class__, MyTup[int])


### PR DESCRIPTION
There are several tests that use ``asertIs`` (not ``assertEqual``). It turns out that two of them explicitly depend on caching. To avoid possible (although highly unlikely) failures due to cache invalidation, I modified one of them to use a type alias (also extended it), and second one to clear caches at the start of this particular test (also added a comment).

@gvanrossum Please, take a look.

(I will make another PR extending some docstrings soon)