### PR TITLE
Extendable NamedTuples

### DIFF
--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -1616,11 +1616,11 @@ class Base2(NamedTuple):
     def method2(self):
         return self.z
 
-class Derived1(Base1):
+class Derived1(Base1, NamedTuple):
     '''Named tuples can have doctrings.'''
     label: str
 
-class Derived2(Base2, Base1):
+class Derived2(Base2, Base1, NamedTuple):
     pass
 
 class TwoDefaults(NamedTuple):
@@ -2317,12 +2317,12 @@ class NonDefaultAfterDefault(NamedTuple):
 """)
         with self.assertRaises(TypeError):
             exec("""
-class BadMerged(Base1, Base2):
+class BadMerged(Base1, Base2, NamedTuple):
     pass
 """)
         with self.assertRaises(TypeError):
             exec("""
-class BadExtended(Base2):
+class BadExtended(Base2, NamedTuple):
     label: str
 """)
 

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -2332,9 +2332,9 @@ class BadExtended(Base2, NamedTuple):
         self.assertEqual(XMeth(42).x, XMeth(42)[0])
         self.assertEqual(str(XRepr(42)), '42 -> 1')
         self.assertEqual(XRepr(1, 2) + XRepr(3), 0)
-        self.assertEqual(Derived1(1, 2, 'test').meth1(), 3)
-        self.assertEqual(Derived2(3, 4).meth1(), 7)
-        self.assertEqual(Derived2(3, 4, 5).meth2(), 5)
+        self.assertEqual(Derived1(1, 2, 'test').method1(), 3)
+        self.assertEqual(Derived2(3, 4).method1(), 7)
+        self.assertEqual(Derived2(3, 4, 5).method2(), 5)
 
         with self.assertRaises(AttributeError):
             exec("""

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -1608,20 +1608,17 @@ class XRepr(NamedTuple):
 class Base1(NamedTuple):
     x: int
     y: int
-    def method1(self):
-        return self.x + self.y
 
 class Base2(NamedTuple):
     z: int = 0
-    def method2(self):
-        return self.z
 
 class Derived1(Base1, NamedTuple):
     '''Named tuples can have doctrings.'''
     label: str
 
 class Derived2(Base2, Base1, NamedTuple):
-    pass
+    def method(self):
+        return self.x + self.y
 
 class TwoDefaults(NamedTuple):
     x: int = 0
@@ -2332,9 +2329,8 @@ class BadExtended(Base2, NamedTuple):
         self.assertEqual(XMeth(42).x, XMeth(42)[0])
         self.assertEqual(str(XRepr(42)), '42 -> 1')
         self.assertEqual(XRepr(1, 2) + XRepr(3), 0)
-        self.assertEqual(Derived1(1, 2, 'test').method1(), 3)
-        self.assertEqual(Derived2(3, 4).method1(), 7)
-        self.assertEqual(Derived2(3, 4, 5).method2(), 5)
+        self.assertEqual(Derived2(1, 2).method(), 3)
+        self.assertEqual(Derived2(3, 4, 5).method(), 7)
 
         with self.assertRaises(AttributeError):
             exec("""

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -1634,7 +1634,7 @@ else:
     # fake names for the sake of static analysis
     ann_module = ann_module2 = ann_module3 = None
     A = B = CSub = G = CoolEmployee = CoolEmployeeWithDefault = object
-    XMeth = XRepr = NoneAndForward = object
+    XMeth = XRepr = NoneAndForward = Derived1 = Derived2 = TwoDefaults = object
 
 gth = get_type_hints
 

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -1604,6 +1604,28 @@ class XRepr(NamedTuple):
         return f'{self.x} -> {self.y}'
     def __add__(self, other):
         return 0
+
+class Base1(NamedTuple):
+    x: int
+    y: int
+    def method1(self):
+        return self.x + self.y
+
+class Base2(NamedTuple):
+    z: int = 0
+    def method2(self):
+        return self.z
+
+class Derived1(Base1):
+    '''Named tuples can have doctrings.'''
+    label: str
+
+class Derived2(Base2, Base1):
+    pass
+
+class TwoDefaults(NamedTuple):
+    x: int = 0
+    other: str = ''
 """
 
 if PY36:
@@ -2278,12 +2300,30 @@ class NamedTupleTests(BaseTestCase):
         self.assertEqual(CoolEmployeeWithDefault._fields, ('name', 'cool'))
         self.assertEqual(CoolEmployeeWithDefault._field_types, dict(name=str, cool=int))
         self.assertEqual(CoolEmployeeWithDefault._field_defaults, dict(cool=0))
+        self.assertEqual(TwoDefaults.__new__.__defaults__, (0, ''))
+        self.assertEqual(TwoDefaults().x, 0)
+        self.assertEqual(TwoDefaults().other, '')
+        self.assertEqual(TwoDefaults()[0], 0)
+        self.assertEqual(TwoDefaults()[1], '')
+        self.assertEqual(Derived2._fields, ('x', 'y', 'z'))
+        self.assertEqual(Derived2._field_types, dict(x=int, y=int, z=int))
+        self.assertEqual(Derived2._field_defaults, dict(z=0))
 
         with self.assertRaises(TypeError):
             exec("""
 class NonDefaultAfterDefault(NamedTuple):
     x: int = 3
     y: int
+""")
+        with self.assertRaises(TypeError):
+            exec("""
+class BadMerged(Base1, Base2):
+    pass
+""")
+        with self.assertRaises(TypeError):
+            exec("""
+class BadExtended(Base2):
+    label: str
 """)
 
     @skipUnless(PY36, 'Python 3.6 required')
@@ -2292,6 +2332,9 @@ class NonDefaultAfterDefault(NamedTuple):
         self.assertEqual(XMeth(42).x, XMeth(42)[0])
         self.assertEqual(str(XRepr(42)), '42 -> 1')
         self.assertEqual(XRepr(1, 2) + XRepr(3), 0)
+        self.assertEqual(Derived1(1, 2, 'test').meth1(), 3)
+        self.assertEqual(Derived2(3, 4).meth1(), 7)
+        self.assertEqual(Derived2(3, 4, 5).meth2(), 5)
 
         with self.assertRaises(AttributeError):
             exec("""
@@ -2308,6 +2351,42 @@ class XMethBad2(NamedTuple):
     def _source(self):
         return 'no chance for this as well'
 """)
+
+    @skipUnless(PY36, 'Python 3.6 required')
+    def test_namedtuple_extending(self):
+        example = Derived1(1, 2, 'test')
+        with self.assertRaises(TypeError):
+            Derived1('test')
+        self.assertIsInstance(example, Derived1)
+        self.assertIsInstance(example, tuple)
+        self.assertEqual(example.x, 1)
+        self.assertEqual(example.y, 2)
+        self.assertEqual(example.label, 'test')
+        self.assertEqual(Derived1.__name__, 'Derived1')
+        self.assertEqual(Derived1._fields, ('x', 'y', 'label'))
+        self.assertEqual(Derived1.__annotations__,
+                         collections.OrderedDict(x=int, y=int, label=str))
+        self.assertIs(Derived1._field_types, Derived1.__annotations__)
+
+    @skipUnless(PY36, 'Python 3.6 required')
+    def test_namedtuple_merging(self):
+        example = Derived2(1, 2)
+        example2 = Derived2(1, 2, 3)
+        with self.assertRaises(TypeError):
+            Derived2(1)
+        with self.assertRaises(TypeError):
+            Derived2(1, 2, 3, 4)
+        self.assertIsInstance(example, Derived2)
+        self.assertIsInstance(example, tuple)
+        self.assertEqual(example.x, 1)
+        self.assertEqual(example.y, 2)
+        self.assertEqual(example.z, 0)
+        self.assertEqual(example2.z, 3)
+        self.assertEqual(Derived2.__name__, 'Derived2')
+        self.assertEqual(Derived2._fields, ('x', 'y', 'z'))
+        self.assertEqual(Derived2.__annotations__,
+                         collections.OrderedDict(x=int, y=int, z=int))
+        self.assertIs(Derived2._field_types, Derived2.__annotations__)
 
     @skipUnless(PY36, 'Python 3.6 required')
     def test_namedtuple_keyword_usage(self):

--- a/src/typing.py
+++ b/src/typing.py
@@ -2113,7 +2113,7 @@ class NamedTupleMeta(type):
         if not _PY36:
             raise TypeError("Class syntax for NamedTuple is only supported"
                             " in Python 3.6+")
-        types = {}
+        types = collections.OrderedDict()
         defaults_ns = {}
         # merge field types and defaults in reversed order (matches how MRO works)
         for base in reversed(bases):
@@ -2123,7 +2123,7 @@ class NamedTupleMeta(type):
         types.update(ns.get('__annotations__', {}))
         defaults_ns.update(ns)
         nm_tpl = _make_nmtuple(typename, types.items())
-        defaults_dict = {}
+        defaults_dict = collections.OrderedDict()
         for field_name in types:
             if field_name in defaults_ns:
                 defaults_dict[field_name] = defaults_ns[field_name]

--- a/src/typing.py
+++ b/src/typing.py
@@ -2115,9 +2115,9 @@ class NamedTupleMeta(type):
                             " in Python 3.6+")
         types = collections.OrderedDict()
         defaults_ns = {}
-        # merge field types and defaults in reversed order (matches how MRO works)
+        # Merge field types and defaults in reverse order (similar to how MRO works).
         for base in reversed(bases):
-            if hasattr(base, '_field_types'):  # New style named tuple
+            if hasattr(base, '_field_types'):  # new style named tuple
                 types.update(base._field_types)
                 defaults_ns.update(base._field_defaults)
         types.update(ns.get('__annotations__', {}))
@@ -2134,7 +2134,7 @@ class NamedTupleMeta(type):
                                         default_names=', '.join(defaults_dict.keys())))
         nm_tpl.__new__.__defaults__ = tuple(defaults_dict.values())
         nm_tpl._field_defaults = defaults_dict
-        # update from user namespace without overriding special namedtuple attributes
+        # Update from user namespace without overriding special namedtuple attributes.
         for key in ns:
             if key in _prohibited:
                 raise AttributeError("Cannot overwrite NamedTuple attribute " + key)

--- a/src/typing.py
+++ b/src/typing.py
@@ -2113,21 +2113,26 @@ class NamedTupleMeta(type):
         if not _PY36:
             raise TypeError("Class syntax for NamedTuple is only supported"
                             " in Python 3.6+")
-        types = ns.get('__annotations__', {})
+        types = {}
+        defaults_ns = {}
+        # merge field types and defaults in reversed order (matches how MRO works)
+        for base in reversed(bases):
+            if isinstance(base, NamedTupleMeta):
+                types.update(getattr(base, '__annotations__', {}))
+                defaults_ns.update(base.__dict__)
+        types.update(ns.get('__annotations__', {}))
+        defaults_ns.update(ns)
         nm_tpl = _make_nmtuple(typename, types.items())
-        defaults = []
         defaults_dict = {}
         for field_name in types:
-            if field_name in ns:
-                default_value = ns[field_name]
-                defaults.append(default_value)
-                defaults_dict[field_name] = default_value
-            elif defaults:
+            if field_name in defaults_ns:
+                defaults_dict[field_name] = defaults_ns[field_name]
+            elif defaults_dict:
                 raise TypeError("Non-default namedtuple field {field_name} cannot "
                                 "follow default field(s) {default_names}"
                                 .format(field_name=field_name,
                                         default_names=', '.join(defaults_dict.keys())))
-        nm_tpl.__new__.__defaults__ = tuple(defaults)
+        nm_tpl.__new__.__defaults__ = tuple(defaults_dict.values())
         nm_tpl._field_defaults = defaults_dict
         # update from user namespace without overriding special namedtuple attributes
         for key in ns:

--- a/src/typing.py
+++ b/src/typing.py
@@ -2118,8 +2118,8 @@ class NamedTupleMeta(type):
         # merge field types and defaults in reversed order (matches how MRO works)
         for base in reversed(bases):
             if hasattr(base, '_field_types'):  # New style named tuple
-                types.update(getattr(base, '__annotations__', {}))
-                defaults_ns.update(base.__dict__)
+                types.update(base._field_types)
+                defaults_ns.update(base._field_defaults)
         types.update(ns.get('__annotations__', {}))
         defaults_ns.update(ns)
         nm_tpl = _make_nmtuple(typename, types.items())

--- a/src/typing.py
+++ b/src/typing.py
@@ -2117,7 +2117,7 @@ class NamedTupleMeta(type):
         defaults_ns = {}
         # merge field types and defaults in reversed order (matches how MRO works)
         for base in reversed(bases):
-            if isinstance(base, NamedTupleMeta):
+            if hasattr(base, '_field_types'):  # New style named tuple
                 types.update(getattr(base, '__annotations__', {}))
                 defaults_ns.update(base.__dict__)
         types.update(ns.get('__annotations__', {}))


### PR DESCRIPTION
Fixes #427 

There are three notes:

First, ``NamedTuple`` must be explicitly mentioned in the bases to get the desired behavior. This is necessary since ``typing.NamedTuple`` returns a plain ``collections.namedtuple``, so that one needs ``NamedTuple`` to invoke ``NamedTupleMeta``:
```python
class A(NamedTuple):
    x: int
    y: int
class B(A, NamedTuple):
    z: int
```

Second, in the case of multiple inheritance fields are collected in reversed order, since this is similar to how MRO works, so that this:
```python
class Point(NamedTuple):
    x: int
    y: int
class Label(NamedTuple):
    label: str
class LabeledPoint(Label, Point, NamedTuple):
    pass
```
is equivalent to
```python
class LabeledPoint(NamedTuple):
    x: int
    y: int
    label: str  # this comes last
```

Finally, user defined methods are not inherited for sub-namedtuples (since the resulting ``collections.namedtuple`` has only single base -- ``tuple``). This could be patched by manually recalculating the MRO, but then ``typing.NamedTuple`` becomes overly complicated.

In general, I propose this to be the _last_ feature of ``typing.NamedTuple``, named tuples are designed to be simple compact classes. I propose to direct all future feature requests to dataclasses.