### PR TITLE
Enable flake8 for test_*.py on Travis CI

### DIFF
--- a/.flake8-tests
+++ b/.flake8-tests
@@ -1,0 +1,32 @@
+# This configuration is specific to test_*.py; you need to invoke it
+# by specifically naming this config, like this:
+#
+# $ flake8 --config=.flake8-tests src/test_typing.py python2/test_typing.py
+#
+# This will be possibly merged in the future.
+
+[flake8]
+# fake builtins for python2/*
+builtins = basestring, unicode
+ignore =
+  # temporary ignores until we sort it out
+  E116,
+  E128,
+  E231,
+  E251,
+  E302,
+  E306,
+  E501,
+  E701,
+  E704,
+  F401,
+  F811,
+  F841,
+  # irrelevant plugins
+  B3,
+  DW12
+exclude =
+  # This config is NOT for the main module.
+  setup.py
+  python2/typing.py,
+  src/typing.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,4 @@ install:
 script:
   - export PYTHONPATH=`python -c "import sys; print('python2' if sys.version.startswith('2') else 'src')"`; py.test $PYTHONPATH
   - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then flake8; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then flake8 --config=.flake8-tests src/test_typing.py python2/test_typing.py; fi

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -1381,6 +1381,9 @@ if ASYNCIO:
         exec(ASYNCIO_TESTS)
     except ImportError:
         ASYNCIO = False
+else:
+    # fake names for the sake of static analysis
+    AwaitableWrapper = AsyncIteratorWrapper = object
 
 PY36 = sys.version_info[:2] >= (3, 6)
 
@@ -1408,6 +1411,10 @@ class CoolEmployeeWithDefault(NamedTuple):
 
 if PY36:
     exec(PY36_TESTS)
+else:
+    # fake names for the sake of static analysis
+    ann_module = ann_module2 = ann_module3 = None
+    A = B = CSub = G = CoolEmployee = CoolEmployeeWithDefault = object
 
 gth = get_type_hints
 


### PR DESCRIPTION
For now this requires a test-specific config while I plow through the warnings
that are specific to tests.

To test this actually does something, I fixed F821 by putting the fake names to
make flake8 happy.  Hopefully you don't find this too terrible.  The other
choice was to disable "undefined names" warnings entirely.  I didn't want to do
that because I find them very useful.