### PR TITLE
Clear class variables created from __slots__

### DIFF
--- a/python2/test_typing.py
+++ b/python2/test_typing.py
@@ -866,6 +866,8 @@ class GenericTests(BaseTestCase):
             c_int.tomato = 0
 
         self.assertEqual(typing._eval_type(C['C'], globals(), locals()), C[C])
+        self.assertEqual(typing._eval_type(C['C'], globals(), locals()).__slots__,
+                         C.__slots__)
         self.assertEqual(copy(C[int]), deepcopy(C[int]))
 
     def test_errors(self):

--- a/python2/test_typing.py
+++ b/python2/test_typing.py
@@ -870,6 +870,22 @@ class GenericTests(BaseTestCase):
                          C.__slots__)
         self.assertEqual(copy(C[int]), deepcopy(C[int]))
 
+    def test_parameterized_slots_dict(self):
+        T = TypeVar('T')
+        class D(Generic[T]):
+            __slots__ = {'banana': 42}
+
+        d = D()
+        d_int = D[int]()
+        self.assertEqual(D.__slots__, D[str].__slots__)
+
+        d.banana = 'yes'
+        d_int.banana = 'yes'
+        with self.assertRaises(AttributeError):
+            d.foobar = 'no'
+        with self.assertRaises(AttributeError):
+            d_int.foobar = 'no'
+
     def test_errors(self):
         with self.assertRaises(TypeError):
             B = SimpleMapping[XK, Any]

--- a/python2/test_typing.py
+++ b/python2/test_typing.py
@@ -849,6 +849,22 @@ class GenericTests(BaseTestCase):
             self.assertEqual(t, deepcopy(t))
             self.assertEqual(t, copy(t))
 
+    def test_parameterized_slots(self):
+        T = TypeVar('T')
+        class C(Generic[T]):
+            __slots__ = ('potato',)
+
+        c = C()
+        c_int = C[int]()
+        self.assertEqual(C.__slots__, C[str].__slots__)
+
+        c.potato = 0
+        c_int.potato = 0
+        with self.assertRaises(AttributeError):
+            c.tomato = 0
+        with self.assertRaises(AttributeError):
+            c_int.tomato = 0
+
     def test_errors(self):
         with self.assertRaises(TypeError):
             B = SimpleMapping[XK, Any]

--- a/python2/test_typing.py
+++ b/python2/test_typing.py
@@ -865,6 +865,9 @@ class GenericTests(BaseTestCase):
         with self.assertRaises(AttributeError):
             c_int.tomato = 0
 
+        self.assertEqual(typing._eval_type(C['C'], globals(), locals()), C[C])
+        self.assertEqual(copy(C[int]), deepcopy(C[int]))
+
     def test_errors(self):
         with self.assertRaises(TypeError):
             B = SimpleMapping[XK, Any]

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -918,6 +918,22 @@ class GenericTests(BaseTestCase):
                          C.__slots__)
         self.assertEqual(copy(C[int]), deepcopy(C[int]))
 
+    def test_parameterized_slots_dict(self):
+        T = TypeVar('T')
+        class D(Generic[T]):
+            __slots__ = {'banana': 42}
+
+        d = D()
+        d_int = D[int]()
+        self.assertEqual(D.__slots__, D[str].__slots__)
+
+        d.banana = 'yes'
+        d_int.banana = 'yes'
+        with self.assertRaises(AttributeError):
+            d.foobar = 'no'
+        with self.assertRaises(AttributeError):
+            d_int.foobar = 'no'
+
     def test_errors(self):
         with self.assertRaises(TypeError):
             B = SimpleMapping[XK, Any]

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -912,6 +912,10 @@ class GenericTests(BaseTestCase):
         with self.assertRaises(AttributeError):
             c_int.tomato = 0
 
+        def foo(x: C['C']): ...
+        self.assertEqual(get_type_hints(foo, globals(), locals())['x'], C[C])
+        self.assertEqual(copy(C[int]), deepcopy(C[int]))
+
     def test_errors(self):
         with self.assertRaises(TypeError):
             B = SimpleMapping[XK, Any]

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -896,6 +896,22 @@ class GenericTests(BaseTestCase):
             self.assertEqual(t, copy(t))
             self.assertEqual(t, deepcopy(t))
 
+    def test_parameterized_slots(self):
+        T = TypeVar('T')
+        class C(Generic[T]):
+            __slots__ = ('potato',)
+
+        c = C()
+        c_int = C[int]()
+        self.assertEqual(C.__slots__, C[str].__slots__)
+
+        c.potato = 0
+        c_int.potato = 0
+        with self.assertRaises(AttributeError):
+            c.tomato = 0
+        with self.assertRaises(AttributeError):
+            c_int.tomato = 0
+
     def test_errors(self):
         with self.assertRaises(TypeError):
             B = SimpleMapping[XK, Any]

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -914,6 +914,8 @@ class GenericTests(BaseTestCase):
 
         def foo(x: C['C']): ...
         self.assertEqual(get_type_hints(foo, globals(), locals())['x'], C[C])
+        self.assertEqual(get_type_hints(foo, globals(), locals())['x'].__slots__,
+                         C.__slots__)
         self.assertEqual(copy(C[int]), deepcopy(C[int]))
 
     def test_errors(self):

--- a/src/typing.py
+++ b/src/typing.py
@@ -870,7 +870,7 @@ def _make_subclasshook(cls):
     return __extrahook__
 
 
-def _safe_copy(dct):
+def _no_slots_copy(dct):
     """Internal helper: copy class __dict__ and clean slots class variables.
     (They will be re-created if necessary by normal class machinery.)
     """
@@ -978,7 +978,7 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
             return self
         return self.__class__(self.__name__,
                               self.__bases__,
-                              _safe_copy(self.__dict__),
+                              _no_slots_copy(self.__dict__),
                               tvars=_type_vars(ev_args) if ev_args else None,
                               args=ev_args,
                               origin=ev_origin,
@@ -1054,7 +1054,7 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
             args = params
         return self.__class__(self.__name__,
                               self.__bases__,
-                              _safe_copy(self.__dict__),
+                              _no_slots_copy(self.__dict__),
                               tvars=tvars,
                               args=args,
                               origin=self,
@@ -1071,7 +1071,7 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
 
     def __copy__(self):
         return self.__class__(self.__name__, self.__bases__,
-                              _safe_copy(self.__dict__),
+                              _no_slots_copy(self.__dict__),
                               self.__parameters__, self.__args__, self.__origin__,
                               self.__extra__, self.__orig_bases__)
 

--- a/src/typing.py
+++ b/src/typing.py
@@ -1041,9 +1041,14 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
             _check_generic(self, params)
             tvars = _type_vars(params)
             args = params
+        dict_copy = dict(self.__dict__)
+        if '__slots__' in dict_copy:
+            # Let usual class machinery re-create slots to avoid conflicts.
+            for slot in dict_copy['__slots__']:
+                dict_copy.pop(slot, None)
         return self.__class__(self.__name__,
                               self.__bases__,
-                              dict(self.__dict__),
+                              dict_copy,
                               tvars=tvars,
                               args=args,
                               origin=self,


### PR DESCRIPTION
Fixes #332 

The class variables created from slots are now cleared before copying generic class ``__dict__`` on subscription, copying, and evaluation. This is necessary only for Python 3, but I added tests for both 3 and 2.

@gvanrossum Please, take a look.