### PR TITLE
Add some tests based on coverage report: Part 2

### DIFF
--- a/python2/test_typing.py
+++ b/python2/test_typing.py
@@ -261,7 +261,6 @@ class UnionTests(BaseTestCase):
         u = Union[List[int], int]
         self.assertEqual(repr(u), 'typing.Union[typing.List[int], int]')
 
-
     def test_cannot_subclass(self):
         with self.assertRaises(TypeError):
             class C(Union):

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -1212,10 +1212,6 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
                               self.__extra__, self.__orig_bases__)
 
 
-# Prevent checks for Generic to crash when defining Generic.
-Generic = None
-
-
 def _generic_new(base_cls, cls, *args, **kwds):
     # Assure type is erased on instantiation,
     # but attempt to store it in __orig_class__

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -1212,6 +1212,10 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
                               self.__extra__, self.__orig_bases__)
 
 
+# Prevent checks for Generic to crash when defining Generic.
+Generic = None
+
+
 def _generic_new(base_cls, cls, *args, **kwds):
     # Assure type is erased on instantiation,
     # but attempt to store it in __orig_class__
@@ -1257,10 +1261,6 @@ class Generic(object):
             raise TypeError("Type Generic cannot be instantiated; "
                             "it can be used only as a base class")
         return _generic_new(cls.__next_in_mro__, cls, *args, **kwds)
-
-
-# prevent class and instance checks against plain Generic
-Generic.__subclasshook__ = _make_subclasshook(Generic)
 
 
 class _TypingEmpty(object):

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -258,6 +258,11 @@ class UnionTests(BaseTestCase):
         self.assertEqual(repr(u), 'typing.Union[%s.Employee, int]' % __name__)
         u = Union[int, Employee]
         self.assertEqual(repr(u), 'typing.Union[int, %s.Employee]' % __name__)
+        T = TypeVar('T')
+        u = Union[T, int][int]
+        self.assertEqual(repr(u), repr(int))
+        u = Union[List[int], int]
+        self.assertEqual(repr(u), 'typing.Union[typing.List[int], int]')
 
     def test_cannot_subclass(self):
         with self.assertRaises(TypeError):
@@ -307,6 +312,15 @@ class UnionTests(BaseTestCase):
     def test_union_instance_type_error(self):
         with self.assertRaises(TypeError):
             isinstance(42, Union[int, str])
+
+    def test_no_eval_union(self):
+        u = Union[int, str]
+        def f(x: u): ...
+        self.assertIs(get_type_hints(f)['x'], u)
+
+    def test_function_repr_union(self):
+        def fun() -> int: ...
+        self.assertEqual(repr(Union[fun, int]), 'typing.Union[fun, int]')
 
     def test_union_str_pattern(self):
         # Shouldn't crash; see http://bugs.python.org/issue25390
@@ -892,6 +906,8 @@ class GenericTests(BaseTestCase):
             Tuple[Generic[T]]
         with self.assertRaises(TypeError):
             List[typing._Protocol]
+        with self.assertRaises(TypeError):
+            isinstance(1, Generic)
 
     def test_type_erasure_special(self):
         T = TypeVar('T')
@@ -1260,6 +1276,19 @@ class ForwardRefTests(BaseTestCase):
         with self.assertRaises(TypeError):
             isinstance(42, fr)
 
+    def test_forwardref_subclass_type_error(self):
+        fr = typing._ForwardRef('int')
+        with self.assertRaises(TypeError):
+            issubclass(int, fr)
+
+    def test_forward_equality(self):
+        fr = typing._ForwardRef('int')
+        self.assertEqual(fr, typing._ForwardRef('int'))
+        self.assertNotEqual(List['int'], List[int])
+
+    def test_forward_repr(self):
+        self.assertEqual(repr(List['int']), "typing.List[_ForwardRef('int')]")
+
     def test_union_forward(self):
 
         def foo(a: Union['T']):
@@ -1467,10 +1496,15 @@ class A:
 class B(A):
     x: ClassVar[Optional['B']] = None
     y: int
+    b: int
 class CSub(B):
     z: ClassVar['CSub'] = B()
 class G(Generic[T]):
     lst: ClassVar[List[T]] = []
+
+class NoneAndForward:
+    parent: 'NoneAndForward'
+    meaning: None
 
 class CoolEmployee(NamedTuple):
     name: str
@@ -1492,6 +1526,7 @@ else:
     # fake names for the sake of static analysis
     ann_module = ann_module2 = ann_module3 = None
     A = B = CSub = G = CoolEmployee = CoolEmployeeWithDefault = XMeth = object
+    NoneAndForward = object
 
 gth = get_type_hints
 
@@ -1526,6 +1561,8 @@ class GetTypeHintTests(BaseTestCase):
                          {'y': Optional[ann_module.C]})
         self.assertEqual(gth(ann_module.S), {'x': str, 'y': str})
         self.assertEqual(gth(ann_module.foo), {'x': int})
+        self.assertEqual(gth(NoneAndForward, globals()),
+                         {'parent': NoneAndForward, 'meaning': type(None)})
 
     @skipUnless(PY36, 'Python 3.6 required')
     def test_respect_no_type_check(self):
@@ -1568,9 +1605,10 @@ class GetTypeHintTests(BaseTestCase):
         self.assertEqual(gth(ann_module2.CV, ann_module2.__dict__),
                          {'var': typing.ClassVar[ann_module2.CV]})
         self.assertEqual(gth(B, globals()),
-                         {'y': int, 'x': ClassVar[Optional[B]]})
+                         {'y': int, 'x': ClassVar[Optional[B]], 'b': int})
         self.assertEqual(gth(CSub, globals()),
-                         {'z': ClassVar[CSub], 'y': int, 'x': ClassVar[Optional[B]]})
+                         {'z': ClassVar[CSub], 'y': int, 'b': int,
+                          'x': ClassVar[Optional[B]]})
         self.assertEqual(gth(G), {'lst': ClassVar[List[T]]})
 
 
@@ -2212,6 +2250,12 @@ class RETests(BaseTestCase):
         Pattern[Union[str, bytes]]
         Match[Union[bytes, str]]
 
+    def test_alias_equality(self):
+        self.assertEqual(Pattern[str], Pattern[str])
+        self.assertNotEqual(Pattern[str], Pattern[bytes])
+        self.assertNotEqual(Pattern[str], Match[str])
+        self.assertNotEqual(Pattern[str], str)
+
     def test_errors(self):
         with self.assertRaises(TypeError):
             # Doesn't fit AnyStr.
@@ -2226,6 +2270,9 @@ class RETests(BaseTestCase):
         with self.assertRaises(TypeError):
             # We don't support isinstance().
             isinstance(42, Pattern[str])
+        with self.assertRaises(TypeError):
+            # We don't support issubclass().
+            issubclass(Pattern[bytes], Pattern[str])
 
     def test_repr(self):
         self.assertEqual(repr(Pattern), 'Pattern[~AnyStr]')

--- a/src/typing.py
+++ b/src/typing.py
@@ -1171,10 +1171,6 @@ class Generic(metaclass=GenericMeta):
         return _generic_new(cls.__next_in_mro__, cls, *args, **kwds)
 
 
-# prevent class and instance checks against plain Generic
-Generic.__subclasshook__ = _make_subclasshook(Generic)
-
-
 class _TypingEmpty:
     """Internal placeholder for () or []. Used by TupleMeta and CallableMeta
     to allow empty list/tuple in specific places, without allowing them

--- a/src/typing.py
+++ b/src/typing.py
@@ -994,10 +994,9 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
         # with issubclass() and isinstance() in the same way as their
         # collections.abc counterparts (e.g., isinstance([], Iterable)).
         if (
-            # allow overriding
             '__subclasshook__' not in namespace and extra or
-            hasattr(self.__subclasshook__, '__name__') and
-            self.__subclasshook__.__name__ == '__extrahook__'
+            # allow overriding
+            getattr(self.__subclasshook__, '__name__', '') == '__extrahook__'
         ):
             self.__subclasshook__ = _make_subclasshook(self)
         if isinstance(extra, abc.ABCMeta):
@@ -1170,6 +1169,10 @@ class Generic(metaclass=GenericMeta):
             raise TypeError("Type Generic cannot be instantiated; "
                             "it can be used only as a base class")
         return _generic_new(cls.__next_in_mro__, cls, *args, **kwds)
+
+
+# prevent class and instance checks against plain Generic
+Generic.__subclasshook__ = _make_subclasshook(Generic)
 
 
 class _TypingEmpty:


### PR DESCRIPTION
This is a continuation of #373 

Here, however, a (very small) change to ``typing.py`` was necessary. The two PRs boost coverage to virtually 100% (if one does not count ``pass``es in abstract methods and other trivial things).