### PR TITLE
Raise AttributeError on name collision in NamedTuple

### DIFF
--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -1418,11 +1418,6 @@ class XMeth(NamedTuple):
     x: int
     def double(self):
         return 2 * self.x
-
-class XMethBad(NamedTuple):
-    x: int
-    def _fields(self):
-        return 'no chance for this'
 """
 
 if PY36:
@@ -2057,8 +2052,14 @@ class NonDefaultAfterDefault(NamedTuple):
     def test_annotation_usage_with_methods(self):
         self.assertEquals(XMeth(1).double(), 2)
         self.assertEquals(XMeth(42).x, XMeth(42)[0])
-        self.assertEquals(XMethBad(1)._fields, ('x',))
-        self.assertEquals(XMethBad(1).__annotations__, {'x': int})
+
+        with self.assertRaises(AttributeError):
+            exec("""
+class XMethBad(NamedTuple):
+    x: int
+    def _fields(self):
+        return 'no chance for this'
+""")
 
     @skipUnless(PY36, 'Python 3.6 required')
     def test_namedtuple_keyword_usage(self):

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -1425,8 +1425,7 @@ if PY36:
 else:
     # fake names for the sake of static analysis
     ann_module = ann_module2 = ann_module3 = None
-    A = B = CSub = G = CoolEmployee = CoolEmployeeWithDefault = object
-    XMeth = XMethBad = object
+    A = B = CSub = G = CoolEmployee = CoolEmployeeWithDefault = XMeth = object
 
 gth = get_type_hints
 

--- a/src/typing.py
+++ b/src/typing.py
@@ -2004,6 +2004,11 @@ class NamedTupleMeta(type):
         for key in ns:
             if not hasattr(nm_tpl, key):
                 setattr(nm_tpl, key, ns[key])
+            elif (
+                key not in ['__module__', '__qualname__', '__annotations__'] and
+                key not in nm_tpl._field_defaults
+            ):
+                raise AttributeError("Cannot overwrite NamedTuple attribute " + key)
         return nm_tpl
 
 


### PR DESCRIPTION
This is a follow-up for #362 

This explicitly prohibits overwriting ``NamedTuple`` fields and special attributes:
```python
class X(NamedTuple):
    x: int
    def _fileds(self):  # This will be an error
        ...
```