### PR TITLE
Add typing.Deque

### DIFF
--- a/python2/test_typing.py
+++ b/python2/test_typing.py
@@ -1272,14 +1272,6 @@ class CollectionsAbcTests(BaseTestCase):
         with self.assertRaises(TypeError):
             typing.Set[int]()
 
-    def test_no_set_instantiation(self):
-        with self.assertRaises(TypeError):
-            typing.Set()
-        with self.assertRaises(TypeError):
-            typing.Set[T]()
-        with self.assertRaises(TypeError):
-            typing.Set[int]()
-
     def test_set_subclass_instantiation(self):
 
         class MySet(typing.Set[int]):

--- a/python2/test_typing.py
+++ b/python2/test_typing.py
@@ -1183,6 +1183,9 @@ class CollectionsAbcTests(BaseTestCase):
     def test_list(self):
         self.assertIsSubclass(list, typing.List)
 
+    def test_deque(self):
+        self.assertIsSubclass(collections.deque, typing.Deque)
+
     def test_set(self):
         self.assertIsSubclass(set, typing.Set)
         self.assertNotIsSubclass(frozenset, typing.Set)
@@ -1252,6 +1255,22 @@ class CollectionsAbcTests(BaseTestCase):
 
         self.assertIsSubclass(MyDefDict, collections.defaultdict)
         self.assertNotIsSubclass(collections.defaultdict, MyDefDict)
+
+    def test_no_deque_instantiation(self):
+        with self.assertRaises(TypeError):
+            typing.Deque()
+        with self.assertRaises(TypeError):
+            typing.Deque[T]()
+        with self.assertRaises(TypeError):
+            typing.Deque[int]()
+
+    def test_no_set_instantiation(self):
+        with self.assertRaises(TypeError):
+            typing.Set()
+        with self.assertRaises(TypeError):
+            typing.Set[T]()
+        with self.assertRaises(TypeError):
+            typing.Set[int]()
 
     def test_no_set_instantiation(self):
         with self.assertRaises(TypeError):

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -51,6 +51,7 @@ __all__ = [
     'SupportsInt',
 
     # Concrete collection types.
+    'Deque',
     'Dict',
     'DefaultDict',
     'List',
@@ -1664,6 +1665,15 @@ class List(list, MutableSequence[T]):
                             "use list() instead")
         return _generic_new(list, cls, *args, **kwds)
 
+class Deque(collections.deque, MutableSequence[T], extra=collections.deque):
+
+    __slots__ = ()
+
+    def __new__(cls, *args, **kwds):
+        if _geqv(cls, Deque):
+            raise TypeError("Type Deque cannot be instantiated; "
+                            "use deque() instead")
+        return _generic_new(collections.deque, cls, *args, **kwds)
 
 class Set(set, MutableSet[T]):
     __slots__ = ()

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -1665,9 +1665,9 @@ class List(list, MutableSequence[T]):
                             "use list() instead")
         return _generic_new(list, cls, *args, **kwds)
 
-class Deque(collections.deque, MutableSequence[T], extra=collections.deque):
-
+class Deque(collections.deque, MutableSequence[T]):
     __slots__ = ()
+    __extra__ = collections.deque
 
     def __new__(cls, *args, **kwds):
         if _geqv(cls, Deque):

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -1572,6 +1572,9 @@ class CollectionsAbcTests(BaseTestCase):
     def test_list(self):
         self.assertIsSubclass(list, typing.List)
 
+    def test_deque(self):
+        self.assertIsSubclass(collections.deque, typing.Deque)
+
     def test_set(self):
         self.assertIsSubclass(set, typing.Set)
         self.assertNotIsSubclass(frozenset, typing.Set)
@@ -1641,6 +1644,14 @@ class CollectionsAbcTests(BaseTestCase):
 
         self.assertIsSubclass(MyDefDict, collections.defaultdict)
         self.assertNotIsSubclass(collections.defaultdict, MyDefDict)
+
+    def test_no_deque_instantiation(self):
+        with self.assertRaises(TypeError):
+            typing.Deque()
+        with self.assertRaises(TypeError):
+            typing.Deque[T]()
+        with self.assertRaises(TypeError):
+            typing.Deque[int]()
 
     def test_no_set_instantiation(self):
         with self.assertRaises(TypeError):

--- a/src/typing.py
+++ b/src/typing.py
@@ -59,6 +59,7 @@ __all__ = [
     'SupportsRound',
 
     # Concrete collection types.
+    'Deque',
     'Dict',
     'DefaultDict',
     'List',
@@ -1771,6 +1772,15 @@ class List(list, MutableSequence[T], extra=list):
                             "use list() instead")
         return _generic_new(list, cls, *args, **kwds)
 
+class Deque(collections.deque, MutableSequence[T], extra=collections.deque):
+
+    __slots__ = ()
+
+    def __new__(cls, *args, **kwds):
+        if _geqv(cls, Deque):
+            raise TypeError("Type Deque cannot be instantiated; "
+                            "use deque() instead")
+        return _generic_new(collections.deque, cls, *args, **kwds)
 
 class Set(set, MutableSet[T], extra=set):
 


### PR DESCRIPTION
Fixes #353 

I have noticed that Raymond added one blanc line between classes instead of two, and it is better to use full name "collections.deque()" in the error message (as we do in other places).

@gvanrossum If you think it is better to fix this in a separate PR then this one could be merged, otherwise I will add one more commit here.