### PR TITLE
Make sure copy and deepcopy are returning same class

### DIFF
--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -1069,6 +1069,9 @@ class GenericTests(BaseTestCase):
         for t in things + [Any]:
             self.assertEqual(t, copy(t))
             self.assertEqual(t, deepcopy(t))
+            if sys.version_info >= (3, 3):
+                self.assertTrue(t is copy(t))
+                self.assertTrue(t is deepcopy(t))
 
     def test_weakref_all(self):
         T = TypeVar('T')

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -1071,7 +1071,7 @@ class GenericTests(BaseTestCase):
             self.assertEqual(t, deepcopy(t))
             if sys.version_info >= (3, 3):
                 # From copy module documentation:
-                # It does “copy” functions and classes (shallow and deeply), by returning
+                # It does "copy" functions and classes (shallow and deeply), by returning
                 # the original object unchanged; this is compatible with the way these
                 # are treated by the pickle module.
                 self.assertTrue(t is copy(t))

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -1070,6 +1070,10 @@ class GenericTests(BaseTestCase):
             self.assertEqual(t, copy(t))
             self.assertEqual(t, deepcopy(t))
             if sys.version_info >= (3, 3):
+                # From copy module documentation:
+                # It does “copy” functions and classes (shallow and deeply), by returning
+                # the original object unchanged; this is compatible with the way these
+                # are treated by the pickle module.
                 self.assertTrue(t is copy(t))
                 self.assertTrue(t is deepcopy(t))
 


### PR DESCRIPTION
This should hold on Python 3.3 and newer (it does not hold on 3.2 and 2.7).

From [documentation](https://docs.python.org/3/library/copy.html):

>  It does “copy” functions and classes (shallow and deeply), by returning the original object unchanged; this is compatible with the way these are treated by the pickle module.