### PR TITLE
Allow defining methods in NamedTuple class syntax

### DIFF
--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -2046,19 +2046,19 @@ class NamedTupleTests(BaseTestCase):
         self.assertEqual(CoolEmployeeWithDefault._field_types, dict(name=str, cool=int))
         self.assertEqual(CoolEmployeeWithDefault._field_defaults, dict(cool=0))
 
-    @skipUnless(PY36, 'Python 3.6 required')
-    def test_annotation_usage_with_methods(self):
-        self.assertEquals(XMeth(1).double(), 2)
-        self.assertEquals(XMeth(42).x, XMeth(42)[0])
-        self.assertEquals(XMethBad(1)._fields, ('x',))
-        self.assertEquals(XMethBad(1).__annotations__, {'x': int})
-
         with self.assertRaises(TypeError):
             exec("""
 class NonDefaultAfterDefault(NamedTuple):
     x: int = 3
     y: int
 """)
+
+    @skipUnless(PY36, 'Python 3.6 required')
+    def test_annotation_usage_with_methods(self):
+        self.assertEquals(XMeth(1).double(), 2)
+        self.assertEquals(XMeth(42).x, XMeth(42)[0])
+        self.assertEquals(XMethBad(1)._fields, ('x',))
+        self.assertEquals(XMethBad(1).__annotations__, {'x': int})
 
     @skipUnless(PY36, 'Python 3.6 required')
     def test_namedtuple_keyword_usage(self):

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -1413,6 +1413,16 @@ class CoolEmployee(NamedTuple):
 class CoolEmployeeWithDefault(NamedTuple):
     name: str
     cool: int = 0
+
+class XMeth(NamedTuple):
+    x: int
+    def double(self):
+        return 2 * self.x
+
+class XMethBad(NamedTuple):
+    x: int
+    def _fields(self):
+        return 'no chance for this'
 """
 
 if PY36:
@@ -2034,6 +2044,13 @@ class NamedTupleTests(BaseTestCase):
         self.assertEqual(CoolEmployeeWithDefault._fields, ('name', 'cool'))
         self.assertEqual(CoolEmployeeWithDefault._field_types, dict(name=str, cool=int))
         self.assertEqual(CoolEmployeeWithDefault._field_defaults, dict(cool=0))
+
+    @skipUnless(PY36, 'Python 3.6 required')
+    def test_annotation_usage_with_methods(self):
+        self.assertEquals(XMeth(1).double(), 2)
+        self.assertEquals(XMeth(42).x, XMeth(42)[0])
+        self.assertEquals(XMethBad(1)._fields, ('x',))
+        self.assertEquals(XMethBad(1).__annotations__, {'x': int})
 
         with self.assertRaises(TypeError):
             exec("""

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -1431,6 +1431,7 @@ else:
     # fake names for the sake of static analysis
     ann_module = ann_module2 = ann_module3 = None
     A = B = CSub = G = CoolEmployee = CoolEmployeeWithDefault = object
+    XMeth = XMethBad = object
 
 gth = get_type_hints
 

--- a/src/typing.py
+++ b/src/typing.py
@@ -2000,6 +2000,10 @@ class NamedTupleMeta(type):
                                         default_names=', '.join(defaults_dict.keys())))
         nm_tpl.__new__.__defaults__ = tuple(defaults)
         nm_tpl._field_defaults = defaults_dict
+        # update from user namespace without overriding special namedtuple attributes
+        for key in ns:
+            if not hasattr(nm_tpl, key):
+                setattr(nm_tpl, key, ns[key])
         return nm_tpl
 
 


### PR DESCRIPTION
Fixes #352.

I think the only limitation is that the methods defined by user should not shadow the special namedtuple attributes.