### PR TITLE
Allow tuples to be used with isinstance().

### DIFF
--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -395,10 +395,37 @@ class TupleTests(BaseTestCase):
             pass
         self.assertTrue(issubclass(MyTuple, Tuple))
 
+    @skipUnless(sys.version_info < (3, 7), 'Tuples could not be used with '
+                                           'isinstance() until 3.7.')
     def test_tuple_instance_type_error(self):
         with self.assertRaises(TypeError):
             isinstance((0, 0), Tuple[int, int])
         self.assertIsInstance((0, 0), Tuple)
+
+    @skipUnless(sys.version_info >= (3, 7), 'Tuples can be used with '
+                                            'isinstance() since 3.7.')
+    def test_tuple_instance_type(self):
+        # Unparameterized tuples.
+        self.assertIsInstance((), Tuple)
+        self.assertIsInstance((1, 3, 3, 7), Tuple)
+
+        # Instances of parameterized tuples.
+        self.assertIsInstance((3), Tuple[int])
+        self.assertIsInstance(('foo', 'bar'), Tuple[str, Any])
+
+        # Not tuples at all.
+        self.assertNotIsInstance('foo', Tuple)
+        self.assertNotIsInstance(123, Tuple)
+
+        # Element count mismatch.
+        self.assertNotIsInstance((1,), Tuple[int, int])
+        self.assertNotIsInstance((1,2), Tuple[int])
+
+        # Element type mismatch.
+        self.assertNotIsInstance(('foo',), Tuple[int])
+        self.assertNotIsInstance((1, 'foo'), Tuple[int, int])
+        self.assertNotIsInstance((1, 'foo'), Tuple[Any, int])
+
 
     def test_repr(self):
         self.assertEqual(repr(Tuple), 'typing.Tuple')

--- a/src/typing.py
+++ b/src/typing.py
@@ -1260,10 +1260,17 @@ class TupleMeta(GenericMeta):
         return super().__getitem__(parameters)
 
     def __instancecheck__(self, obj):
-        if self.__args__ is None:
-            return isinstance(obj, tuple)
-        raise TypeError("Parameterized Tuple cannot be used "
-                        "with isinstance().")
+        # Check if the instance is a tuple.
+        if not isinstance(obj, tuple):
+            return False
+        # Check if the instance and type have the same number of elements.
+        if len(obj) != len(self.__args__):
+            return False
+        # Check each element's type.
+        for type, element in zip(self.__args__, obj):
+            if not isinstance(element, type):
+                return False
+        return True
 
     def __subclasscheck__(self, cls):
         if self.__args__ is None:

--- a/src/typing.py
+++ b/src/typing.py
@@ -1264,7 +1264,7 @@ class TupleMeta(GenericMeta):
         if not isinstance(obj, tuple):
             return False
         # Check if the instance and type have the same number of elements.
-        if len(obj) != len(self.__args__):
+        if len(obj) != (0 if self.__args__ is None else len(self.__args__)):
             return False
         # Check each element's type.
         for type, element in zip(self.__args__, obj):


### PR DESCRIPTION
While trying to use PyContracts in my code, I stumbled upon the problem that it uses `isinstance()` internally, but tuples' `__instancecheck()` implementation explicitly states that is not supported. I could not find information about this, so decided to submit a PR after manual testing worked locally.