### PR TITLE
Allow GenericMeta as a parameter for generics

### DIFF
--- a/python2/test_typing.py
+++ b/python2/test_typing.py
@@ -13,7 +13,7 @@ from typing import T, KT, VT  # Not in __all__.
 from typing import Union, Optional
 from typing import Tuple, List, MutableMapping
 from typing import Callable
-from typing import Generic, ClassVar
+from typing import Generic, ClassVar, GenericMeta
 from typing import cast
 from typing import Type
 from typing import NewType
@@ -687,6 +687,12 @@ class GenericTests(BaseTestCase):
         self.assertEqual(D.__bases__, (C, List))
         self.assertEqual(C.__orig_bases__, (List[T][U][V],))
         self.assertEqual(D.__orig_bases__, (C, List[T][U][V]))
+
+    def test_subscript_meta(self):
+        T = TypeVar('T')
+        self.assertEqual(Type[GenericMeta], Type[GenericMeta])
+        self.assertEqual(Union[T, int][GenericMeta], Union[GenericMeta, int])
+        self.assertEqual(Callable[..., GenericMeta].__args__, (Ellipsis, GenericMeta))
 
     def test_extended_generic_rules_eq(self):
         T = TypeVar('T')

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -568,7 +568,7 @@ def _replace_arg(arg, tvars, args):
 
     if tvars is None:
         tvars = []
-    if hasattr(arg, '_subs_tree'):
+    if hasattr(arg, '_subs_tree') and isinstance(arg, (GenericMeta, _TypingBase)):
         return arg._subs_tree(tvars, args)
     if isinstance(arg, TypeVar):
         for i, tvar in enumerate(tvars):

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -12,7 +12,7 @@ from typing import T, KT, VT  # Not in __all__.
 from typing import Union, Optional
 from typing import Tuple, List, MutableMapping
 from typing import Callable
-from typing import Generic, ClassVar
+from typing import Generic, ClassVar, GenericMeta
 from typing import cast
 from typing import get_type_hints
 from typing import no_type_check, no_type_check_decorator
@@ -717,6 +717,12 @@ class GenericTests(BaseTestCase):
         self.assertEqual(D.__bases__, (C, List))
         self.assertEqual(C.__orig_bases__, (List[T][U][V],))
         self.assertEqual(D.__orig_bases__, (C, List[T][U][V]))
+
+    def test_subscript_meta(self):
+        T = TypeVar('T')
+        self.assertEqual(Type[GenericMeta], Type[GenericMeta])
+        self.assertEqual(Union[T, int][GenericMeta], Union[GenericMeta, int])
+        self.assertEqual(Callable[..., GenericMeta].__args__, (Ellipsis, GenericMeta))
 
     def test_extended_generic_rules_eq(self):
         T = TypeVar('T')

--- a/src/typing.py
+++ b/src/typing.py
@@ -513,7 +513,7 @@ def _replace_arg(arg, tvars, args):
 
     if tvars is None:
         tvars = []
-    if hasattr(arg, '_subs_tree'):
+    if hasattr(arg, '_subs_tree') and isinstance(arg, (GenericMeta, _TypingBase)):
         return arg._subs_tree(tvars, args)
     if isinstance(arg, TypeVar):
         for i, tvar in enumerate(tvars):


### PR DESCRIPTION
Fixes #347 

This is a simple fix (also fixes situations where a random class has a ``_subs_tree`` attribute, it is not necessary to reserve this name).

In general, things like ``List[GenericMeta]`` are not very useful for static checking, but could be used for documentation and runtime checks (I have found such use case in one library).