### PR TITLE
Optimize ABC caches

### DIFF
--- a/python2/typing.py
+++ b/python2/typing.py
@@ -1084,7 +1084,8 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
     def _abc_negative_cache(self, value):
         if isinstance(self.__extra__, abc.ABCMeta):
             self.__extra__._abc_negative_cache = value
-        _gorg(self)._abc_generic_negative_cache = value
+        else:
+            _gorg(self)._abc_generic_negative_cache = value
 
     @property
     def _abc_negative_cache_version(self):
@@ -1096,7 +1097,8 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
     def _abc_negative_cache_version(self, value):
         if isinstance(self.__extra__, abc.ABCMeta):
             self.__extra__._abc_negative_cache_version = value
-        _gorg(self)._abc_generic_negative_cache_version = value
+        else:
+            _gorg(self)._abc_generic_negative_cache_version = value
 
     def _get_type_vars(self, tvars):
         if self.__origin__ and self.__parameters__:

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -1082,10 +1082,11 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
 
     @_abc_negative_cache.setter
     def _abc_negative_cache(self, value):
-        if isinstance(self.__extra__, abc.ABCMeta):
-            self.__extra__._abc_negative_cache = value
-        else:
-            _gorg(self)._abc_generic_negative_cache = value
+        if self.__origin__ is None:
+            if isinstance(self.__extra__, abc.ABCMeta):
+                self.__extra__._abc_negative_cache = value
+            else:
+                self._abc_generic_negative_cache = value
 
     @property
     def _abc_negative_cache_version(self):
@@ -1095,10 +1096,11 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
 
     @_abc_negative_cache_version.setter
     def _abc_negative_cache_version(self, value):
-        if isinstance(self.__extra__, abc.ABCMeta):
-            self.__extra__._abc_negative_cache_version = value
-        else:
-            _gorg(self)._abc_generic_negative_cache_version = value
+        if self.__origin__ is None:
+            if isinstance(self.__extra__, abc.ABCMeta):
+                self.__extra__._abc_negative_cache_version = value
+            else:
+                self._abc_generic_negative_cache_version = value
 
     def _get_type_vars(self, tvars):
         if self.__origin__ and self.__parameters__:

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -935,7 +935,7 @@ def _valid_for_check(cls):
                         "or instance checks" % cls)
     if (
         cls.__origin__ is not None and
-        sys._getframe(3).f_globals['__name__'] not in ['abc', 'functools']
+        sys._getframe(2).f_globals['__name__'] not in ['abc', 'functools']
     ):
         raise TypeError("Parameterized generics cannot be used with class "
                         "or instance checks")
@@ -951,7 +951,6 @@ def _make_subclasshook(cls):
         # Registered classes need not be checked here because
         # cls and its extra share the same _abc_registry.
         def __extrahook__(cls, subclass):
-            _valid_for_check(cls)
             res = cls.__extra__.__subclasshook__(subclass)
             if res is not NotImplemented:
                 return res
@@ -966,7 +965,6 @@ def _make_subclasshook(cls):
     else:
         # For non-ABC extras we'll just call issubclass().
         def __extrahook__(cls, subclass):
-            _valid_for_check(cls)
             if cls.__extra__ and issubclass(subclass, cls.__extra__):
                 return True
             return NotImplemented
@@ -1044,6 +1042,7 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
         # remove bare Generic from bases if there are other generic bases
         if any(isinstance(b, GenericMeta) and b is not Generic for b in bases):
             bases = tuple(b for b in bases if b is not Generic)
+        namespace.update({'__origin__': origin, '__extra__': extra})
         self = super(GenericMeta, cls).__new__(cls, name, bases, namespace)
 
         self.__parameters__ = tvars
@@ -1052,8 +1051,6 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
         self.__args__ = tuple(Ellipsis if a is _TypingEllipsis else
                               () if a is _TypingEmpty else
                               a for a in args) if args else None
-        self.__origin__ = origin
-        self.__extra__ = extra
         # Speed hack (https://github.com/python/typing/issues/196).
         self.__next_in_mro__ = _next_in_mro(self)
         # Preserve base classes on subclassing (__bases__ are type erased now).
@@ -1081,6 +1078,38 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
         super(GenericMeta, self).__init__(*args, **kwargs)
         if isinstance(self.__extra__, abc.ABCMeta):
             self._abc_registry = self.__extra__._abc_registry
+            self._abc_cache = self.__extra__._abc_cache
+        elif self.__origin__ is not None:
+            self._abc_registry = self.__origin__._abc_registry
+            self._abc_cache = self.__origin__._abc_cache
+
+    # _abc_negative_cache and _abc_negative_cache_version
+    # realised as descriptors, since GenClass[t1, t2, ...] always
+    # share subclass info with GenClass.
+    # This is an important memory optimization.
+    @property
+    def _abc_negative_cache(self):
+        if isinstance(self.__extra__, abc.ABCMeta):
+            return self.__extra__._abc_negative_cache
+        return _gorg(self)._abc_generic_negative_cache
+
+    @_abc_negative_cache.setter
+    def _abc_negative_cache(self, value):
+        if isinstance(self.__extra__, abc.ABCMeta):
+            self.__extra__._abc_negative_cache = value
+        _gorg(self)._abc_generic_negative_cache = value
+
+    @property
+    def _abc_negative_cache_version(self):
+        if isinstance(self.__extra__, abc.ABCMeta):
+            return self.__extra__._abc_negative_cache_version
+        return _gorg(self)._abc_generic_negative_cache_version
+
+    @_abc_negative_cache_version.setter
+    def _abc_negative_cache_version(self, value):
+        if isinstance(self.__extra__, abc.ABCMeta):
+            self.__extra__._abc_negative_cache_version = value
+        _gorg(self)._abc_generic_negative_cache_version = value
 
     def _get_type_vars(self, tvars):
         if self.__origin__ and self.__parameters__:
@@ -1179,6 +1208,10 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
                               origin=self,
                               extra=self.__extra__,
                               orig_bases=self.__orig_bases__)
+
+    def __subclasscheck__(self, cls):
+        _valid_for_check(self)
+        return super(GenericMeta, self).__subclasscheck__(cls)
 
     def __instancecheck__(self, instance):
         # Since we extend ABC.__subclasscheck__ and

--- a/src/typing.py
+++ b/src/typing.py
@@ -1011,7 +1011,8 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
     def _abc_negative_cache(self, value):
         if isinstance(self.__extra__, abc.ABCMeta):
             self.__extra__._abc_negative_cache = value
-        _gorg(self)._abc_generic_negative_cache = value
+        else:
+            _gorg(self)._abc_generic_negative_cache = value
 
     @property
     def _abc_negative_cache_version(self):
@@ -1023,7 +1024,8 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
     def _abc_negative_cache_version(self, value):
         if isinstance(self.__extra__, abc.ABCMeta):
             self.__extra__._abc_negative_cache_version = value
-        _gorg(self)._abc_generic_negative_cache_version = value
+        else:
+            _gorg(self)._abc_generic_negative_cache_version = value
 
     def _get_type_vars(self, tvars):
         if self.__origin__ and self.__parameters__:

--- a/src/typing.py
+++ b/src/typing.py
@@ -849,19 +849,6 @@ def _next_in_mro(cls):
     return next_in_mro
 
 
-def _valid_for_check(cls):
-    """An internal helper to prohibit isinstance([1], List[str]) etc."""
-    if cls is Generic:
-        raise TypeError("Class %r cannot be used with class "
-                        "or instance checks" % cls)
-    if (
-        cls.__origin__ is not None and
-        sys._getframe(2).f_globals['__name__'] not in ['abc', 'functools']
-    ):
-        raise TypeError("Parameterized generics cannot be used with class "
-                        "or instance checks")
-
-
 def _make_subclasshook(cls):
     """Construct a __subclasshook__ callable that incorporates
     the associated __extra__ class in subclass checks performed
@@ -1137,7 +1124,14 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
                               orig_bases=self.__orig_bases__)
 
     def __subclasscheck__(self, cls):
-        _valid_for_check(self)
+        if self.__origin__ is not None:
+            if sys._getframe(1).f_globals['__name__'] not in ['abc', 'functools']:
+                raise TypeError("Parameterized generics cannot be used with class "
+                                "or instance checks")
+            return False
+        if self is Generic:
+            raise TypeError("Class %r cannot be used with class "
+                            "or instance checks" % self)
         return super().__subclasscheck__(cls)
 
     def __instancecheck__(self, instance):

--- a/src/typing.py
+++ b/src/typing.py
@@ -1000,6 +1000,9 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
         if isinstance(extra, abc.ABCMeta):
             self._abc_registry = extra._abc_registry
             self._abc_cache = extra._abc_cache
+        elif origin is not None:
+            self._abc_registry = _gorg(self)._abc_registry
+            self._abc_cache = _gorg(self)._abc_cache
 
         if origin and hasattr(origin, '__qualname__'):  # Fix for Python 3.2.
             self.__qualname__ = origin.__qualname__

--- a/src/typing.py
+++ b/src/typing.py
@@ -1019,6 +1019,7 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
         if isinstance(self.__extra__, abc.ABCMeta):
             return self.__extra__._abc_negative_cache
         return _gorg(self)._abc_generic_negative_cache
+
     @_abc_negative_cache.setter
     def _abc_negative_cache(self, value):
         if isinstance(self.__extra__, abc.ABCMeta):
@@ -1030,15 +1031,12 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
         if isinstance(self.__extra__, abc.ABCMeta):
             return self.__extra__._abc_negative_cache_version
         return _gorg(self)._abc_generic_negative_cache_version
+
     @_abc_negative_cache_version.setter
     def _abc_negative_cache_version(self, value):
         if isinstance(self.__extra__, abc.ABCMeta):
             self.__extra__._abc_negative_cache_version = value
         _gorg(self)._abc_generic_negative_cache_version = value
-
-    def __subclasscheck__(self, cls):
-        _valid_for_check(self)
-        return super().__subclasscheck__(cls)
 
     def _get_type_vars(self, tvars):
         if self.__origin__ and self.__parameters__:
@@ -1137,6 +1135,10 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
                               origin=self,
                               extra=self.__extra__,
                               orig_bases=self.__orig_bases__)
+
+    def __subclasscheck__(self, cls):
+        _valid_for_check(self)
+        return super().__subclasscheck__(cls)
 
     def __instancecheck__(self, instance):
         # Since we extend ABC.__subclasscheck__ and

--- a/src/typing.py
+++ b/src/typing.py
@@ -1001,8 +1001,8 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
             self._abc_registry = extra._abc_registry
             self._abc_cache = extra._abc_cache
         elif origin is not None:
-            self._abc_registry = _gorg(self)._abc_registry
-            self._abc_cache = _gorg(self)._abc_cache
+            self._abc_registry = origin._abc_registry
+            self._abc_cache = origin._abc_cache
 
         if origin and hasattr(origin, '__qualname__'):  # Fix for Python 3.2.
             self.__qualname__ = origin.__qualname__

--- a/src/typing.py
+++ b/src/typing.py
@@ -1009,10 +1009,11 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
 
     @_abc_negative_cache.setter
     def _abc_negative_cache(self, value):
-        if isinstance(self.__extra__, abc.ABCMeta):
-            self.__extra__._abc_negative_cache = value
-        else:
-            _gorg(self)._abc_generic_negative_cache = value
+        if self.__origin__ is None:
+            if isinstance(self.__extra__, abc.ABCMeta):
+                self.__extra__._abc_negative_cache = value
+            else:
+                self._abc_generic_negative_cache = value
 
     @property
     def _abc_negative_cache_version(self):
@@ -1022,10 +1023,11 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
 
     @_abc_negative_cache_version.setter
     def _abc_negative_cache_version(self, value):
-        if isinstance(self.__extra__, abc.ABCMeta):
-            self.__extra__._abc_negative_cache_version = value
-        else:
-            _gorg(self)._abc_generic_negative_cache_version = value
+        if self.__origin__ is None:
+            if isinstance(self.__extra__, abc.ABCMeta):
+                self.__extra__._abc_negative_cache_version = value
+            else:
+                self._abc_generic_negative_cache_version = value
 
     def _get_type_vars(self, tvars):
         if self.__origin__ and self.__parameters__:


### PR DESCRIPTION
Extensive use of ``isinstance`` with ABCs causes significant increase in memory consumption by generics, see https://mail.python.org/pipermail/python-dev/2017-January/147194.html

Here I make ``_abc_cache`` and friends shortcut to the type's ``__extra__`` or ``_gorg`` (using descriptors where necessary). This allows to reduce memory consumption up to 4x on a micro-benchmark simulating conditions described in the python-dev thread. (There is of course a speed penalty, but it seems to be minor).

@methane Please take a look.