### PR TITLE
Add type for WSGI Applications in typing

### DIFF
--- a/python2/test_typing.py
+++ b/python2/test_typing.py
@@ -1588,6 +1588,13 @@ class RETests(BaseTestCase):
                          "Cannot subclass typing._TypeAlias")
 
 
+class WSGIApplicationTests(BaseTestCase):
+
+    def test_wsgi_application(self):
+        from typing import Callable, WSGIApplication
+        self.assertIsSubclass(WSGIApplication, Callable)
+
+
 class AllTests(BaseTestCase):
     """Tests for __all__."""
 

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -69,6 +69,7 @@ __all__ = [
     'overload',
     'Text',
     'TYPE_CHECKING',
+    'WSGIApplication',
 ]
 
 # The pseudo-submodules 're' and 'io' are part of the public
@@ -2003,6 +2004,19 @@ Pattern = _TypeAlias('Pattern', AnyStr, type(stdlib_re.compile('')),
                      lambda p: p.pattern)
 Match = _TypeAlias('Match', AnyStr, type(stdlib_re.match('', '')),
                    lambda m: m.re.pattern)
+
+
+exc_info = Tuple[Optional[Type[BaseException]],
+                 Optional[BaseException],
+                 Optional[types.TracebackType]]
+
+WSGIApplication = Callable[
+    [Dict[str, str],
+     Union[Callable[[Text, List[Tuple[Text, Text]]],
+                    Callable[[Union[bytes, str, unicode]], None]],
+           Callable[[Text, List[Tuple[str, str, unicode]], exc_info],
+                    Callable[[Union[bytes, str, unicode]], None]]]
+     ], Iterable[Union[bytes, str, unicode]]]
 
 
 class re(object):

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -2037,6 +2037,13 @@ class RETests(BaseTestCase):
                          "Cannot subclass typing._TypeAlias")
 
 
+class WSGIApplicationTests(BaseTestCase):
+
+    def test_wsgi_application(self):
+        from typing import Callable, WSGIApplication
+        self.assertIsSubclass(WSGIApplication, Callable)
+
+
 class AllTests(BaseTestCase):
     """Tests for __all__."""
 

--- a/src/typing.py
+++ b/src/typing.py
@@ -77,6 +77,7 @@ __all__ = [
     'overload',
     'Text',
     'TYPE_CHECKING',
+    'WSGIApplication',
 ]
 
 # The pseudo-submodules 're' and 'io' are part of the public
@@ -2147,6 +2148,19 @@ Pattern = _TypeAlias('Pattern', AnyStr, type(stdlib_re.compile('')),
                      lambda p: p.pattern)
 Match = _TypeAlias('Match', AnyStr, type(stdlib_re.match('', '')),
                    lambda m: m.re.pattern)
+
+
+exc_info = Tuple[Optional[Type[BaseException]],
+                 Optional[BaseException],
+                 Optional[types.TracebackType]]
+
+WSGIApplication = Callable[
+    [Dict[str, str],
+     Union[Callable[[Text, List[Tuple[Text, Text]]],
+                    Callable[[Union[bytes, str]], None]],
+           Callable[[Text, List[Tuple[str, str]], exc_info],
+                    Callable[[Union[bytes, str]], None]]]
+     ], Iterable[Union[bytes, str]]]
 
 
 class re:


### PR DESCRIPTION
I'm working on adding stubs for Flask, and WSGI Applications are one of the types that
get frequently passed around.  This seems pretty core to Python itself so it seems
to make sense to add to `typing` itself.