### PR TITLE
Prevent ABC registry from being wiped out by new __setattr__

### DIFF
--- a/python2/test_typing.py
+++ b/python2/test_typing.py
@@ -669,6 +669,14 @@ class GenericTests(BaseTestCase):
         self.assertEqual(D.x, 'from derived x')
         self.assertEqual(D[str].z, 'from derived z')
 
+    def test_abc_registry_kept(self):
+        T = TypeVar('T')
+        class C(Generic[T]): pass
+        C.register(int)
+        self.assertIsInstance(1, C)
+        C[int]
+        self.assertIsInstance(1, C)
+
     def test_false_subclasses(self):
         class MyMapping(MutableMapping[str, str]): pass
         self.assertNotIsInstance({}, MyMapping)

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -1245,7 +1245,10 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
 
     def __setattr__(self, attr, value):
         # We consider all the subscripted genrics as proxies for original class
-        if attr.startswith('__') and attr.endswith('__'):
+        if (
+            attr.startswith('__') and attr.endswith('__') or
+            attr.startswith('_abc_')
+        ):
             super(GenericMeta, self).__setattr__(attr, value)
         else:
             super(GenericMeta, _gorg(self)).__setattr__(attr, value)

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -701,6 +701,14 @@ class GenericTests(BaseTestCase):
         self.assertEqual(D.x, 'from derived x')
         self.assertEqual(D[str].z, 'from derived z')
 
+    def test_abc_registry_kept(self):
+        T = TypeVar('T')
+        class C(Generic[T]): ...
+        C.register(int)
+        self.assertIsInstance(1, C)
+        C[int]
+        self.assertIsInstance(1, C)
+
     def test_false_subclasses(self):
         class MyMapping(MutableMapping[str, str]): pass
         self.assertNotIsInstance({}, MyMapping)

--- a/src/typing.py
+++ b/src/typing.py
@@ -1160,7 +1160,10 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
 
     def __setattr__(self, attr, value):
         # We consider all the subscripted genrics as proxies for original class
-        if attr.startswith('__') and attr.endswith('__'):
+        if (
+            attr.startswith('__') and attr.endswith('__') or
+            attr.startswith('_abc_')
+        ):
             super(GenericMeta, self).__setattr__(attr, value)
         else:
             super(GenericMeta, _gorg(self)).__setattr__(attr, value)


### PR DESCRIPTION
This fixes a bug that unfortunately sneaked into #393 