### PR TITLE
Fix isinstance() for Protocols

### DIFF
--- a/python2/test_typing.py
+++ b/python2/test_typing.py
@@ -480,7 +480,13 @@ class ProtocolTests(BaseTestCase):
     def test_protocol_instance_type_error(self):
         with self.assertRaises(TypeError):
             isinstance(0, typing.SupportsAbs)
-
+        class C1(typing.SupportsInt):
+            def __int__(self):
+                return 42
+        class C2(C1):
+            pass
+        c = C2()
+        self.assertIsInstance(c, C1)
 
 class GenericTests(BaseTestCase):
 

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -1462,6 +1462,8 @@ class _ProtocolMeta(GenericMeta):
     """
 
     def __instancecheck__(self, obj):
+        if _Protocol not in self.__bases__:
+            return super(_ProtocolMeta, self).__instancecheck__(obj)
         raise TypeError("Protocols cannot be used with isinstance().")
 
     def __subclasscheck__(self, cls):

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -509,6 +509,13 @@ class ProtocolTests(BaseTestCase):
     def test_protocol_instance_type_error(self):
         with self.assertRaises(TypeError):
             isinstance(0, typing.SupportsAbs)
+        class C1(typing.SupportsInt):
+            def __int__(self) -> int:
+                return 42
+        class C2(C1):
+            pass
+        c = C2()
+        self.assertIsInstance(c, C1)
 
 
 class GenericTests(BaseTestCase):

--- a/src/typing.py
+++ b/src/typing.py
@@ -1503,6 +1503,8 @@ class _ProtocolMeta(GenericMeta):
     """
 
     def __instancecheck__(self, obj):
+        if _Protocol not in self.__bases__:
+            return super().__instancecheck__(obj)
         raise TypeError("Protocols cannot be used with isinstance().")
 
     def __subclasscheck__(self, cls):


### PR DESCRIPTION
Fixes #297 

This allows to use ``isinstance()`` with classes that inherit from protocols in ``typing.py`` such as ``SupportsInt`` etc.

@gvanrossum I was thinking about how protocols should work (including runtime), and now I think that the "quick-fix" that you proposed is actually the right fix for this issue. (Main motivation is that a class that inherits from a protocol should not be considered a protocol itself, unless it lists ``Protocol`` in bases.)

Please, take a look.