### PR TITLE
Make get_type_hints not throw an error on builtin methods

### DIFF
--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -1476,7 +1476,7 @@ class GetTypeHintTests(BaseTestCase):
         class Der(ABase): ...
         self.assertEqual(gth(ABase.meth), {'x': int})
 
-    def test_get_type_hints_for_builins(self):
+    def test_get_type_hints_for_builtins(self):
         # Should not fail for built-in classes and functions.
         self.assertEqual(gth(int), {})
         self.assertEqual(gth(type), {})
@@ -1484,6 +1484,7 @@ class GetTypeHintTests(BaseTestCase):
         self.assertEqual(gth(len), {})
         self.assertEqual(gth(object.__str__), {})
         self.assertEqual(gth(object().__str__), {})
+        self.assertEqual(gth(str.join), {})
 
     def test_previous_behavior(self):
         def testf(x, y): ...

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -1482,6 +1482,8 @@ class GetTypeHintTests(BaseTestCase):
         self.assertEqual(gth(type), {})
         self.assertEqual(gth(dir), {})
         self.assertEqual(gth(len), {})
+        self.assertEqual(gth(object.__str__), {})
+        self.assertEqual(gth(object().__str__), {})
 
     def test_previous_behavior(self):
         def testf(x, y): ...

--- a/src/typing.py
+++ b/src/typing.py
@@ -1461,8 +1461,8 @@ def get_type_hints(obj, globalns=None, localns=None):
             isinstance(obj, types.BuiltinFunctionType) or
             isinstance(obj, types.MethodType) or
             isinstance(obj, types.ModuleType) or
-			isinstance(obj, _wrapper_descriptor_type) or
-			isinstance(obj, _method_wrapper_type)
+            isinstance(obj, _wrapper_descriptor_type) or
+            isinstance(obj, _method_wrapper_type)
         ):
             return {}
         else:

--- a/src/typing.py
+++ b/src/typing.py
@@ -10,6 +10,12 @@ try:
     import collections.abc as collections_abc
 except ImportError:
     import collections as collections_abc  # Fallback for PY3.2.
+try:
+    from types import SlotWrapperType, MethodWrapperType, MethodDescriptorType
+except ImportError:
+    SlotWrapperType = type(object.__init__)
+    MethodWrapperType = type(object().__str__)
+    MethodDescriptorType = type(str.join)
 
 
 # Please keep __all__ alphabetized within each category.
@@ -1398,10 +1404,6 @@ def _get_defaults(func):
     return res
 
 
-# Types of builtin C methods
-_wrapper_descriptor_type = type(object.__init__)
-_method_wrapper_type = type(object().__str__)
-
 def get_type_hints(obj, globalns=None, localns=None):
     """Return type hints for an object.
 
@@ -1461,8 +1463,9 @@ def get_type_hints(obj, globalns=None, localns=None):
             isinstance(obj, types.BuiltinFunctionType) or
             isinstance(obj, types.MethodType) or
             isinstance(obj, types.ModuleType) or
-            isinstance(obj, _wrapper_descriptor_type) or
-            isinstance(obj, _method_wrapper_type)
+            isinstance(obj, SlotWrapperType) or
+            isinstance(obj, MethodWrapperType) or
+            isinstance(obj, MethodDescriptorType)
         ):
             return {}
         else:

--- a/src/typing.py
+++ b/src/typing.py
@@ -1398,6 +1398,10 @@ def _get_defaults(func):
     return res
 
 
+# Types of builtin C methods
+_wrapper_descriptor_type = type(object.__init__)
+_method_wrapper_type = type(object().__str__)
+
 def get_type_hints(obj, globalns=None, localns=None):
     """Return type hints for an object.
 
@@ -1456,7 +1460,9 @@ def get_type_hints(obj, globalns=None, localns=None):
             isinstance(obj, types.FunctionType) or
             isinstance(obj, types.BuiltinFunctionType) or
             isinstance(obj, types.MethodType) or
-            isinstance(obj, types.ModuleType)
+            isinstance(obj, types.ModuleType) or
+			isinstance(obj, _wrapper_descriptor_type) or
+			isinstance(obj, _method_wrapper_type)
         ):
             return {}
         else:


### PR DESCRIPTION
While builtin functions are supported, calling get_type_hints on a builtin method like `object.__init__` causes an error. I change this to return an empty dictionary instead.