### PR TITLE
Allow istantiation of Deque and DefaultDict

### DIFF
--- a/python2/test_typing.py
+++ b/python2/test_typing.py
@@ -1315,13 +1315,10 @@ class CollectionsAbcTests(BaseTestCase):
         self.assertIsSubclass(MyDict, dict)
         self.assertNotIsSubclass(dict, MyDict)
 
-    def test_no_defaultdict_instantiation(self):
-        with self.assertRaises(TypeError):
-            typing.DefaultDict()
-        with self.assertRaises(TypeError):
-            typing.DefaultDict[KT, VT]()
-        with self.assertRaises(TypeError):
-            typing.DefaultDict[str, int]()
+    def test_defaultdict_instantiation(self):
+        self.assertIs(type(typing.DefaultDict()), collections.defaultdict)
+        self.assertIs(type(typing.DefaultDict[KT, VT]()), collections.defaultdict)
+        self.assertIs(type(typing.DefaultDict[str, int]()), collections.defaultdict)
 
     def test_defaultdict_subclass(self):
 
@@ -1334,13 +1331,12 @@ class CollectionsAbcTests(BaseTestCase):
         self.assertIsSubclass(MyDefDict, collections.defaultdict)
         self.assertNotIsSubclass(collections.defaultdict, MyDefDict)
 
-    def test_no_deque_instantiation(self):
-        with self.assertRaises(TypeError):
-            typing.Deque()
-        with self.assertRaises(TypeError):
-            typing.Deque[T]()
-        with self.assertRaises(TypeError):
-            typing.Deque[int]()
+    def test_deque_instantiation(self):
+        self.assertIs(type(typing.Deque()), collections.deque)
+        self.assertIs(type(typing.Deque[T]()), collections.deque)
+        self.assertIs(type(typing.Deque[int]()), collections.deque)
+        class D(typing.Deque[T]): pass
+        self.assertIs(type(D[int]()), D)
 
     def test_no_set_instantiation(self):
         with self.assertRaises(TypeError):

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -1714,8 +1714,7 @@ class Deque(collections.deque, MutableSequence[T]):
 
     def __new__(cls, *args, **kwds):
         if _geqv(cls, Deque):
-            raise TypeError("Type Deque cannot be instantiated; "
-                            "use deque() instead")
+            return collections.deque(*args, **kwds)
         return _generic_new(collections.deque, cls, *args, **kwds)
 
 
@@ -1780,8 +1779,7 @@ class DefaultDict(collections.defaultdict, MutableMapping[KT, VT]):
 
     def __new__(cls, *args, **kwds):
         if _geqv(cls, DefaultDict):
-            raise TypeError("Type DefaultDict cannot be instantiated; "
-                            "use collections.defaultdict() instead")
+            return collections.defaultdict(*args, **kwds)
         return _generic_new(collections.defaultdict, cls, *args, **kwds)
 
 

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -1713,13 +1713,10 @@ class CollectionsAbcTests(BaseTestCase):
         self.assertIsSubclass(MyDict, dict)
         self.assertNotIsSubclass(dict, MyDict)
 
-    def test_no_defaultdict_instantiation(self):
-        with self.assertRaises(TypeError):
-            typing.DefaultDict()
-        with self.assertRaises(TypeError):
-            typing.DefaultDict[KT, VT]()
-        with self.assertRaises(TypeError):
-            typing.DefaultDict[str, int]()
+    def test_defaultdict_instantiation(self):
+        self.assertIs(type(typing.DefaultDict()), collections.defaultdict)
+        self.assertIs(type(typing.DefaultDict[KT, VT]()), collections.defaultdict)
+        self.assertIs(type(typing.DefaultDict[str, int]()), collections.defaultdict)
 
     def test_defaultdict_subclass(self):
 
@@ -1732,13 +1729,12 @@ class CollectionsAbcTests(BaseTestCase):
         self.assertIsSubclass(MyDefDict, collections.defaultdict)
         self.assertNotIsSubclass(collections.defaultdict, MyDefDict)
 
-    def test_no_deque_instantiation(self):
-        with self.assertRaises(TypeError):
-            typing.Deque()
-        with self.assertRaises(TypeError):
-            typing.Deque[T]()
-        with self.assertRaises(TypeError):
-            typing.Deque[int]()
+    def test_deque_instantiation(self):
+        self.assertIs(type(typing.Deque()), collections.deque)
+        self.assertIs(type(typing.Deque[T]()), collections.deque)
+        self.assertIs(type(typing.Deque[int]()), collections.deque)
+        class D(typing.Deque[T]): ...
+        self.assertIs(type(D[int]()), D)
 
     def test_no_set_instantiation(self):
         with self.assertRaises(TypeError):

--- a/src/typing.py
+++ b/src/typing.py
@@ -1825,8 +1825,7 @@ class Deque(collections.deque, MutableSequence[T], extra=collections.deque):
 
     def __new__(cls, *args, **kwds):
         if _geqv(cls, Deque):
-            raise TypeError("Type Deque cannot be instantiated; "
-                            "use deque() instead")
+            return collections.deque(*args, **kwds)
         return _generic_new(collections.deque, cls, *args, **kwds)
 
 
@@ -1895,8 +1894,7 @@ class DefaultDict(collections.defaultdict, MutableMapping[KT, VT],
 
     def __new__(cls, *args, **kwds):
         if _geqv(cls, DefaultDict):
-            raise TypeError("Type DefaultDict cannot be instantiated; "
-                            "use collections.defaultdict() instead")
+            return collections.defaultdict(*args, **kwds)
         return _generic_new(collections.defaultdict, cls, *args, **kwds)
 
 


### PR DESCRIPTION
As discussed in #367 ``Deque`` and ``DefaultDict`` will follow the rules of user-defined classes.
Instantiating them will return instances of plain ``collections.deque`` and ``collections.defaultdict``.