### PR TITLE
Add AsyncContextManager generic class

### DIFF
--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -1552,6 +1552,12 @@ class AsyncIteratorWrapper(typing.AsyncIterator[T_a]):
             return data
         else:
             raise StopAsyncIteration
+
+class ACM:
+    async def __aenter__(self):
+        return self
+    async def __aexit__(self, etype, eval, tb):
+        return None
 """
 
 if ASYNCIO:
@@ -1562,7 +1568,7 @@ if ASYNCIO:
 else:
     # fake names for the sake of static analysis
     asyncio = None
-    AwaitableWrapper = AsyncIteratorWrapper = object
+    AwaitableWrapper = AsyncIteratorWrapper = ACM = object
 
 PY36 = sys.version_info[:2] >= (3, 6)
 
@@ -2164,6 +2170,19 @@ class OtherABCTests(BaseTestCase):
         cm = manager()
         self.assertIsInstance(cm, typing.ContextManager)
         self.assertNotIsInstance(42, typing.ContextManager)
+
+    @skipUnless(ASYNCIO, 'Python 3.5 required')
+    def test_async_contextmanager(self):
+        class NotACM:
+            pass
+        self.assertIsInstance(ACM(), typing.AsyncContextManager)
+        self.assertNotIsInstance(NotACM(), typing.AsyncContextManager)
+        @contextlib.contextmanager
+        def manager():
+            yield 42
+
+        cm = manager()
+        self.assertNotIsInstance(cm, typing.AsyncContextManager)
 
 
 class TypeTests(BaseTestCase):

--- a/src/typing.py
+++ b/src/typing.py
@@ -10,6 +10,7 @@ try:
     import collections.abc as collections_abc
 except ImportError:
     import collections as collections_abc  # Fallback for PY3.2.
+import _collections_abc  # Needed for private function _check_methods
 try:
     from types import WrapperDescriptorType, MethodWrapperType, MethodDescriptorType
 except ImportError:
@@ -1996,7 +1997,7 @@ class AsyncContextManager(Generic[T_co]):
     @classmethod
     def __subclasshook__(cls, C):
         if cls is AsyncContextManager:
-            return collections_abc._check_methods(C, "__aenter__", "__aexit__")
+            return _collections_abc._check_methods(C, "__aenter__", "__aexit__")
         return NotImplemented
 
 __all__.append('AsyncContextManager')

--- a/src/typing.py
+++ b/src/typing.py
@@ -10,7 +10,7 @@ try:
     import collections.abc as collections_abc
 except ImportError:
     import collections as collections_abc  # Fallback for PY3.2.
-if sys.version_info[:2] >= (3, 5):
+if sys.version_info[:2] >= (3, 6):
     import _collections_abc  # Needed for private function _check_methods # noqa
 try:
     from types import WrapperDescriptorType, MethodWrapperType, MethodDescriptorType
@@ -1994,11 +1994,15 @@ class AsyncContextManager(Generic[T_co]):
     @abc.abstractmethod
     async def __aexit__(self, exc_type, exc_value, traceback):
         return None
-
+    
     @classmethod
     def __subclasshook__(cls, C):
         if cls is AsyncContextManager:
-            return _collections_abc._check_methods(C, "__aenter__", "__aexit__")
+            if sys.version_info[:2] >= (3, 6):
+                return _collections_abc._check_methods(C, "__aenter__", "__aexit__")
+            if (any("__aenter__" in B.__dict__ for B in C.__mro__) and
+                    any("__aexit__" in B.__dict__ for B in C.__mro__)):
+                return True
         return NotImplemented
 
 __all__.append('AsyncContextManager')

--- a/src/typing.py
+++ b/src/typing.py
@@ -1994,7 +1994,7 @@ class AsyncContextManager(Generic[T_co]):
     @abc.abstractmethod
     async def __aexit__(self, exc_type, exc_value, traceback):
         return None
-    
+
     @classmethod
     def __subclasshook__(cls, C):
         if cls is AsyncContextManager:

--- a/src/typing.py
+++ b/src/typing.py
@@ -1976,7 +1976,8 @@ else:
 
 
 if hasattr(contextlib, 'AbstractAsyncContextManager'):
-    class AsyncContextManager(Generic[T_co], extra=contextlib.AbstractAsyncContextManager):
+    class AsyncContextManager(Generic[T_co],
+                              extra=contextlib.AbstractAsyncContextManager):
         __slots__ = ()
 
     __all__.append('AsyncContextManager')
@@ -1995,8 +1996,7 @@ class AsyncContextManager(Generic[T_co]):
     @classmethod
     def __subclasshook__(cls, C):
         if cls is AsyncContextManager:
-            return _collections_abc._check_methods(C, "__aenter__",
-                                                   "__aexit__")
+            return collections_abc._check_methods(C, "__aenter__", "__aexit__")
         return NotImplemented
 
 __all__.append('AsyncContextManager')

--- a/src/typing.py
+++ b/src/typing.py
@@ -10,7 +10,8 @@ try:
     import collections.abc as collections_abc
 except ImportError:
     import collections as collections_abc  # Fallback for PY3.2.
-import _collections_abc  # Needed for private function _check_methods
+if sys.version_info[:2] >= (3, 5):
+    import _collections_abc  # Needed for private function _check_methods # noqa
 try:
     from types import WrapperDescriptorType, MethodWrapperType, MethodDescriptorType
 except ImportError:


### PR DESCRIPTION
Asynchronous context managers are defined by PEP 492, but there is no corresponding generic abstract class in ``typing``. This PR adds it for Python 3.5+.