### PR TITLE
Fix hash of GenericMeta classes

### DIFF
--- a/python2/mod.py
+++ b/python2/mod.py
@@ -2,8 +2,10 @@ from typing import TypeVar, Generic
 
 T = TypeVar('T')
 
+
 class A(Generic[T]):
     pass
+
 
 class B(Generic[T]):
     class A(Generic[T]):

--- a/python2/mod.py
+++ b/python2/mod.py
@@ -1,0 +1,10 @@
+from typing import TypeVar, Generic
+
+T = TypeVar('T')
+
+class A(Generic[T]):
+    pass
+
+class B(Generic[T]):
+    class A(Generic[T]):
+        pass

--- a/python2/test_typing.py
+++ b/python2/test_typing.py
@@ -707,6 +707,42 @@ class GenericTests(BaseTestCase):
         self.assertEqual(Union[T, int][GenericMeta], Union[GenericMeta, int])
         self.assertEqual(Callable[..., GenericMeta].__args__, (Ellipsis, GenericMeta))
 
+    def test_generic_hashes(self):
+        import mod
+        class A(Generic[T]):
+            pass
+
+        class B(Generic[T]):
+            class A(Generic[T]):
+                pass
+
+        self.assertEqual(A, A)
+        self.assertEqual(mod.A[str], mod.A[str])
+        self.assertEqual(B.A, B.A)
+        self.assertEqual(mod.B.A[B.A[str]], mod.B.A[B.A[str]])
+
+        self.assertNotEqual(A, B.A)
+        self.assertNotEqual(A, mod.A)
+        self.assertNotEqual(A, mod.B.A)
+        self.assertNotEqual(B.A, mod.A)
+        self.assertNotEqual(B.A, mod.B.A)
+
+        self.assertNotEqual(A[str], B.A[str])
+        self.assertNotEqual(A[List[Any]], B.A[List[Any]])
+        self.assertNotEqual(A[str], mod.A[str])
+        self.assertNotEqual(A[str], mod.B.A[str])
+        self.assertNotEqual(B.A[int], mod.A[int])
+        self.assertNotEqual(B.A[List[Any]], mod.B.A[List[Any]])
+
+        self.assertNotEqual(Tuple[A[str]], Tuple[B.A[str]])
+        self.assertNotEqual(Tuple[A[List[Any]]], Tuple[B.A[List[Any]]])
+        self.assertNotEqual(Union[str, A[str]], Union[str, mod.A[str]])
+        self.assertNotEqual(Union[A[str], A[str]], Union[A[str], mod.A[str]])
+        self.assertNotEqual(typing.FrozenSet[A[str]], typing.FrozenSet[mod.B.A[str]])
+
+        self.assertTrue(repr(Tuple[A[str]]).endswith('typing.A[str]]'))
+        self.assertTrue(repr(Tuple[mod.A[str]]).endswith('mod.A[str]]'))
+
     def test_extended_generic_rules_eq(self):
         T = TypeVar('T')
         U = TypeVar('U')

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -1073,7 +1073,8 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
 
         if origin and hasattr(origin, '__qualname__'):  # Fix for Python 3.2.
             self.__qualname__ = origin.__qualname__
-        self.__tree_hash__ = hash(self._subs_tree()) if origin else hash((self.__name__,))
+        self.__tree_hash__ = (hash(self._subs_tree()) if origin else
+                              super(GenericMeta, self).__hash__())
         return self
 
     def __init__(self, *args, **kwargs):

--- a/src/mod.py
+++ b/src/mod.py
@@ -2,8 +2,10 @@ from typing import TypeVar, Generic
 
 T = TypeVar('T')
 
+
 class A(Generic[T]):
     pass
+
 
 class B(Generic[T]):
     class A(Generic[T]):

--- a/src/mod.py
+++ b/src/mod.py
@@ -1,0 +1,10 @@
+from typing import TypeVar, Generic
+
+T = TypeVar('T')
+
+class A(Generic[T]):
+    pass
+
+class B(Generic[T]):
+    class A(Generic[T]):
+        pass

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -738,6 +738,44 @@ class GenericTests(BaseTestCase):
         self.assertEqual(Union[T, int][GenericMeta], Union[GenericMeta, int])
         self.assertEqual(Callable[..., GenericMeta].__args__, (Ellipsis, GenericMeta))
 
+    def test_generic_hashes(self):
+        import mod
+        class A(Generic[T]):
+            ...
+
+        class B(Generic[T]):
+            class A(Generic[T]):
+                ...
+
+        self.assertEqual(A, A)
+        self.assertEqual(mod.A[str], mod.A[str])
+        self.assertEqual(B.A, B.A)
+        self.assertEqual(mod.B.A[B.A[str]], mod.B.A[B.A[str]])
+
+        self.assertNotEqual(A, B.A)
+        self.assertNotEqual(A, mod.A)
+        self.assertNotEqual(A, mod.B.A)
+        self.assertNotEqual(B.A, mod.A)
+        self.assertNotEqual(B.A, mod.B.A)
+
+        self.assertNotEqual(A[str], B.A[str])
+        self.assertNotEqual(A[List[Any]], B.A[List[Any]])
+        self.assertNotEqual(A[str], mod.A[str])
+        self.assertNotEqual(A[str], mod.B.A[str])
+        self.assertNotEqual(B.A[int], mod.A[int])
+        self.assertNotEqual(B.A[List[Any]], mod.B.A[List[Any]])
+
+        self.assertNotEqual(Tuple[A[str]], Tuple[B.A[str]])
+        self.assertNotEqual(Tuple[A[List[Any]]], Tuple[B.A[List[Any]]])
+        self.assertNotEqual(Union[str, A[str]], Union[str, mod.A[str]])
+        self.assertNotEqual(Union[A[str], A[str]], Union[A[str], mod.A[str]])
+        self.assertNotEqual(typing.FrozenSet[A[str]], typing.FrozenSet[mod.B.A[str]])
+
+        self.assertTrue(repr(Tuple[A[str]]).endswith('<locals>.A[str]]'))
+        self.assertTrue(repr(Tuple[B.A[str]]).endswith('<locals>.B.A[str]]'))
+        self.assertTrue(repr(Tuple[mod.A[str]]).endswith('mod.A[str]]'))
+        self.assertTrue(repr(Tuple[mod.B.A[str]]).endswith('mod.B.A[str]]'))
+
     def test_extended_generic_rules_eq(self):
         T = TypeVar('T')
         U = TypeVar('U')

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -771,10 +771,11 @@ class GenericTests(BaseTestCase):
         self.assertNotEqual(Union[A[str], A[str]], Union[A[str], mod.A[str]])
         self.assertNotEqual(typing.FrozenSet[A[str]], typing.FrozenSet[mod.B.A[str]])
 
-        self.assertTrue(repr(Tuple[A[str]]).endswith('<locals>.A[str]]'))
-        self.assertTrue(repr(Tuple[B.A[str]]).endswith('<locals>.B.A[str]]'))
-        self.assertTrue(repr(Tuple[mod.A[str]]).endswith('mod.A[str]]'))
-        self.assertTrue(repr(Tuple[mod.B.A[str]]).endswith('mod.B.A[str]]'))
+        if sys.version_info[:2] > (3, 2):
+            self.assertTrue(repr(Tuple[A[str]]).endswith('<locals>.A[str]]'))
+            self.assertTrue(repr(Tuple[B.A[str]]).endswith('<locals>.B.A[str]]'))
+            self.assertTrue(repr(Tuple[mod.A[str]]).endswith('mod.A[str]]'))
+            self.assertTrue(repr(Tuple[mod.B.A[str]]).endswith('mod.B.A[str]]'))
 
     def test_extended_generic_rules_eq(self):
         T = TypeVar('T')

--- a/src/typing.py
+++ b/src/typing.py
@@ -1005,7 +1005,8 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
 
         if origin and hasattr(origin, '__qualname__'):  # Fix for Python 3.2.
             self.__qualname__ = origin.__qualname__
-        self.__tree_hash__ = hash(self._subs_tree()) if origin else hash((self.__name__,))
+        self.__tree_hash__ = (hash(self._subs_tree()) if origin else
+                              super(GenericMeta, self).__hash__())
         return self
 
     def _get_type_vars(self, tvars):


### PR DESCRIPTION
Fixes #351 

It looks like there is a very simple fix (defer hashing of bare generics to ``super()``).
Nevertheless, I add extensive tests to avoid this difficult to catch bug in the future.

Note that I added a new module, since it is necessary to check that classes with same name defined in different modules compare unequal (we cannot use ``ann_module`` for this, since it is better to have test for all versions including 2.7).