### PR TITLE
Prepend bases on first subscription

### DIFF
--- a/python2/test_typing.py
+++ b/python2/test_typing.py
@@ -521,6 +521,7 @@ class GenericTests(BaseTestCase):
         Y[unicode]
         with self.assertRaises(TypeError):
             Y[unicode, unicode]
+        self.assertIsSubclass(SimpleMapping[str, int], SimpleMapping)
 
     def test_generic_errors(self):
         T = TypeVar('T')

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -1169,8 +1169,11 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
             _check_generic(self, params)
             tvars = _type_vars(params)
             args = params
+
+        gorg = _gorg(self)
+        prepend = (gorg,) if gorg not in self.__bases__ else ()
         return self.__class__(self.__name__,
-                              self.__bases__,
+                              prepend + self.__bases__,
                               dict(self.__dict__),
                               tvars=tvars,
                               args=args,

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -1170,8 +1170,7 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
             tvars = _type_vars(params)
             args = params
 
-        gorg = _gorg(self)
-        prepend = (gorg,) if gorg not in self.__bases__ else ()
+        prepend = (self,) if self.__origin__ is None else ()
         return self.__class__(self.__name__,
                               prepend + self.__bases__,
                               dict(self.__dict__),

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -552,6 +552,7 @@ class GenericTests(BaseTestCase):
         Y[str]
         with self.assertRaises(TypeError):
             Y[str, str]
+        self.assertIsSubclass(SimpleMapping[str, int], SimpleMapping)
 
     def test_generic_errors(self):
         T = TypeVar('T')

--- a/src/typing.py
+++ b/src/typing.py
@@ -1097,8 +1097,7 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
             tvars = _type_vars(params)
             args = params
 
-        gorg = _gorg(self)
-        prepend = (gorg,) if gorg not in self.__bases__ else ()
+        prepend = (self,) if self.__origin__ is None else ()
         return self.__class__(self.__name__,
                               prepend + self.__bases__,
                               _no_slots_copy(self.__dict__),

--- a/src/typing.py
+++ b/src/typing.py
@@ -1096,8 +1096,11 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
             _check_generic(self, params)
             tvars = _type_vars(params)
             args = params
+
+        gorg = _gorg(self)
+        prepend = (gorg,) if gorg not in self.__bases__ else ()
         return self.__class__(self.__name__,
-                              self.__bases__,
+                              prepend + self.__bases__,
                               _no_slots_copy(self.__dict__),
                               tvars=tvars,
                               args=args,


### PR DESCRIPTION
Fixes #385 
Fixes #384 

In previous versions of typing, ``__bases__`` on subscription where prepend with ``__origin__``, so that MRO of, e.g., ``Mapping[int, T][str]`` was:
```python
[Mapping[int, str], Mapping[int, T], Mapping, collections.abc.Mapping, ...]
```
This was removed for several reasons. However, now it looks like complete removal of such prepending was too radical, since now e.g. ``issublcass(Node[int], Node)`` returns ``False``. I believe such runtime check should be equivalent to ``issublcass(Node, Node)``, i.e., ``True``.

Here I propose to fix this by only prepending ``__bases__`` on *first* subscription, so that, e.g, ``Mapping[int, T][str].__mro__`` will be:
```python
[Mapping[int, str], Mapping, collections.abc.Mapping, ...]
```

This PR also fixes an ambiguity when using ``typing`` ABCs with ``singledispatch()``.