### PR TITLE
Treat subscripted generics as "proxies" for original class.

### DIFF
--- a/python2/test_typing.py
+++ b/python2/test_typing.py
@@ -642,6 +642,33 @@ class GenericTests(BaseTestCase):
         c.bar = 'abc'
         self.assertEqual(c.__dict__, {'bar': 'abc'})
 
+    def test_subscripted_generics_as_proxies(self):
+        T = TypeVar('T')
+        class C(Generic[T]):
+            x = 'def'
+        self.assertEqual(C[int].x, 'def')
+        self.assertEqual(C[C[int]].x, 'def')
+        C[C[int]].x = 'changed'
+        self.assertEqual(C.x, 'changed')
+        self.assertEqual(C[str].x, 'changed')
+        C[List[str]].z = 'new'
+        self.assertEqual(C.z, 'new')
+        self.assertEqual(C[Tuple[int]].z, 'new')
+
+        self.assertEqual(C().x, 'changed')
+        self.assertEqual(C[Tuple[str]]().z, 'new')
+
+        class D(C[T]):
+            pass
+        self.assertEqual(D[int].x, 'changed')
+        self.assertEqual(D.z, 'new')
+        D.z = 'from derived z'
+        D[int].x = 'from derived x'
+        self.assertEqual(C.x, 'changed')
+        self.assertEqual(C[int].z, 'new')
+        self.assertEqual(D.x, 'from derived x')
+        self.assertEqual(D[str].z, 'from derived z')
+
     def test_false_subclasses(self):
         class MyMapping(MutableMapping[str, str]): pass
         self.assertNotIsInstance({}, MyMapping)

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -1243,6 +1243,13 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
                               self.__parameters__, self.__args__, self.__origin__,
                               self.__extra__, self.__orig_bases__)
 
+    def __setattr__(self, attr, value):
+        # We consider all the subscripted genrics as proxies for original class
+        if attr.startswith('__') and attr.endswith('__'):
+            type.__setattr__(self, attr, value)
+        else:
+            type.__setattr__(_gorg(self), attr, value)
+
 
 # Prevent checks for Generic to crash when defining Generic.
 Generic = None

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -1246,9 +1246,9 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
     def __setattr__(self, attr, value):
         # We consider all the subscripted genrics as proxies for original class
         if attr.startswith('__') and attr.endswith('__'):
-            type.__setattr__(self, attr, value)
+            super(GenericMeta, self).__setattr__(attr, value)
         else:
-            type.__setattr__(_gorg(self), attr, value)
+            super(GenericMeta, _gorg(self)).__setattr__(attr, value)
 
 
 # Prevent checks for Generic to crash when defining Generic.

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -674,6 +674,33 @@ class GenericTests(BaseTestCase):
         c.bar = 'abc'
         self.assertEqual(c.__dict__, {'bar': 'abc'})
 
+    def test_subscripted_generics_as_proxies(self):
+        T = TypeVar('T')
+        class C(Generic[T]):
+            x = 'def'
+        self.assertEqual(C[int].x, 'def')
+        self.assertEqual(C[C[int]].x, 'def')
+        C[C[int]].x = 'changed'
+        self.assertEqual(C.x, 'changed')
+        self.assertEqual(C[str].x, 'changed')
+        C[List[str]].z = 'new'
+        self.assertEqual(C.z, 'new')
+        self.assertEqual(C[Tuple[int]].z, 'new')
+
+        self.assertEqual(C().x, 'changed')
+        self.assertEqual(C[Tuple[str]]().z, 'new')
+
+        class D(C[T]):
+            pass
+        self.assertEqual(D[int].x, 'changed')
+        self.assertEqual(D.z, 'new')
+        D.z = 'from derived z'
+        D[int].x = 'from derived x'
+        self.assertEqual(C.x, 'changed')
+        self.assertEqual(C[int].z, 'new')
+        self.assertEqual(D.x, 'from derived x')
+        self.assertEqual(D[str].z, 'from derived z')
+
     def test_false_subclasses(self):
         class MyMapping(MutableMapping[str, str]): pass
         self.assertNotIsInstance({}, MyMapping)

--- a/src/typing.py
+++ b/src/typing.py
@@ -1161,9 +1161,9 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
     def __setattr__(self, attr, value):
         # We consider all the subscripted genrics as proxies for original class
         if attr.startswith('__') and attr.endswith('__'):
-            type.__setattr__(self, attr, value)
+            super(GenericMeta, self).__setattr__(attr, value)
         else:
-            type.__setattr__(_gorg(self), attr, value)
+            super(GenericMeta, _gorg(self)).__setattr__(attr, value)
 
 
 # Prevent checks for Generic to crash when defining Generic.

--- a/src/typing.py
+++ b/src/typing.py
@@ -1158,6 +1158,12 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
                               self.__parameters__, self.__args__, self.__origin__,
                               self.__extra__, self.__orig_bases__)
 
+    def __setattr__(self, attr, value):
+        if attr.startswith('__') and attr.endswith('__'):
+            type.__setattr__(self, attr, value)
+        else:
+            type.__setattr__(_gorg(self), attr, value)
+
 
 # Prevent checks for Generic to crash when defining Generic.
 Generic = None

--- a/src/typing.py
+++ b/src/typing.py
@@ -1159,6 +1159,7 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
                               self.__extra__, self.__orig_bases__)
 
     def __setattr__(self, attr, value):
+        # We consider all the subscripted genrics as proxies for original class
         if attr.startswith('__') and attr.endswith('__'):
             type.__setattr__(self, attr, value)
         else:


### PR DESCRIPTION
Fixes #392 

As noted by @JukkaL, conceptually, subscripting generic classes should not create independent class objects (type should be erased at runtime). In particular, class variables should be shared between subscripted generics and original class.

Here I implement this semantics using a custom ``__setattr__``.

@gvanrossum There is a question (assuming we agree that this is needed) whether this should go in 3.6.1 that has "feature freeze" in less than a week, or should we postpone this until 3.6.2?