### PR TITLE
Add NoReturn type

### DIFF
--- a/python2/test_typing.py
+++ b/python2/test_typing.py
@@ -125,15 +125,9 @@ class NoReturnTests(BaseTestCase):
     def test_repr(self):
         self.assertEqual(repr(NoReturn), 'typing.NoReturn')
 
-    def test_errors(self):
+    def test_not_generic(self):
         with self.assertRaises(TypeError):
             NoReturn[int]
-        with self.assertRaises(TypeError):
-            List[NoReturn]
-        with self.assertRaises(TypeError):
-            Union[int, NoReturn]
-        with self.assertRaises(TypeError):
-            Callable[..., NoReturn]
 
     def test_cannot_subclass(self):
         with self.assertRaises(TypeError):

--- a/python2/test_typing.py
+++ b/python2/test_typing.py
@@ -7,7 +7,7 @@ import sys
 from unittest import TestCase, main, SkipTest
 from copy import copy, deepcopy
 
-from typing import Any
+from typing import Any, NoReturn
 from typing import TypeVar, AnyStr
 from typing import T, KT, VT  # Not in __all__.
 from typing import Union, Optional
@@ -108,6 +108,46 @@ class AnyTests(BaseTestCase):
         typing.Match[Any]
         typing.Pattern[Any]
         typing.IO[Any]
+
+
+class NoReturnTests(BaseTestCase):
+
+    def test_noreturn_instance_type_error(self):
+        with self.assertRaises(TypeError):
+            isinstance(42, NoReturn)
+
+    def test_noreturn_subclass_type_error(self):
+        with self.assertRaises(TypeError):
+            issubclass(Employee, NoReturn)
+        with self.assertRaises(TypeError):
+            issubclass(NoReturn, Employee)
+
+    def test_repr(self):
+        self.assertEqual(repr(NoReturn), 'typing.NoReturn')
+
+    def test_errors(self):
+        with self.assertRaises(TypeError):
+            NoReturn[int]
+        with self.assertRaises(TypeError):
+            List[NoReturn]
+        with self.assertRaises(TypeError):
+            Union[int, NoReturn]
+        with self.assertRaises(TypeError):
+            Callable[..., NoReturn]
+
+    def test_cannot_subclass(self):
+        with self.assertRaises(TypeError):
+            class A(NoReturn):
+                pass
+        with self.assertRaises(TypeError):
+            class A(type(NoReturn)):
+                pass
+
+    def test_cannot_instantiate(self):
+        with self.assertRaises(TypeError):
+            NoReturn()
+        with self.assertRaises(TypeError):
+            type(NoReturn)()
 
 
 class TypeVarTests(BaseTestCase):

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -347,8 +347,7 @@ def _type_check(arg, msg):
     if isinstance(arg, basestring):
         arg = _ForwardRef(arg)
     if (
-        isinstance(arg, _TypingBase) and
-        type(arg).__name__ in ('_ClassVar', '_NoReturn') or
+        isinstance(arg, _TypingBase) and type(arg).__name__ == '_ClassVar' or
         not isinstance(arg, (type, _TypingBase)) and not callable(arg)
     ):
         raise TypeError(msg + " Got %.100r." % (arg,))
@@ -498,7 +497,7 @@ class _NoReturn(_FinalTypingBase):
           raise Exception('no way')
 
     This type is invalid in other positions, e.g., ``List[NoReturn]``
-    will fail at runtime.
+    will fail in static type checkers.
     """
     __metaclass__ = NoReturnMeta
     __slots__ = ()

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -6,7 +6,7 @@ import sys
 from unittest import TestCase, main, skipUnless, SkipTest
 from copy import copy, deepcopy
 
-from typing import Any
+from typing import Any, NoReturn
 from typing import TypeVar, AnyStr
 from typing import T, KT, VT  # Not in __all__.
 from typing import Union, Optional
@@ -111,6 +111,46 @@ class AnyTests(BaseTestCase):
         typing.Match[Any]
         typing.Pattern[Any]
         typing.IO[Any]
+
+
+class NoReturnTests(BaseTestCase):
+
+    def test_noreturn_instance_type_error(self):
+        with self.assertRaises(TypeError):
+            isinstance(42, NoReturn)
+
+    def test_noreturn_subclass_type_error(self):
+        with self.assertRaises(TypeError):
+            issubclass(Employee, NoReturn)
+        with self.assertRaises(TypeError):
+            issubclass(NoReturn, Employee)
+
+    def test_repr(self):
+        self.assertEqual(repr(NoReturn), 'typing.NoReturn')
+
+    def test_errors(self):
+        with self.assertRaises(TypeError):
+            NoReturn[int]
+        with self.assertRaises(TypeError):
+            List[NoReturn]
+        with self.assertRaises(TypeError):
+            Union[int, NoReturn]
+        with self.assertRaises(TypeError):
+            Callable[..., NoReturn]
+
+    def test_cannot_subclass(self):
+        with self.assertRaises(TypeError):
+            class A(NoReturn):
+                pass
+        with self.assertRaises(TypeError):
+            class A(type(NoReturn)):
+                pass
+
+    def test_cannot_instantiate(self):
+        with self.assertRaises(TypeError):
+            NoReturn()
+        with self.assertRaises(TypeError):
+            type(NoReturn)()
 
 
 class TypeVarTests(BaseTestCase):

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -128,15 +128,9 @@ class NoReturnTests(BaseTestCase):
     def test_repr(self):
         self.assertEqual(repr(NoReturn), 'typing.NoReturn')
 
-    def test_errors(self):
+    def test_not_generic(self):
         with self.assertRaises(TypeError):
             NoReturn[int]
-        with self.assertRaises(TypeError):
-            List[NoReturn]
-        with self.assertRaises(TypeError):
-            Union[int, NoReturn]
-        with self.assertRaises(TypeError):
-            Callable[..., NoReturn]
 
     def test_cannot_subclass(self):
         with self.assertRaises(TypeError):

--- a/src/typing.py
+++ b/src/typing.py
@@ -363,8 +363,7 @@ def _type_check(arg, msg):
     if isinstance(arg, str):
         arg = _ForwardRef(arg)
     if (
-        isinstance(arg, _TypingBase) and
-        type(arg).__name__ in ('_ClassVar', '_NoReturn') or
+        isinstance(arg, _TypingBase) and type(arg).__name__ == '_ClassVar' or
         not isinstance(arg, (type, _TypingBase)) and not callable(arg)
     ):
         raise TypeError(msg + " Got %.100r." % (arg,))
@@ -431,7 +430,7 @@ class _NoReturn(_FinalTypingBase, _root=True):
           raise Exception('no way')
 
     This type is invalid in other positions, e.g., ``List[NoReturn]``
-    will fail at runtime.
+    will fail in static type checkers.
     """
 
     __slots__ = ()

--- a/src/typing.py
+++ b/src/typing.py
@@ -363,7 +363,8 @@ def _type_check(arg, msg):
     if isinstance(arg, str):
         arg = _ForwardRef(arg)
     if (
-        isinstance(arg, _TypingBase) and type(arg).__name__ == '_ClassVar' or
+        isinstance(arg, _TypingBase) and
+        type(arg).__name__ in ('_ClassVar', '_NoReturn') or
         not isinstance(arg, (type, _TypingBase)) and not callable(arg)
     ):
         raise TypeError(msg + " Got %.100r." % (arg,))
@@ -418,6 +419,31 @@ class _Any(_FinalTypingBase, _root=True):
 
 
 Any = _Any(_root=True)
+
+
+class _NoReturn(_FinalTypingBase, _root=True):
+    """Special type indicating functions that never return.
+    Example::
+
+      from typing import NoReturn
+
+      def stop() -> NoReturn:
+          raise Exception('no way')
+
+    This type is invalid in other positions, e.g., ``List[NoReturn]``
+    will fail at runtime.
+    """
+
+    __slots__ = ()
+
+    def __instancecheck__(self, obj):
+        raise TypeError("NoReturn cannot be used with isinstance().")
+
+    def __subclasscheck__(self, cls):
+        raise TypeError("NoReturn cannot be used with issubclass().")
+
+
+NoReturn = _NoReturn(_root=True)
 
 
 class TypeVar(_TypingBase, _root=True):


### PR DESCRIPTION
Fixes #165 

Note that here I prohibit ``List[NoReturn]``, but maybe we should allow this in order to allow ``Union[int, NoReturn]`` and/or ``Callable[..., NoReturn]`` (or make exceptions for the latter two).

As discussed in #165, this PR should wait until Python 3.6.1 is released.