### PR TITLE
Add missing classes to __all__

### DIFF
--- a/python2/test_typing.py
+++ b/python2/test_typing.py
@@ -1838,6 +1838,8 @@ class AllTests(BaseTestCase):
         self.assertNotIn('sys', a)
         # Check that Text is defined.
         self.assertIn('Text', a)
+        # Check previously missing class.
+        self.assertIn('SupportsComplex', a)
 
     def test_respect_no_type_check(self):
         @typing.no_type_check

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -49,6 +49,7 @@ __all__ = [
     # Structural checks, a.k.a. protocols.
     'Reversible',
     'SupportsAbs',
+    'SupportsComplex',
     'SupportsFloat',
     'SupportsInt',
 

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -2458,6 +2458,9 @@ class AllTests(BaseTestCase):
         self.assertNotIn('sys', a)
         # Check that Text is defined.
         self.assertIn('Text', a)
+        # Check previously missing classes.
+        self.assertIn('SupportsBytes', a)
+        self.assertIn('SupportsComplex', a)
 
 
 if __name__ == '__main__':

--- a/src/typing.py
+++ b/src/typing.py
@@ -63,6 +63,8 @@ __all__ = [
     # Structural checks, a.k.a. protocols.
     'Reversible',
     'SupportsAbs',
+    'SupportsBytes',
+    'SupportsComplex',
     'SupportsFloat',
     'SupportsInt',
     'SupportsRound',


### PR DESCRIPTION
``SupportsComplex`` and ``SupportsBytes`` were previously missing in ``__all__`` (only one of them in Python 2 version). This PR fixes this (I suppose there is no reason to exclude them from ``__all__``).