### PR TITLE
Enable weak references to typing types

### DIFF
--- a/python2/test_typing.py
+++ b/python2/test_typing.py
@@ -22,6 +22,7 @@ from typing import IO, TextIO, BinaryIO
 from typing import Pattern, Match
 import abc
 import typing
+import weakref
 try:
     import collections.abc as collections_abc
 except ImportError:
@@ -848,6 +849,14 @@ class GenericTests(BaseTestCase):
         for t in things:
             self.assertEqual(t, deepcopy(t))
             self.assertEqual(t, copy(t))
+
+    def test_weakref_all(self):
+        T = TypeVar('T')
+        things = [Any, Union[T, int], Callable[..., T], Tuple[Any, Any],
+                  Optional[List[int]], typing.Mapping[int, str],
+                  typing.re.Match[bytes], typing.Iterable['whatever']]
+        for t in things:
+            self.assertEqual(weakref.ref(t)(), t)
 
     def test_parameterized_slots(self):
         T = TypeVar('T')

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -134,7 +134,7 @@ class TypingMeta(type):
 class _TypingBase(object):
     """Internal indicator of special typing constructs."""
     __metaclass__ = TypingMeta
-    __slots__ = ()
+    __slots__ = ('__weakref__',)
 
     def __init__(self, *args, **kwds):
         pass

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -23,6 +23,7 @@ from typing import IO, TextIO, BinaryIO
 from typing import Pattern, Match
 import abc
 import typing
+import weakref
 try:
     import collections.abc as collections_abc
 except ImportError:
@@ -895,6 +896,14 @@ class GenericTests(BaseTestCase):
         for t in things + [Any]:
             self.assertEqual(t, copy(t))
             self.assertEqual(t, deepcopy(t))
+
+    def test_weakref_all(self):
+        T = TypeVar('T')
+        things = [Any, Union[T, int], Callable[..., T], Tuple[Any, Any],
+                  Optional[List[int]], typing.Mapping[int, str],
+                  typing.re.Match[bytes], typing.Iterable['whatever']]
+        for t in things:
+            self.assertEqual(weakref.ref(t)(), t)
 
     def test_parameterized_slots(self):
         T = TypeVar('T')

--- a/src/typing.py
+++ b/src/typing.py
@@ -144,7 +144,7 @@ class TypingMeta(type):
 class _TypingBase(metaclass=TypingMeta, _root=True):
     """Internal indicator of special typing constructs."""
 
-    __slots__ = ()
+    __slots__ = ('__weakref__',)
 
     def __init__(self, *args, **kwds):
         pass


### PR DESCRIPTION
Fixes #345 

This is a simple fix adding ``__weakref__`` to ``__slots__`` in ``_TypingBase`` (+ test with a random selection of types).