### PR TITLE
Add missing mod_generics_cache.py to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,8 @@
 include LICENSE README.rst
 include src/typing.py
 include src/test_typing.py
+include src/mod_generics_cache.py
 include python2/typing.py
 include python2/test_typing.py
+include python2/test_typing.py
+include python2/mod_generics_cache.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,5 +4,4 @@ include src/test_typing.py
 include src/mod_generics_cache.py
 include python2/typing.py
 include python2/test_typing.py
-include python2/test_typing.py
 include python2/mod_generics_cache.py


### PR DESCRIPTION
This is needed for `python setup.py test` to work on the source distribution.

In the `3.6.1` release package that one test (`test_generic_hashes`) fails now on Pythons < 3.6.1. I don't think it's urgent enough to release 3.6.1.1 right away, but it would be nice to have this fixed for the next release.