### PR TITLE
Bump version to 3.6.2 and use setuptools instead of distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,20 +2,20 @@
 # coding: utf-8
 
 import sys
-from distutils.core import setup
+from setuptools import setup
 
 if sys.version_info < (2, 7, 0) or (3, 0, 0) <= sys.version_info < (3, 3, 0):
     sys.stderr.write('ERROR: You need Python 2.7 or 3.3+ '
                      'to install the typing package.\n')
     exit(1)
 
-version = '3.6.1'
+version = '3.6.2'
 description = 'Type Hints for Python'
 long_description = '''\
 Typing -- Type Hints for Python
 
 This is a backport of the standard library typing module to Python
-versions older than 3.6.
+versions older than 3.5.
 
 Typing defines a standard notation for Python function and variable
 type annotations. The notation can be used for documenting code in a
@@ -35,8 +35,6 @@ classifiers = [
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3.3',
     'Programming Language :: Python :: 3.4',
-    'Programming Language :: Python :: 3.5',
-    'Programming Language :: Python :: 3.6',
     'Topic :: Software Development',
 ]
 
@@ -44,7 +42,7 @@ setup(name='typing',
       version=version,
       description=description,
       long_description=long_description,
-      author='Guido van Rossum, Jukka Lehtosalo, Łukasz Langa',
+      author='Guido van Rossum, Jukka Lehtosalo, Łukasz Langa, Ivan Levkivskyi',
       author_email='jukka.lehtosalo@iki.fi',
       url='https://docs.python.org/3/library/typing.html',
       license='PSF',


### PR DESCRIPTION
Also update metadata to remove compatibility with 3.5+, and add Ivan
to the list of authors.

This is the version I intend to release as typing 3.6.2, except that I just found there's a problem with the py3 wheel -- it is identical to the py2 wheel. I'll try to debug.

In a sense this fixes #450 (I intend to release from this branch but we'll also have to merge the PR to get setup.py fixed in master).