### PR TITLE
Remove duplicate test in AnyTests

### DIFF
--- a/python2/test_typing.py
+++ b/python2/test_typing.py
@@ -99,10 +99,6 @@ class AnyTests(BaseTestCase):
         with self.assertRaises(TypeError):
             type(Any)()
 
-    def test_cannot_subscript(self):
-        with self.assertRaises(TypeError):
-            Any[int]
-
     def test_any_is_subclass(self):
         # These expressions must simply not fail.
         typing.Match[Any]

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -102,10 +102,6 @@ class AnyTests(BaseTestCase):
         with self.assertRaises(TypeError):
             type(Any)()
 
-    def test_cannot_subscript(self):
-        with self.assertRaises(TypeError):
-            Any[int]
-
     def test_any_works_with_alias(self):
         # These expressions must simply not fail.
         typing.Match[Any]


### PR DESCRIPTION
``test_cannot_subscript`` duplicates part of ``test_errors``.