### PR TITLE
Allow overriding some methods in NamedTuple

### DIFF
--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -1418,6 +1418,14 @@ class XMeth(NamedTuple):
     x: int
     def double(self):
         return 2 * self.x
+
+class XRepr(NamedTuple):
+    x: int
+    y: int = 1
+    def __str__(self):
+        return f'{self.x} -> {self.y}'
+    def __add__(self, other):
+        return 0
 """
 
 if PY36:
@@ -1425,7 +1433,8 @@ if PY36:
 else:
     # fake names for the sake of static analysis
     ann_module = ann_module2 = ann_module3 = None
-    A = B = CSub = G = CoolEmployee = CoolEmployeeWithDefault = XMeth = object
+    A = B = CSub = G = CoolEmployee = CoolEmployeeWithDefault = object
+    XMeth = XRepr = object
 
 gth = get_type_hints
 
@@ -2051,6 +2060,8 @@ class NonDefaultAfterDefault(NamedTuple):
     def test_annotation_usage_with_methods(self):
         self.assertEqual(XMeth(1).double(), 2)
         self.assertEqual(XMeth(42).x, XMeth(42)[0])
+        self.assertEqual(str(XRepr(42)), '42 -> 1')
+        self.assertEqual(XRepr(1, 2) + XRepr(3), 0)
 
         with self.assertRaises(AttributeError):
             exec("""

--- a/src/typing.py
+++ b/src/typing.py
@@ -1982,6 +1982,7 @@ _prohibited = ('__new__', '__init__', '__slots__', '__getnewargs__',
 
 _special = ('__module__', '__name__', '__qualname__', '__annotations__')
 
+
 class NamedTupleMeta(type):
 
     def __new__(cls, typename, bases, ns):

--- a/src/typing.py
+++ b/src/typing.py
@@ -2009,10 +2009,10 @@ class NamedTupleMeta(type):
         nm_tpl._field_defaults = defaults_dict
         # update from user namespace without overriding special namedtuple attributes
         for key in ns:
-            if key not in _prohibited + _special + nm_tpl._fields:
-                setattr(nm_tpl, key, ns[key])
-            elif key in _prohibited:
+            if key in _prohibited:
                 raise AttributeError("Cannot overwrite NamedTuple attribute " + key)
+            elif key not in _special and key not in nm_tpl._fields:
+                setattr(nm_tpl, key, ns[key])
         return nm_tpl
 
 

--- a/src/typing.py
+++ b/src/typing.py
@@ -1975,6 +1975,12 @@ def _make_nmtuple(name, types):
 
 _PY36 = sys.version_info[:2] >= (3, 6)
 
+# attributes prohibited to set in NamedTuple class syntax
+_prohibited = ('__new__', '__init__', '__slots__', '__getnewargs__',
+               '_fields', '_field_defaults', '_field_types',
+               '_make', '_replace', '_asdict')
+
+_special = ('__module__', '__name__', '__qualname__', '__annotations__')
 
 class NamedTupleMeta(type):
 
@@ -2002,12 +2008,9 @@ class NamedTupleMeta(type):
         nm_tpl._field_defaults = defaults_dict
         # update from user namespace without overriding special namedtuple attributes
         for key in ns:
-            if not hasattr(nm_tpl, key):
+            if key not in _prohibited + _special + nm_tpl._fields:
                 setattr(nm_tpl, key, ns[key])
-            elif (
-                key not in ['__module__', '__qualname__', '__annotations__'] and
-                key not in nm_tpl._field_defaults
-            ):
+            elif key in _prohibited:
                 raise AttributeError("Cannot overwrite NamedTuple attribute " + key)
         return nm_tpl
 


### PR DESCRIPTION
Fixes #369 

This allows to customize ``__repr__`` and other methods using ``NamedTuple`` class syntax.
Basically I just change the logic to "everything is allowed except if explicitly prohibited".