### PR TITLE
Prohibit '_source' as a method name in NamedTuple

### DIFF
--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -2303,6 +2303,14 @@ class XMethBad(NamedTuple):
         return 'no chance for this'
 """)
 
+        with self.assertRaises(AttributeError):
+            exec("""
+class XMethBad2(NamedTuple):
+    x: int
+    def _source(self):
+        return 'no chance for this as well'
+""")
+
     @skipUnless(PY36, 'Python 3.6 required')
     def test_namedtuple_keyword_usage(self):
         LocalEmployee = NamedTuple("LocalEmployee", name=str, age=int)

--- a/src/typing.py
+++ b/src/typing.py
@@ -2076,7 +2076,7 @@ _PY36 = sys.version_info[:2] >= (3, 6)
 # attributes prohibited to set in NamedTuple class syntax
 _prohibited = ('__new__', '__init__', '__slots__', '__getnewargs__',
                '_fields', '_field_defaults', '_field_types',
-               '_make', '_replace', '_asdict')
+               '_make', '_replace', '_asdict', '_source')
 
 _special = ('__module__', '__name__', '__qualname__', '__annotations__')
 


### PR DESCRIPTION
``_source`` is a special attribute of ``collections.namedtuple``, we should prohibit shadowing it by a method defined in a subclass of ``typing.NamedTuple``.