### PR TITLE
add AsyncGenerator

### DIFF
--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -1344,7 +1344,6 @@ class OverloadTests(BaseTestCase):
 
 
 ASYNCIO = sys.version_info[:2] >= (3, 5)
-ASYNC_GENERATOR = sys.version_info[:2] >= (3, 6)
 
 ASYNCIO_TESTS = """
 import asyncio

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -1820,7 +1820,12 @@ class CollectionsAbcTests(BaseTestCase):
 
     @skipUnless(PY36, 'Python 3.6 required')
     def test_subclassing_async_generator(self):
-        class G(typing.AsyncGenerator[int, int]): ...
+        class G(typing.AsyncGenerator[int, int]):
+            def asend(self, value):
+                pass
+            def athrow(self, typ, val=None, tb=None):
+                pass
+
         ns = {}
         exec('async def g(): yield 0', globals(), ns)
         g = ns['g']
@@ -1829,6 +1834,13 @@ class CollectionsAbcTests(BaseTestCase):
         self.assertIsSubclass(G, collections.AsyncGenerator)
         self.assertIsSubclass(G, collections.AsyncIterable)
         self.assertNotIsSubclass(type(g), G)
+
+        instance = G()
+        self.assertIsInstance(instance, typing.AsyncGenerator)
+        self.assertIsInstance(instance, typing.AsyncIterable)
+        self.assertIsInstance(instance, collections.AsyncGenerator)
+        self.assertIsInstance(instance, collections.AsyncIterable)
+        self.assertNotIsInstance(type(g), G)
 
     def test_subclassing_subclasshook(self):
 

--- a/src/typing.py
+++ b/src/typing.py
@@ -51,7 +51,8 @@ __all__ = [
     # AsyncIterable,
     # Coroutine,
     # Collection,
-    # ContextManager
+    # ContextManager,
+    # AsyncGenerator,
 
     # Structural checks, a.k.a. protocols.
     'Reversible',
@@ -1899,6 +1900,21 @@ class Generator(Iterator[T_co], Generic[T_co, T_contra, V_co],
             raise TypeError("Type Generator cannot be instantiated; "
                             "create a subclass instead")
         return _generic_new(_G_base, cls, *args, **kwds)
+
+if hasattr(collections_abc, 'AsyncGenerator'):
+    _AG_base = collections_abc.AsyncGenerator
+
+    class AsyncGenerator(AsyncIterator[T_co], Generic[T_co, T_contra],
+                         extra=_AG_base):
+        __slots__ = ()
+
+        def __new__(cls, *args, **kwds):
+            if _geqv(cls, AsyncGenerator):
+                raise TypeError("Type AsyncGenerator cannot be instantiated; "
+                                "create a subclass instead")
+            return _generic_new(_AG_base, cls, *args, **kwds)
+
+    __all__.append('AsyncGenerator')
 
 
 # Internal type variable used for Type[].

--- a/src/typing.py
+++ b/src/typing.py
@@ -1908,12 +1908,6 @@ if hasattr(collections_abc, 'AsyncGenerator'):
                          extra=_AG_base):
         __slots__ = ()
 
-        def __new__(cls, *args, **kwds):
-            if _geqv(cls, AsyncGenerator):
-                raise TypeError("Type AsyncGenerator cannot be instantiated; "
-                                "create a subclass instead")
-            return _generic_new(_AG_base, cls, *args, **kwds)
-
     __all__.append('AsyncGenerator')
 
 


### PR DESCRIPTION
Looks like this was inadvertently omitted from 3.6 as released.

Should I submit a separate patch to CPython directly to add documentation?