### PR TITLE
Protocols in typing extensions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 python:
   - "nightly"
   - "3.7-dev"
+  - "3.6.2"
   - "3.6.1"
   - "3.6.0"
   - "3.5.3"

--- a/typing_extensions/README.rst
+++ b/typing_extensions/README.rst
@@ -17,7 +17,8 @@ able to take advantage of new types added to the ``typing`` module, such as
 
 The ``typing_extensions`` module contains both backports of these changes
 as well as experimental types that will eventually be added to the ``typing``
-module.
+module, such as ``Protocol`` (see PEP 544 for details about protocols and
+static duck typing).
 
 Users of other Python versions should continue to install and use
 use the ``typing`` module from PyPi instead of using this one unless
@@ -40,6 +41,8 @@ All Python versions:
 - ``NewType``
 - ``NoReturn``
 - ``overload`` (note that older versions of ``typing`` only let you use ``overload`` in stubs)
+- ``Protocol`` (except on Python 3.5.0)
+- ``runtime`` (except on Python 3.5.0)
 - ``Text``
 - ``Type``
 - ``TYPE_CHECKING``

--- a/typing_extensions/src_py2/test_typing_extensions.py
+++ b/typing_extensions/src_py2/test_typing_extensions.py
@@ -616,6 +616,13 @@ class ProtocolTests(BaseTestCase):
             class Concrete(Proto):
                 pass
 
+    def test_none_treated_correctly(self):
+        @runtime
+        class P(Protocol):
+            x = None  # type: int
+        class B(object): pass
+        self.assertNotIsInstance(B(), P)
+
     def test_protocols_pickleable(self):
         global P, CP  # pickle wants to reference the class by name
         T = typing.TypeVar('T')

--- a/typing_extensions/src_py2/test_typing_extensions.py
+++ b/typing_extensions/src_py2/test_typing_extensions.py
@@ -3,11 +3,12 @@ import os
 import abc
 import contextlib
 import collections
+import pickle
 from unittest import TestCase, main, skipUnless
 
 from typing_extensions import NoReturn, ClassVar
 from typing_extensions import ContextManager, Counter, Deque, DefaultDict
-from typing_extensions import NewType, overload
+from typing_extensions import NewType, overload, Protocol, runtime
 import typing
 import typing_extensions
 
@@ -209,6 +210,394 @@ class OverloadTests(BaseTestCase):
             pass
 
         blah()
+
+
+class ProtocolTests(BaseTestCase):
+
+    def test_basic_protocol(self):
+        @runtime
+        class P(Protocol):
+            def meth(self):
+                pass
+        class C(object): pass
+        class D(object):
+            def meth(self):
+                pass
+        self.assertIsSubclass(D, P)
+        self.assertIsInstance(D(), P)
+        self.assertNotIsSubclass(C, P)
+        self.assertNotIsInstance(C(), P)
+
+    def test_everything_implements_empty_protocol(self):
+        @runtime
+        class Empty(Protocol): pass
+        class C(object): pass
+        for thing in (object, type, tuple, C):
+            self.assertIsSubclass(thing, Empty)
+        for thing in (object(), 1, (), typing):
+            self.assertIsInstance(thing, Empty)
+
+    def test_no_inheritance_from_nominal(self):
+        class C(object): pass
+        class BP(Protocol): pass
+        with self.assertRaises(TypeError):
+            class P(C, Protocol):
+                pass
+        with self.assertRaises(TypeError):
+            class P(Protocol, C):
+                pass
+        with self.assertRaises(TypeError):
+            class P(BP, C, Protocol):
+                pass
+        class D(BP, C): pass
+        class E(C, BP): pass
+        self.assertNotIsInstance(D(), E)
+        self.assertNotIsInstance(E(), D)
+
+    def test_no_instantiation(self):
+        class P(Protocol): pass
+        with self.assertRaises(TypeError):
+            P()
+        class C(P): pass
+        self.assertIsInstance(C(), C)
+        T = typing.TypeVar('T')
+        class PG(Protocol[T]): pass
+        with self.assertRaises(TypeError):
+            PG()
+        with self.assertRaises(TypeError):
+            PG[int]()
+        with self.assertRaises(TypeError):
+            PG[T]()
+        class CG(PG[T]): pass
+        self.assertIsInstance(CG[int](), CG)
+
+    def test_cannot_instantiate_abstract(self):
+        @runtime
+        class P(Protocol):
+            @abc.abstractmethod
+            def ameth(self):
+                raise NotImplementedError
+        class B(P):
+            pass
+        class C(B):
+            def ameth(self):
+                return 26
+        with self.assertRaises(TypeError):
+            B()
+        self.assertIsInstance(C(), P)
+
+    def test_subprotocols_extending(self):
+        class P1(Protocol):
+            def meth1(self):
+                pass
+        @runtime
+        class P2(P1, Protocol):
+            def meth2(self):
+                pass
+        class C(object):
+            def meth1(self):
+                pass
+            def meth2(self):
+                pass
+        class C1(object):
+            def meth1(self):
+                pass
+        class C2(object):
+            def meth2(self):
+                pass
+        self.assertNotIsInstance(C1(), P2)
+        self.assertNotIsInstance(C2(), P2)
+        self.assertNotIsSubclass(C1, P2)
+        self.assertNotIsSubclass(C2, P2)
+        self.assertIsInstance(C(), P2)
+        self.assertIsSubclass(C, P2)
+
+    def test_subprotocols_merging(self):
+        class P1(Protocol):
+            def meth1(self):
+                pass
+        class P2(Protocol):
+            def meth2(self):
+                pass
+        @runtime
+        class P(P1, P2, Protocol):
+            pass
+        class C(object):
+            def meth1(self):
+                pass
+            def meth2(self):
+                pass
+        class C1(object):
+            def meth1(self):
+                pass
+        class C2(object):
+            def meth2(self):
+                pass
+        self.assertNotIsInstance(C1(), P)
+        self.assertNotIsInstance(C2(), P)
+        self.assertNotIsSubclass(C1, P)
+        self.assertNotIsSubclass(C2, P)
+        self.assertIsInstance(C(), P)
+        self.assertIsSubclass(C, P)
+
+    def test_protocols_issubclass(self):
+        T = typing.TypeVar('T')
+        @runtime
+        class P(Protocol):
+            x = 1
+        @runtime
+        class PG(Protocol[T]):
+            x = 1
+        class BadP(Protocol):
+            x = 1
+        class BadPG(Protocol[T]):
+            x = 1
+        class C(object):
+            x = 1
+        self.assertIsSubclass(C, P)
+        self.assertIsSubclass(C, PG)
+        self.assertIsSubclass(BadP, PG)
+        self.assertIsSubclass(PG[int], PG)
+        self.assertIsSubclass(BadPG[int], P)
+        self.assertIsSubclass(BadPG[T], PG)
+        with self.assertRaises(TypeError):
+            issubclass(C, PG[T])
+        with self.assertRaises(TypeError):
+            issubclass(C, PG[C])
+        with self.assertRaises(TypeError):
+            issubclass(C, BadP)
+        with self.assertRaises(TypeError):
+            issubclass(C, BadPG)
+        with self.assertRaises(TypeError):
+            issubclass(P, PG[T])
+        with self.assertRaises(TypeError):
+            issubclass(PG, PG[int])
+
+    def test_protocols_isinstance(self):
+        T = typing.TypeVar('T')
+        @runtime
+        class P(Protocol):
+            def meth(x): pass
+        @runtime
+        class PG(Protocol[T]):
+            def meth(x): pass
+        class BadP(Protocol):
+            def meth(x): pass
+        class BadPG(Protocol[T]):
+            def meth(x): pass
+        class C(object):
+            def meth(x): pass
+        self.assertIsInstance(C(), P)
+        self.assertIsInstance(C(), PG)
+        with self.assertRaises(TypeError):
+            isinstance(C(), PG[T])
+        with self.assertRaises(TypeError):
+            isinstance(C(), PG[C])
+        with self.assertRaises(TypeError):
+            isinstance(C(), BadP)
+        with self.assertRaises(TypeError):
+            isinstance(C(), BadPG)
+
+    def test_protocols_isinstance_init(self):
+        T = typing.TypeVar('T')
+        @runtime
+        class P(Protocol):
+            x = 1
+        @runtime
+        class PG(Protocol[T]):
+            x = 1
+        class C(object):
+            def __init__(self, x):
+                self.x = x
+        self.assertIsInstance(C(1), P)
+        self.assertIsInstance(C(1), PG)
+
+    def test_protocols_support_register(self):
+        @runtime
+        class P(Protocol):
+            x = 1
+        class PM(Protocol):
+            def meth(self): pass
+        class D(PM): pass
+        class C(object): pass
+        D.register(C)
+        P.register(C)
+        self.assertIsInstance(C(), P)
+        self.assertIsInstance(C(), D)
+
+    def test_none_blocks_implementation(self):
+        @runtime
+        class P(Protocol):
+            x = 1
+        class A(object):
+            x = 1
+        class B(A):
+            x = None
+        class C(object):
+            def __init__(self):
+                self.x = None
+        self.assertNotIsInstance(B(), P)
+        self.assertNotIsInstance(C(), P)
+
+    def test_non_protocol_subclasses(self):
+        class P(Protocol):
+            x = 1
+        @runtime
+        class PR(Protocol):
+            def meth(self): pass
+        class NonP(P):
+            x = 1
+        class NonPR(PR): pass
+        class C(object):
+            x = 1
+        class D(object):
+            def meth(self): pass
+        self.assertNotIsInstance(C(), NonP)
+        self.assertNotIsInstance(D(), NonPR)
+        self.assertNotIsSubclass(C, NonP)
+        self.assertNotIsSubclass(D, NonPR)
+        self.assertIsInstance(NonPR(), PR)
+        self.assertIsSubclass(NonPR, PR)
+
+    def test_custom_subclasshook(self):
+        class P(Protocol):
+            x = 1
+        class OKClass(object): pass
+        class BadClass(object):
+            x = 1
+        class C(P):
+            @classmethod
+            def __subclasshook__(cls, other):
+                return other.__name__.startswith("OK")
+        self.assertIsInstance(OKClass(), C)
+        self.assertNotIsInstance(BadClass(), C)
+        self.assertIsSubclass(OKClass, C)
+        self.assertNotIsSubclass(BadClass, C)
+
+    def test_defining_generic_protocols(self):
+        T = typing.TypeVar('T')
+        S = typing.TypeVar('S')
+        @runtime
+        class PR(Protocol[T, S]):
+            def meth(self): pass
+        class P(PR[int, T], Protocol[T]):
+            y = 1
+        self.assertIsSubclass(PR[int, T], PR)
+        self.assertIsSubclass(P[str], PR)
+        with self.assertRaises(TypeError):
+            PR[int]
+        with self.assertRaises(TypeError):
+            P[int, str]
+        with self.assertRaises(TypeError):
+            PR[int, 1]
+        with self.assertRaises(TypeError):
+            PR[int, ClassVar]
+        class C(PR[int, T]): pass
+        self.assertIsInstance(C[str](), C)
+
+    def test_init_called(self):
+        T = typing.TypeVar('T')
+        class P(Protocol[T]): pass
+        class C(P[T]):
+            def __init__(self):
+                self.test = 'OK'
+        self.assertEqual(C[int]().test, 'OK')
+
+    def test_protocols_bad_subscripts(self):
+        T = typing.TypeVar('T')
+        S = typing.TypeVar('S')
+        with self.assertRaises(TypeError):
+            class P(Protocol[T, T]): pass
+        with self.assertRaises(TypeError):
+            class P(Protocol[int]): pass
+        with self.assertRaises(TypeError):
+            class P(Protocol[T], Protocol[S]): pass
+        with self.assertRaises(TypeError):
+            class P(Protocol[T], typing.Mapping[T, S]): pass
+
+    def test_generic_protocols_repr(self):
+        T = typing.TypeVar('T')
+        S = typing.TypeVar('S')
+        class P(Protocol[T, S]): pass
+        self.assertTrue(repr(P).endswith('P'))
+        self.assertTrue(repr(P[T, S]).endswith('P[~T, ~S]'))
+        self.assertTrue(repr(P[int, str]).endswith('P[int, str]'))
+
+    def test_generic_protocols_eq(self):
+        T = typing.TypeVar('T')
+        S = typing.TypeVar('S')
+        class P(Protocol[T, S]): pass
+        self.assertEqual(P, P)
+        self.assertEqual(P[int, T], P[int, T])
+        self.assertEqual(P[T, T][typing.Tuple[T, S]][int, str],
+                         P[typing.Tuple[int, str], typing.Tuple[int, str]])
+
+    def test_generic_protocols_special_from_generic(self):
+        T = typing.TypeVar('T')
+        class P(Protocol[T]): pass
+        self.assertEqual(P.__parameters__, (T,))
+        self.assertIs(P.__args__, None)
+        self.assertIs(P.__origin__, None)
+        self.assertEqual(P[int].__parameters__, ())
+        self.assertEqual(P[int].__args__, (int,))
+        self.assertIs(P[int].__origin__, P)
+
+    def test_generic_protocols_special_from_protocol(self):
+        @runtime
+        class PR(Protocol):
+            x = 1
+        class P(Protocol):
+            def meth(self):
+                pass
+        T = typing.TypeVar('T')
+        class PG(Protocol[T]):
+            x = 1
+            def meth(self):
+                pass
+        self.assertTrue(P._is_protocol)
+        self.assertTrue(PR._is_protocol)
+        self.assertTrue(PG._is_protocol)
+        with self.assertRaises(AttributeError):
+            self.assertFalse(P._is_runtime_protocol)
+        self.assertTrue(PR._is_runtime_protocol)
+        self.assertTrue(PG[int]._is_protocol)
+        self.assertEqual(P._get_protocol_attrs(), {'meth'})
+        self.assertEqual(PR._get_protocol_attrs(), {'x'})
+        self.assertEqual(frozenset(PG._get_protocol_attrs()),
+                         frozenset({'x', 'meth'}))
+        self.assertEqual(frozenset(PG[int]._get_protocol_attrs()),
+                         frozenset({'x', 'meth'}))
+
+    def test_no_runtime_deco_on_nominal(self):
+        with self.assertRaises(TypeError):
+            @runtime
+            class C(object): pass
+
+    def test_protocols_pickleable(self):
+        global P, CP  # pickle wants to reference the class by name
+        T = typing.TypeVar('T')
+
+        @runtime
+        class P(Protocol[T]):
+            x = 1
+        class CP(P[int]):
+            pass
+
+        c = CP()
+        c.foo = 42
+        c.bar = 'abc'
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            z = pickle.dumps(c, proto)
+            x = pickle.loads(z)
+            self.assertEqual(x.foo, 42)
+            self.assertEqual(x.bar, 'abc')
+            self.assertEqual(x.x, 1)
+            self.assertEqual(x.__dict__, {'foo': 42, 'bar': 'abc'})
+            s = pickle.dumps(P)
+            D = pickle.loads(s)
+            class E(object):
+                x = 1
+            self.assertIsInstance(E(), D)
 
 
 class AllTests(BaseTestCase):

--- a/typing_extensions/src_py2/typing_extensions.py
+++ b/typing_extensions/src_py2/typing_extensions.py
@@ -109,7 +109,7 @@ def _collection_protocol(cls):
                                '_abcoll', 'abc'))
 
 
-class ProtocolMeta(GenericMeta):
+class _ProtocolMeta(GenericMeta):
     """Internal metaclass for Protocol.
 
     This exists so Protocol classes can be generic without deriving
@@ -134,7 +134,7 @@ class ProtocolMeta(GenericMeta):
                     if gvars is not None:
                         raise TypeError(
                             "Cannot inherit from Generic[...] or"
-                            " Protocol[...] multiple types.")
+                            " Protocol[...] multiple times.")
                     gvars = base.__parameters__
             if gvars is None:
                 gvars = tvars
@@ -181,10 +181,10 @@ class ProtocolMeta(GenericMeta):
         return self
 
     def __init__(cls, *args, **kwargs):
-        super(ProtocolMeta, cls).__init__(*args, **kwargs)
+        super(_ProtocolMeta, cls).__init__(*args, **kwargs)
         if not cls.__dict__.get('_is_protocol', None):
             cls._is_protocol = any(b is Protocol or
-                                   isinstance(b, ProtocolMeta) and
+                                   isinstance(b, _ProtocolMeta) and
                                    b.__origin__ is Protocol
                                    for b in cls.__bases__)
         if cls._is_protocol:
@@ -236,7 +236,7 @@ class ProtocolMeta(GenericMeta):
                 return False
             raise TypeError("Instance and class checks can only be used with"
                             " @runtime protocols")
-        return super(ProtocolMeta, self).__subclasscheck__(cls)
+        return super(_ProtocolMeta, self).__subclasscheck__(cls)
 
     def _get_protocol_attrs(self):
         attrs = set()
@@ -327,7 +327,7 @@ class Protocol(object):
     given attributes, ignoring their type signatures.
     """
 
-    __metaclass__ = ProtocolMeta
+    __metaclass__ = _ProtocolMeta
     __slots__ = ()
     _is_protocol = True
 
@@ -346,7 +346,7 @@ def runtime(cls):
     This allows a simple-minded structural check very similar to the
     one-offs in collections.abc such as Hashable.
     """
-    if not isinstance(cls, ProtocolMeta) or not cls._is_protocol:
+    if not isinstance(cls, _ProtocolMeta) or not cls._is_protocol:
         raise TypeError('@runtime can be only applied to protocol classes,'
                         ' got %r' % cls)
     cls._is_runtime_protocol = True

--- a/typing_extensions/src_py2/typing_extensions.py
+++ b/typing_extensions/src_py2/typing_extensions.py
@@ -15,8 +15,8 @@ from typing import (
 __all__ = [
     # Super-special typing primitives.
     'ClassVar',
-    'Type',
     'Protocol',
+    'Type',
 
     # Concrete collection types.
     'ContextManager',
@@ -97,26 +97,13 @@ else:
 
 
 def _gorg(cls):
-    """This function exists for compatibility with old typing versions"""
+    """This function exists for compatibility with old typing versions."""
     assert isinstance(cls, GenericMeta)
     if hasattr(cls, '_gorg'):
         return cls._gorg
     while cls.__origin__ is not None:
         cls = cls.__origin__
     return cls
-
-
-def _collection_protocol(cls):
-    # Selected set of collections ABCs that are considered protocols.
-    name = cls.__name__
-    return (name in ('ABC', 'Callable', 'Awaitable',
-                     'Iterable', 'Iterator', 'AsyncIterable', 'AsyncIterator',
-                     'Hashable', 'Sized', 'Container', 'Collection', 'Reversible',
-                     'Sequence', 'MutableSequence', 'Mapping', 'MutableMapping',
-                     'AbstractContextManager', 'ContextManager',
-                     'AbstractAsyncContextManager', 'AsyncContextManager',) and
-            cls.__module__ in ('collections.abc', 'typing', 'contextlib',
-                               '_abcoll', 'abc'))
 
 
 class _ProtocolMeta(GenericMeta):
@@ -197,8 +184,7 @@ class _ProtocolMeta(GenericMeta):
             for base in cls.__mro__[1:]:
                 if not (base in (object, Generic, Callable) or
                         isinstance(base, TypingMeta) and base._is_protocol or
-                        isinstance(base, GenericMeta) and base.__origin__ is Generic or
-                        _collection_protocol(base)):
+                        isinstance(base, GenericMeta) and base.__origin__ is Generic):
                     raise TypeError('Protocols can only inherit from other protocols,'
                                     ' got %r' % base)
 
@@ -211,7 +197,8 @@ class _ProtocolMeta(GenericMeta):
             if not cls.__dict__.get('_is_protocol', None):
                 return NotImplemented
             if not isinstance(other, type):
-                # Same error as for issubclass(1, int)
+                # Similar error as for issubclass(1, int)
+                # (also not a chance for old-style classes)
                 raise TypeError('issubclass() arg 1 must be a new-style class')
             for attr in cls._get_protocol_attrs():
                 for base in other.__mro__:
@@ -262,8 +249,7 @@ class _ProtocolMeta(GenericMeta):
                         '__orig_bases__', '__extra__', '__tree_hash__',
                         '__doc__', '__subclasshook__', '__init__', '__new__',
                         '__module__', '_MutableMapping__marker',
-                        '__metaclass__', '_gorg') and
-                        getattr(base, attr, object()) is not None):
+                        '__metaclass__', '_gorg')):
                     attrs.add(attr)
         return attrs
 

--- a/typing_extensions/src_py2/typing_extensions.py
+++ b/typing_extensions/src_py2/typing_extensions.py
@@ -189,6 +189,7 @@ class _ProtocolMeta(GenericMeta):
                                     ' got %r' % base)
             cls._callable_members_only = all(callable(getattr(cls, attr))
                                              for attr in cls._get_protocol_attrs())
+
             def _no_init(self, *args, **kwargs):
                 if type(self)._is_protocol:
                     raise TypeError('Protocols cannot be instantiated')
@@ -226,7 +227,8 @@ class _ProtocolMeta(GenericMeta):
             return True
         if self._is_protocol:
             if all(hasattr(instance, attr) and
-                    (not callable(getattr(self, attr)) or getattr(instance, attr) is not None)
+                    (not callable(getattr(self, attr)) or
+                     getattr(instance, attr) is not None)
                     for attr in self._get_protocol_attrs()):
                 return True
         return super(GenericMeta, self).__instancecheck__(instance)
@@ -242,7 +244,8 @@ class _ProtocolMeta(GenericMeta):
                 not self._callable_members_only):
             if sys._getframe(1).f_globals['__name__'] in ['abc', 'functools']:
                 return super(GenericMeta, self).__subclasscheck__(cls)
-            raise TypeError("Protocols with non-method members don't support issubclass()")
+            raise TypeError("Protocols with non-method members"
+                            " don't support issubclass()")
         return super(_ProtocolMeta, self).__subclasscheck__(cls)
 
     def _get_protocol_attrs(self):

--- a/typing_extensions/src_py2/typing_extensions.py
+++ b/typing_extensions/src_py2/typing_extensions.py
@@ -1,10 +1,14 @@
 import abc
-import collections
+import sys
 import typing
 from typing import (
-    ClassVar, Type,
-    Counter, DefaultDict, Deque,
+    ClassVar, Type, Generic, Callable, GenericMeta, TypingMeta,
+    Counter, DefaultDict, Deque, TypeVar, Tuple,
     NewType, overload, Text, TYPE_CHECKING,
+    # We use internal typing helpers here, but this significantly reduces
+    # code duplication. (Also this is only until Protocol is in typing.)
+    _generic_new, _type_vars, _next_in_mro, _tp_cache, _type_check,
+    _TypingEllipsis, _TypingEmpty, _make_subclasshook, _check_generic
 )
 
 # Please keep __all__ alphabetized within each category.
@@ -12,6 +16,7 @@ __all__ = [
     # Super-special typing primitives.
     'ClassVar',
     'Type',
+    'Protocol',
 
     # Concrete collection types.
     'ContextManager',
@@ -22,6 +27,7 @@ __all__ = [
     # One-off things.
     'NewType',
     'overload',
+    'runtime',
     'Text',
     'TYPE_CHECKING',
 ]
@@ -89,3 +95,259 @@ else:
                     return True
             return NotImplemented
 
+
+def _collection_protocol(cls):
+    # Selected set of collections ABCs that are considered protocols.
+    name = cls.__name__
+    return (name in ('ABC', 'Callable', 'Awaitable',
+                     'Iterable', 'Iterator', 'AsyncIterable', 'AsyncIterator',
+                     'Hashable', 'Sized', 'Container', 'Collection', 'Reversible',
+                     'Sequence', 'MutableSequence', 'Mapping', 'MutableMapping',
+                     'AbstractContextManager', 'ContextManager',
+                     'AbstractAsyncContextManager', 'AsyncContextManager',) and
+            cls.__module__ in ('collections.abc', 'typing', 'contextlib',
+                               '_abcoll', 'abc'))
+
+
+class ProtocolMeta(GenericMeta):
+    """Internal metaclass for Protocol.
+
+    This exists so Protocol classes can be generic without deriving
+    from Generic.
+    """
+
+    def __new__(cls, name, bases, namespace,
+                tvars=None, args=None, origin=None, extra=None, orig_bases=None):
+        # This is just a version copied from GenericMeta.__new__ that
+        # includes "Protocol" special treatment. (Comments removed for brevity.)
+        if tvars is not None:
+            assert origin is not None
+            assert all(isinstance(t, TypeVar) for t in tvars), tvars
+        else:
+            tvars = _type_vars(bases)
+            gvars = None
+            for base in bases:
+                if base is Generic:
+                    raise TypeError("Cannot inherit from plain Generic")
+                if (isinstance(base, GenericMeta) and
+                        base.__origin__ in (Generic, Protocol)):
+                    if gvars is not None:
+                        raise TypeError(
+                            "Cannot inherit from Generic[...] or"
+                            " Protocol[...] multiple types.")
+                    gvars = base.__parameters__
+            if gvars is None:
+                gvars = tvars
+            else:
+                tvarset = set(tvars)
+                gvarset = set(gvars)
+                if not tvarset <= gvarset:
+                    raise TypeError(
+                        "Some type variables (%s) "
+                        "are not listed in %s[%s]" %
+                        (", ".join(str(t) for t in tvars if t not in gvarset),
+                         "Generic" if any(b.__origin__ is Generic
+                                          for b in bases) else "Protocol",
+                         ", ".join(str(g) for g in gvars)))
+                tvars = gvars
+
+        initial_bases = bases
+        if extra is None:
+            extra = namespace.get('__extra__')
+        if extra is not None and type(extra) is abc.ABCMeta and extra not in bases:
+            bases = (extra,) + bases
+        bases = tuple(b._gorg if isinstance(b, GenericMeta) else b for b in bases)
+
+        if any(isinstance(b, GenericMeta) and b is not Generic for b in bases):
+            bases = tuple(b for b in bases if b is not Generic)
+        namespace.update({'__origin__': origin, '__extra__': extra})
+        self = abc.ABCMeta.__new__(cls, name, bases, namespace)
+        abc.ABCMeta.__setattr__(self, '_gorg', self if not origin else origin._gorg)
+
+        self.__parameters__ = tvars
+        self.__args__ = tuple(Ellipsis if a is _TypingEllipsis else
+                              () if a is _TypingEmpty else
+                              a for a in args) if args else None
+        self.__next_in_mro__ = _next_in_mro(self)
+        if orig_bases is None:
+            self.__orig_bases__ = initial_bases
+        if (
+            '__subclasshook__' not in namespace and extra or
+            getattr(self.__subclasshook__, '__name__', '') == '__extrahook__'
+        ):
+            self.__subclasshook__ = _make_subclasshook(self)
+        self.__tree_hash__ = (hash(self._subs_tree()) if origin else
+                              abc.ABCMeta.__hash__(self))
+        return self
+
+    def __init__(cls, *args, **kwargs):
+        super(ProtocolMeta, cls).__init__(*args, **kwargs)
+        if not cls.__dict__.get('_is_protocol', None):
+            cls._is_protocol = any(b is Protocol or
+                                   isinstance(b, ProtocolMeta) and
+                                   b.__origin__ is Protocol
+                                   for b in cls.__bases__)
+        if cls._is_protocol:
+            for base in cls.__mro__[1:]:
+                if not (base in (object, Generic, Callable) or
+                        isinstance(base, TypingMeta) and base._is_protocol or
+                        isinstance(base, GenericMeta) and base.__origin__ is Generic or
+                        _collection_protocol(base)):
+                    raise TypeError('Protocols can only inherit from other protocols,'
+                                    ' got %r' % base)
+
+            def _no_init(self, *args, **kwargs):
+                if type(self)._is_protocol:
+                    raise TypeError('Protocols cannot be instantiated')
+            cls.__init__ = _no_init
+
+        def _proto_hook(cls, other):
+            if not cls.__dict__.get('_is_protocol', None):
+                return NotImplemented
+            for attr in cls._get_protocol_attrs():
+                for base in other.__mro__:
+                    if attr in base.__dict__:
+                        if base.__dict__[attr] is None:
+                            return NotImplemented
+                        break
+                else:
+                    return NotImplemented
+            return True
+        if '__subclasshook__' not in cls.__dict__:
+            cls.__subclasshook__ = classmethod(_proto_hook)
+
+    def __instancecheck__(self, instance):
+        # We need this method for situations where attributes are assigned in __init__
+        if isinstance(instance, type):
+            # This looks like a fundamental limitation of Python 2.
+            # It cannot support runtime protocol metaclasses
+            return False
+        if issubclass(instance.__class__, self):
+            return True
+        if self._is_protocol:
+            return all(hasattr(instance, attr) and getattr(instance, attr) is not None
+                       for attr in self._get_protocol_attrs())
+        return False
+
+    def __subclasscheck__(self, cls):
+        if (self.__dict__.get('_is_protocol', None) and
+                not self.__dict__.get('_is_runtime_protocol', None)):
+            if sys._getframe(1).f_globals['__name__'] in ['abc', 'functools']:
+                return False
+            raise TypeError("Instance and class checks can only be used with"
+                            " @runtime protocols")
+        return super(ProtocolMeta, self).__subclasscheck__(cls)
+
+    def _get_protocol_attrs(self):
+        attrs = set()
+        for base in self.__mro__[:-1]:  # without object
+            if base.__name__ in ('Protocol', 'Generic'):
+                continue
+            annotations = getattr(base, '__annotations__', {})
+            for attr in list(base.__dict__.keys()) + list(annotations.keys()):
+                if (not attr.startswith('_abc_') and attr not in (
+                        '__abstractmethods__', '__annotations__', '__weakref__',
+                        '_is_protocol', '_is_runtime_protocol', '__dict__',
+                        '__args__', '__slots__', '_get_protocol_attrs',
+                        '__next_in_mro__', '__parameters__', '__origin__',
+                        '__orig_bases__', '__extra__', '__tree_hash__',
+                        '__doc__', '__subclasshook__', '__init__', '__new__',
+                        '__module__', '_MutableMapping__marker',
+                        '__metaclass__', '_gorg') and
+                        getattr(base, attr, object()) is not None):
+                    attrs.add(attr)
+        return attrs
+
+    @_tp_cache
+    def __getitem__(self, params):
+        # We also need to copy this from GenericMeta.__getitem__ to get
+        # special treatment of "Protocol". (Comments removed for brevity.)
+        if not isinstance(params, tuple):
+            params = (params,)
+        if not params and self._gorg is not Tuple:
+            raise TypeError(
+                "Parameter list to %s[...] cannot be empty" % self.__qualname__)
+        msg = "Parameters to generic types must be types."
+        params = tuple(_type_check(p, msg) for p in params)
+        if self in (Generic, Protocol):
+            if not all(isinstance(p, TypeVar) for p in params):
+                raise TypeError(
+                    "Parameters to %r[...] must all be type variables", self)
+            if len(set(params)) != len(params):
+                raise TypeError(
+                    "Parameters to %r[...] must all be unique", self)
+            tvars = params
+            args = params
+        elif self in (Tuple, Callable):
+            tvars = _type_vars(params)
+            args = params
+        elif self.__origin__ in (Generic, Protocol):
+            raise TypeError("Cannot subscript already-subscripted %s" %
+                            repr(self))
+        else:
+            _check_generic(self, params)
+            tvars = _type_vars(params)
+            args = params
+
+        prepend = (self,) if self.__origin__ is None else ()
+        return self.__class__(self.__name__,
+                              prepend + self.__bases__,
+                              dict(self.__dict__),
+                              tvars=tvars,
+                              args=args,
+                              origin=self,
+                              extra=self.__extra__,
+                              orig_bases=self.__orig_bases__)
+
+
+class Protocol(object):
+    """Base class for protocol classes. Protocol classes are defined as::
+
+      class Proto(Protocol[T]):
+          def meth(self):
+              # type: () -> int
+              ...
+
+    Such classes are primarily used with static type checkers that recognize
+    structural subtyping (static duck-typing), for example::
+
+      class C:
+          def meth(self):
+              # type: () -> int
+              return 0
+
+      def func(x):
+          # type: (Proto[int]) -> int
+          return x.meth()
+
+      func(C())  # Passes static type check
+
+    See PEP 544 for details. Protocol classes decorated with @typing_extensions.runtime
+    act as simple-minded runtime protocols that checks only the presence of
+    given attributes, ignoring their type signatures.
+    """
+
+    __metaclass__ = ProtocolMeta
+    __slots__ = ()
+    _is_protocol = True
+
+    def __new__(cls, *args, **kwds):
+        if cls._gorg is Protocol:
+            raise TypeError("Type Protocol cannot be instantiated; "
+                            "it can be used only as a base class")
+        return _generic_new(cls.__next_in_mro__, cls, *args, **kwds)
+
+
+def runtime(cls):
+    """Mark a protocol class as a runtime protocol, so that it
+    can be used with isinstance() and issubclass(). Raise TypeError
+    if applied to a non-protocol class.
+
+    This allows a simple-minded structural check very similar to the
+    one-offs in collections.abc such as Hashable.
+    """
+    if not isinstance(cls, ProtocolMeta) or not cls._is_protocol:
+        raise TypeError('@runtime can be only applied to protocol classes,'
+                        ' got %r' % cls)
+    cls._is_runtime_protocol = True
+    return cls

--- a/typing_extensions/src_py2/typing_extensions.py
+++ b/typing_extensions/src_py2/typing_extensions.py
@@ -216,7 +216,8 @@ class _ProtocolMeta(GenericMeta):
         # We need this method for situations where attributes are assigned in __init__
         if isinstance(instance, type):
             # This looks like a fundamental limitation of Python 2.
-            # It cannot support runtime protocol metaclasses
+            # It cannot support runtime protocol metaclasses, On Python 2 classes
+            # cannot be correctly inspected as instances of protocols.
             return False
         if issubclass(instance.__class__, self):
             return True
@@ -298,10 +299,10 @@ class _ProtocolMeta(GenericMeta):
 class Protocol(object):
     """Base class for protocol classes. Protocol classes are defined as::
 
-      class Proto(Protocol[T]):
+      class Proto(Protocol):
           def meth(self):
               # type: () -> int
-              ...
+              pass
 
     Such classes are primarily used with static type checkers that recognize
     structural subtyping (static duck-typing), for example::
@@ -312,7 +313,7 @@ class Protocol(object):
               return 0
 
       def func(x):
-          # type: (Proto[int]) -> int
+          # type: (Proto) -> int
           return x.meth()
 
       func(C())  # Passes static type check
@@ -320,6 +321,13 @@ class Protocol(object):
     See PEP 544 for details. Protocol classes decorated with @typing_extensions.runtime
     act as simple-minded runtime protocols that checks only the presence of
     given attributes, ignoring their type signatures.
+
+    Protocol classes can be generic, they are defined as::
+
+      class GenProto(Protocol[T]):
+          def meth(self):
+              # type: () -> T
+              pass
     """
 
     __metaclass__ = _ProtocolMeta

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -58,7 +58,7 @@ ASYNCIO = sys.version_info[:2] >= (3, 5)
 PY36 = sys.version_info[:2] >= (3, 6)
 
 # Protocols are hard to backport to the original version of typing 3.5.0
-NO_PROTOCOL = sys.version_info[:3] == (3, 5, 0)
+HAVE_PROTOCOLS = sys.version_info[:3] != (3, 5, 0)
 
 
 class BaseTestCase(TestCase):
@@ -1188,7 +1188,7 @@ class ProtocolTests(BaseTestCase):
             self.assertIsInstance(E(), D)
 
 
-if NO_PROTOCOL:
+if not HAVE_PROTOCOLS:
     ProtocolTests = None
 
 

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -928,7 +928,7 @@ class ProtocolTests(BaseTestCase):
         self.assertIsInstance(C(), P)
         self.assertIsInstance(C(), D)
 
-    def test_none_on_class_blocks_implementation(self):
+    def test_none_on_non_callable_doesnt_block_implementation(self):
         @runtime
         class P(Protocol):
             x = 1
@@ -941,6 +941,20 @@ class ProtocolTests(BaseTestCase):
                 self.x = None
         self.assertIsInstance(B(), P)
         self.assertIsInstance(C(), P)
+
+    def test_none_on_callable_blocks_implementation(self):
+        @runtime
+        class P(Protocol):
+            def x(self): ...
+        class A:
+            def x(self): ...
+        class B(A):
+            x = None
+        class C:
+            def __init__(self):
+                self.x = None
+        self.assertNotIsInstance(B(), P)
+        self.assertNotIsInstance(C(), P)
 
     def test_non_protocol_subclasses(self):
         class P(Protocol):
@@ -1132,6 +1146,20 @@ class ProtocolTests(BaseTestCase):
             x = None  # type: int
         class B(object): pass
         self.assertNotIsInstance(B(), P)
+        class C:
+            x = 1
+        class D:
+            x = None
+        self.assertIsInstance(C(), P)
+        self.assertIsInstance(D(), P)
+        class CI:
+            def __init__(self):
+                self.x = 1
+        class DI:
+            def __init__(self):
+                self.x = None
+        self.assertIsInstance(C(), P)
+        self.assertIsInstance(D(), P)
 
     def test_protocols_pickleable(self):
         global P, CP  # pickle wants to reference the class by name

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -792,16 +792,16 @@ class ProtocolTests(BaseTestCase):
         T = TypeVar('T')
         @runtime
         class P(Protocol):
-            x = 1
+            def x(self): ...
         @runtime
         class PG(Protocol[T]):
-            x = 1
+            def x(self): ...
         class BadP(Protocol):
-            x = 1
+            def x(self): ...
         class BadPG(Protocol[T]):
-            x = 1
+            def x(self): ...
         class C:
-            x = 1
+            def x(self): ...
         self.assertIsSubclass(C, P)
         self.assertIsSubclass(C, PG)
         self.assertIsSubclass(BadP, PG)
@@ -821,24 +821,19 @@ class ProtocolTests(BaseTestCase):
         with self.assertRaises(TypeError):
             issubclass(PG, PG[int])
 
-    @skipUnless(PY36, 'Python 3.6 required')
-    def test_protocols_issubclass_py36(self):
-        class OtherPoint:
+    def test_protocols_issubclass_non_callable(self):
+        class C:
             x = 1
-            y = 2
-            label = 'other'
-        class Bad: pass
-        self.assertNotIsSubclass(MyPoint, Point)
-        self.assertIsSubclass(OtherPoint, Point)
-        self.assertNotIsSubclass(Bad, Point)
-        self.assertNotIsSubclass(MyPoint, Position)
-        self.assertIsSubclass(OtherPoint, Position)
-        self.assertIsSubclass(Concrete, Proto)
-        self.assertIsSubclass(Other, Proto)
-        self.assertNotIsSubclass(Concrete, Other)
-        self.assertNotIsSubclass(Other, Concrete)
-        self.assertIsSubclass(Point, Position)
-        self.assertIsSubclass(NT, Position)
+        @runtime
+        class PNonCall(Protocol):
+            x = 1
+        with self.assertRaises(TypeError):
+            issubclass(C, PNonCall)
+        self.assertIsInstance(C(), PNonCall)
+        PNonCall.register(C)
+        with self.assertRaises(TypeError):
+            issubclass(C, PNonCall)
+        self.assertIsInstance(C(), PNonCall)
 
     def test_protocols_isinstance(self):
         T = TypeVar('T')

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -1011,6 +1011,18 @@ class ProtocolTests(BaseTestCase):
             PR[int]
         with self.assertRaises(TypeError):
             PR[int, 1]
+        class P1(Protocol, Generic[T]):
+            def bar(self, x: T) -> str: ...
+        class P2(Generic[T], Protocol):
+            def bar(self, x: T) -> str: ...
+        @runtime
+        class PSub(P1[str], Protocol):
+            x = 1
+        class Test:
+            x = 1
+            def bar(self, x: str) -> str:
+                return x
+        self.assertIsInstance(Test(), PSub)
         if TYPING_3_5_3:
             with self.assertRaises(TypeError):
                 PR[int, ClassVar]

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -985,8 +985,9 @@ class ProtocolTests(BaseTestCase):
             P[int, str]
         with self.assertRaises(TypeError):
             PR[int, 1]
-        with self.assertRaises(TypeError):
-            PR[int, ClassVar]
+        if TYPING_3_5_3:
+            with self.assertRaises(TypeError):
+                PR[int, ClassVar]
         class C(PR[int, T]): pass
         self.assertIsInstance(C[str](), C)
 
@@ -1010,6 +1011,7 @@ class ProtocolTests(BaseTestCase):
         with self.assertRaises(TypeError):
             class P(typing.Mapping[T, S], Protocol[T]): pass
 
+    @skipUnless(TYPING_3_5_3, 'New style __repr__ and __eq__ only')
     def test_generic_protocols_repr(self):
         T = TypeVar('T')
         S = TypeVar('S')
@@ -1018,6 +1020,7 @@ class ProtocolTests(BaseTestCase):
         self.assertTrue(repr(P[T, S]).endswith('P[~T, ~S]'))
         self.assertTrue(repr(P[int, str]).endswith('P[int, str]'))
 
+    @skipUnless(TYPING_3_5_3, 'New style __repr__ and __eq__ only')
     def test_generic_protocols_eq(self):
         T = TypeVar('T')
         S = TypeVar('S')

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -928,7 +928,7 @@ class ProtocolTests(BaseTestCase):
         self.assertIsInstance(C(), P)
         self.assertIsInstance(C(), D)
 
-    def test_none_blocks_implementation(self):
+    def test_none_on_class_blocks_implementation(self):
         @runtime
         class P(Protocol):
             x = 1
@@ -939,8 +939,8 @@ class ProtocolTests(BaseTestCase):
         class C:
             def __init__(self):
                 self.x = None
-        self.assertNotIsInstance(B(), P)
-        self.assertNotIsInstance(C(), P)
+        self.assertIsInstance(B(), P)
+        self.assertIsInstance(C(), P)
 
     def test_non_protocol_subclasses(self):
         class P(Protocol):

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -1123,6 +1123,13 @@ class ProtocolTests(BaseTestCase):
             class Concrete(Proto):
                 pass
 
+    def test_none_treated_correctly(self):
+        @runtime
+        class P(Protocol):
+            x = None  # type: int
+        class B(object): pass
+        self.assertNotIsInstance(B(), P)
+
     def test_protocols_pickleable(self):
         global P, CP  # pickle wants to reference the class by name
         T = TypeVar('T')

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -57,8 +57,7 @@ ASYNCIO = sys.version_info[:2] >= (3, 5)
 # For checks reliant on Python 3.6 syntax changes (e.g. classvar)
 PY36 = sys.version_info[:2] >= (3, 6)
 
-# It is very difficult to backport Protocols to these versions due to
-# different generics system. See https://github.com/python/typing/pull/195
+# Protocols are hard to backport to the original version of typing 3.5.0
 NO_PROTOCOL = sys.version_info[:3] == (3, 5, 0)
 
 

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -974,6 +974,14 @@ class ProtocolTests(BaseTestCase):
         self.assertIsSubclass(OKClass, C)
         self.assertNotIsSubclass(BadClass, C)
 
+    def test_issubclass_fails_correctly(self):
+        @runtime
+        class P(Protocol):
+            x = 1
+        class C: pass
+        with self.assertRaises(TypeError):
+            issubclass(C(), P)
+
     @skipUnless(not OLD_GENERICS, "New style generics required")
     def test_defining_generic_protocols(self):
         T = TypeVar('T')
@@ -1108,6 +1116,12 @@ class ProtocolTests(BaseTestCase):
         with self.assertRaises(TypeError):
             @runtime
             class C: pass
+        class Proto(Protocol):
+            x = 1
+        with self.assertRaises(TypeError):
+            @runtime
+            class Concrete(Proto):
+                pass
 
     def test_protocols_pickleable(self):
         global P, CP  # pickle wants to reference the class by name

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -3,6 +3,7 @@ import os
 import abc
 import contextlib
 import collections
+import pickle
 from unittest import TestCase, main, skipUnless
 from typing import TypeVar, Optional
 from typing import T, KT, VT  # Not in __all__.
@@ -10,7 +11,7 @@ from typing import Tuple, List
 from typing import Generic
 from typing import get_type_hints
 from typing import no_type_check
-from typing_extensions import NoReturn, ClassVar, Type, NewType
+from typing_extensions import NoReturn, ClassVar, Type, NewType, Protocol, runtime
 import typing
 import typing_extensions
 import collections.abc as collections_abc
@@ -592,6 +593,498 @@ class NewTypeTests(BaseTestCase):
         with self.assertRaises(TypeError):
             class D(UserName):
                 pass
+
+
+PY36_PROTOCOL_TESTS = """
+class Coordinate(Protocol):
+    x: int
+    y: int
+
+@runtime
+class Point(Coordinate, Protocol):
+    label: str
+
+class MyPoint:
+    x: int
+    y: int
+    label: str
+
+class XAxis(Protocol):
+    x: int
+
+class YAxis(Protocol):
+    y: int
+
+@runtime
+class Position(XAxis, YAxis, Protocol):
+    pass
+
+@runtime
+class Proto(Protocol):
+    attr: int
+    def meth(self, arg: str) -> int:
+        ...
+
+class Concrete(Proto):
+    pass
+
+class Other:
+    attr: int = 1
+    def meth(self, arg: str) -> int:
+        if arg == 'this':
+            return 1
+        return 0
+
+class NT(NamedTuple):
+    x: int
+    y: int
+"""
+
+if PY36:
+    exec(PY36_PROTOCOL_TESTS)
+else:
+    # fake names for the sake of static analysis
+    Coordinate = Point = MyPoint = BadPoint = NT = object
+    XAxis = YAxis = Position = Proto = Concrete = Other = object
+
+
+class ProtocolTests(BaseTestCase):
+
+    def test_basic_protocol(self):
+        @runtime
+        class P(Protocol):
+            def meth(self):
+                pass
+        class C: pass
+        class D:
+            def meth(self):
+                pass
+        self.assertIsSubclass(D, P)
+        self.assertIsInstance(D(), P)
+        self.assertNotIsSubclass(C, P)
+        self.assertNotIsInstance(C(), P)
+
+    def test_everything_implements_empty_protocol(self):
+        @runtime
+        class Empty(Protocol): pass
+        class C: pass
+        for thing in (object, type, tuple, C):
+            self.assertIsSubclass(thing, Empty)
+        for thing in (object(), 1, (), typing):
+            self.assertIsInstance(thing, Empty)
+
+    def test_no_inheritance_from_nominal(self):
+        class C: pass
+        class BP(Protocol): pass
+        with self.assertRaises(TypeError):
+            class P(C, Protocol):
+                pass
+        with self.assertRaises(TypeError):
+            class P(Protocol, C):
+                pass
+        with self.assertRaises(TypeError):
+            class P(BP, C, Protocol):
+                pass
+        class D(BP, C): pass
+        class E(C, BP): pass
+        self.assertNotIsInstance(D(), E)
+        self.assertNotIsInstance(E(), D)
+
+    def test_no_instantiation(self):
+        class P(Protocol): pass
+        with self.assertRaises(TypeError):
+            P()
+        class C(P): pass
+        self.assertIsInstance(C(), C)
+        T = TypeVar('T')
+        class PG(Protocol[T]): pass
+        with self.assertRaises(TypeError):
+            PG()
+        with self.assertRaises(TypeError):
+            PG[int]()
+        with self.assertRaises(TypeError):
+            PG[T]()
+        class CG(PG[T]): pass
+        self.assertIsInstance(CG[int](), CG)
+
+    def test_cannot_instantiate_abstract(self):
+        @runtime
+        class P(Protocol):
+            @abc.abstractmethod
+            def ameth(self) -> int:
+                raise NotImplementedError
+        class B(P):
+            pass
+        class C(B):
+            def ameth(self) -> int:
+                return 26
+        with self.assertRaises(TypeError):
+            B()
+        self.assertIsInstance(C(), P)
+
+    def test_subprotocols_extending(self):
+        class P1(Protocol):
+            def meth1(self):
+                pass
+        @runtime
+        class P2(P1, Protocol):
+            def meth2(self):
+                pass
+        class C:
+            def meth1(self):
+                pass
+            def meth2(self):
+                pass
+        class C1:
+            def meth1(self):
+                pass
+        class C2:
+            def meth2(self):
+                pass
+        self.assertNotIsInstance(C1(), P2)
+        self.assertNotIsInstance(C2(), P2)
+        self.assertNotIsSubclass(C1, P2)
+        self.assertNotIsSubclass(C2, P2)
+        self.assertIsInstance(C(), P2)
+        self.assertIsSubclass(C, P2)
+
+    def test_subprotocols_merging(self):
+        class P1(Protocol):
+            def meth1(self):
+                pass
+        class P2(Protocol):
+            def meth2(self):
+                pass
+        @runtime
+        class P(P1, P2, Protocol):
+            pass
+        class C:
+            def meth1(self):
+                pass
+            def meth2(self):
+                pass
+        class C1:
+            def meth1(self):
+                pass
+        class C2:
+            def meth2(self):
+                pass
+        self.assertNotIsInstance(C1(), P)
+        self.assertNotIsInstance(C2(), P)
+        self.assertNotIsSubclass(C1, P)
+        self.assertNotIsSubclass(C2, P)
+        self.assertIsInstance(C(), P)
+        self.assertIsSubclass(C, P)
+
+    def test_protocols_issubclass(self):
+        T = TypeVar('T')
+        @runtime
+        class P(Protocol):
+            x = 1
+        @runtime
+        class PG(Protocol[T]):
+            x = 1
+        class BadP(Protocol):
+            x = 1
+        class BadPG(Protocol[T]):
+            x = 1
+        class C:
+            x = 1
+        self.assertIsSubclass(C, P)
+        self.assertIsSubclass(C, PG)
+        self.assertIsSubclass(BadP, PG)
+        self.assertIsSubclass(PG[int], PG)
+        self.assertIsSubclass(BadPG[int], P)
+        self.assertIsSubclass(BadPG[T], PG)
+        with self.assertRaises(TypeError):
+            issubclass(C, PG[T])
+        with self.assertRaises(TypeError):
+            issubclass(C, PG[C])
+        with self.assertRaises(TypeError):
+            issubclass(C, BadP)
+        with self.assertRaises(TypeError):
+            issubclass(C, BadPG)
+        with self.assertRaises(TypeError):
+            issubclass(P, PG[T])
+        with self.assertRaises(TypeError):
+            issubclass(PG, PG[int])
+
+    @skipUnless(PY36, 'Python 3.6 required')
+    def test_protocols_issubclass_py36(self):
+        class OtherPoint:
+            x = 1
+            y = 2
+            label = 'other'
+        class Bad: pass
+        self.assertNotIsSubclass(MyPoint, Point)
+        self.assertIsSubclass(OtherPoint, Point)
+        self.assertNotIsSubclass(Bad, Point)
+        self.assertNotIsSubclass(MyPoint, Position)
+        self.assertIsSubclass(OtherPoint, Position)
+        self.assertIsSubclass(Concrete, Proto)
+        self.assertIsSubclass(Other, Proto)
+        self.assertNotIsSubclass(Concrete, Other)
+        self.assertNotIsSubclass(Other, Concrete)
+        self.assertIsSubclass(Point, Position)
+        self.assertIsSubclass(NT, Position)
+
+    def test_protocols_isinstance(self):
+        T = TypeVar('T')
+        @runtime
+        class P(Protocol):
+            def meth(x): ...
+        @runtime
+        class PG(Protocol[T]):
+            def meth(x): ...
+        class BadP(Protocol):
+            def meth(x): ...
+        class BadPG(Protocol[T]):
+            def meth(x): ...
+        class C:
+            def meth(x): ...
+        self.assertIsInstance(C(), P)
+        self.assertIsInstance(C(), PG)
+        with self.assertRaises(TypeError):
+            isinstance(C(), PG[T])
+        with self.assertRaises(TypeError):
+            isinstance(C(), PG[C])
+        with self.assertRaises(TypeError):
+            isinstance(C(), BadP)
+        with self.assertRaises(TypeError):
+            isinstance(C(), BadPG)
+
+    @skipUnless(PY36, 'Python 3.6 required')
+    def test_protocols_isinstance_py36(self):
+        class APoint:
+            def __init__(self, x, y, label):
+                self.x = x
+                self.y = y
+                self.label = label
+        class BPoint:
+            label = 'B'
+            def __init__(self, x, y):
+                self.x = x
+                self.y = y
+        class C:
+            def __init__(self, attr):
+                self.attr = attr
+            def meth(self, arg):
+                return 0
+        class Bad: pass
+        self.assertIsInstance(APoint(1, 2, 'A'), Point)
+        self.assertIsInstance(BPoint(1, 2), Point)
+        self.assertNotIsInstance(MyPoint(), Point)
+        self.assertIsInstance(BPoint(1, 2), Position)
+        self.assertIsInstance(Other(), Proto)
+        self.assertIsInstance(Concrete(), Proto)
+        self.assertIsInstance(C(42), Proto)
+        self.assertNotIsInstance(Bad(), Proto)
+        self.assertNotIsInstance(Bad(), Point)
+        self.assertNotIsInstance(Bad(), Position)
+        self.assertNotIsInstance(Bad(), Concrete)
+        self.assertNotIsInstance(Other(), Concrete)
+        self.assertIsInstance(NT(1, 2), Position)
+
+    def test_protocols_isinstance_init(self):
+        T = TypeVar('T')
+        @runtime
+        class P(Protocol):
+            x = 1
+        @runtime
+        class PG(Protocol[T]):
+            x = 1
+        class C:
+            def __init__(self, x):
+                self.x = x
+        self.assertIsInstance(C(1), P)
+        self.assertIsInstance(C(1), PG)
+
+    def test_protocols_support_register(self):
+        @runtime
+        class P(Protocol):
+            x = 1
+        class PM(Protocol):
+            def meth(self): pass
+        class D(PM): pass
+        class C: pass
+        D.register(C)
+        P.register(C)
+        self.assertIsInstance(C(), P)
+        self.assertIsInstance(C(), D)
+
+    def test_none_blocks_implementation(self):
+        @runtime
+        class P(Protocol):
+            x = 1
+        class A:
+            x = 1
+        class B(A):
+            x = None
+        class C:
+            def __init__(self):
+                self.x = None
+        self.assertNotIsInstance(B(), P)
+        self.assertNotIsInstance(C(), P)
+
+    def test_non_protocol_subclasses(self):
+        class P(Protocol):
+            x = 1
+        @runtime
+        class PR(Protocol):
+            def meth(self): pass
+        class NonP(P):
+            x = 1
+        class NonPR(PR): pass
+        class C:
+            x = 1
+        class D:
+            def meth(self): pass
+        self.assertNotIsInstance(C(), NonP)
+        self.assertNotIsInstance(D(), NonPR)
+        self.assertNotIsSubclass(C, NonP)
+        self.assertNotIsSubclass(D, NonPR)
+        self.assertIsInstance(NonPR(), PR)
+        self.assertIsSubclass(NonPR, PR)
+
+    def test_custom_subclasshook(self):
+        class P(Protocol):
+            x = 1
+        class OKClass: pass
+        class BadClass:
+            x = 1
+        class C(P):
+            @classmethod
+            def __subclasshook__(cls, other):
+                return other.__name__.startswith("OK")
+        self.assertIsInstance(OKClass(), C)
+        self.assertNotIsInstance(BadClass(), C)
+        self.assertIsSubclass(OKClass, C)
+        self.assertNotIsSubclass(BadClass, C)
+
+    def test_defining_generic_protocols(self):
+        T = TypeVar('T')
+        S = TypeVar('S')
+        @runtime
+        class PR(Protocol[T, S]):
+            def meth(self): pass
+        class P(PR[int, T], Protocol[T]):
+            y = 1
+        self.assertIsSubclass(PR[int, T], PR)
+        self.assertIsSubclass(P[str], PR)
+        with self.assertRaises(TypeError):
+            PR[int]
+        with self.assertRaises(TypeError):
+            P[int, str]
+        with self.assertRaises(TypeError):
+            PR[int, 1]
+        with self.assertRaises(TypeError):
+            PR[int, ClassVar]
+        class C(PR[int, T]): pass
+        self.assertIsInstance(C[str](), C)
+
+    def test_init_called(self):
+        T = TypeVar('T')
+        class P(Protocol[T]): pass
+        class C(P[T]):
+            def __init__(self):
+                self.test = 'OK'
+        self.assertEqual(C[int]().test, 'OK')
+
+    def test_protocols_bad_subscripts(self):
+        T = TypeVar('T')
+        S = TypeVar('S')
+        with self.assertRaises(TypeError):
+            class P(Protocol[T, T]): pass
+        with self.assertRaises(TypeError):
+            class P(Protocol[int]): pass
+        with self.assertRaises(TypeError):
+            class P(Protocol[T], Protocol[S]): pass
+        with self.assertRaises(TypeError):
+            class P(typing.Mapping[T, S], Protocol[T]): pass
+
+    def test_generic_protocols_repr(self):
+        T = TypeVar('T')
+        S = TypeVar('S')
+        class P(Protocol[T, S]): pass
+        self.assertTrue(repr(P).endswith('P'))
+        self.assertTrue(repr(P[T, S]).endswith('P[~T, ~S]'))
+        self.assertTrue(repr(P[int, str]).endswith('P[int, str]'))
+
+    def test_generic_protocols_eq(self):
+        T = TypeVar('T')
+        S = TypeVar('S')
+        class P(Protocol[T, S]): pass
+        self.assertEqual(P, P)
+        self.assertEqual(P[int, T], P[int, T])
+        self.assertEqual(P[T, T][Tuple[T, S]][int, str],
+                         P[Tuple[int, str], Tuple[int, str]])
+
+    def test_generic_protocols_special_from_generic(self):
+        T = TypeVar('T')
+        class P(Protocol[T]): pass
+        self.assertEqual(P.__parameters__, (T,))
+        self.assertIs(P.__args__, None)
+        self.assertIs(P.__origin__, None)
+        self.assertEqual(P[int].__parameters__, ())
+        self.assertEqual(P[int].__args__, (int,))
+        self.assertIs(P[int].__origin__, P)
+
+    def test_generic_protocols_special_from_protocol(self):
+        @runtime
+        class PR(Protocol):
+            x = 1
+        class P(Protocol):
+            def meth(self):
+                pass
+        T = TypeVar('T')
+        class PG(Protocol[T]):
+            x = 1
+            def meth(self):
+                pass
+        self.assertTrue(P._is_protocol)
+        self.assertTrue(PR._is_protocol)
+        self.assertTrue(PG._is_protocol)
+        with self.assertRaises(AttributeError):
+            self.assertFalse(P._is_runtime_protocol)
+        self.assertTrue(PR._is_runtime_protocol)
+        self.assertTrue(PG[int]._is_protocol)
+        self.assertEqual(P._get_protocol_attrs(), {'meth'})
+        self.assertEqual(PR._get_protocol_attrs(), {'x'})
+        self.assertEqual(frozenset(PG._get_protocol_attrs()),
+                         frozenset({'x', 'meth'}))
+        self.assertEqual(frozenset(PG[int]._get_protocol_attrs()),
+                         frozenset({'x', 'meth'}))
+
+    def test_no_runtime_deco_on_nominal(self):
+        with self.assertRaises(TypeError):
+            @runtime
+            class C: pass
+
+    def test_protocols_pickleable(self):
+        global P, CP  # pickle wants to reference the class by name
+        T = TypeVar('T')
+
+        @runtime
+        class P(Protocol[T]):
+            x = 1
+        class CP(P[int]):
+            pass
+
+        c = CP()
+        c.foo = 42
+        c.bar = 'abc'
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            z = pickle.dumps(c, proto)
+            x = pickle.loads(z)
+            self.assertEqual(x.foo, 42)
+            self.assertEqual(x.bar, 'abc')
+            self.assertEqual(x.x, 1)
+            self.assertEqual(x.__dict__, {'foo': 42, 'bar': 'abc'})
+            s = pickle.dumps(P)
+            D = pickle.loads(s)
+            class E:
+                x = 1
+            self.assertIsInstance(E(), D)
 
 
 class AllTests(BaseTestCase):

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -1127,6 +1127,10 @@ class AllTests(BaseTestCase):
         if PY36:
             self.assertIn('AsyncGenerator', a)
 
+        if TYPING_3_5_3:
+            self.assertIn('Protocol', a)
+            self.assertIn('runtime', a)
+
     def test_typing_extensions_defers_when_possible(self):
         exclude = {'overload', 'Text', 'TYPE_CHECKING'}
         for item in typing_extensions.__all__:

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -54,7 +54,7 @@ PY36 = sys.version_info[:2] >= (3, 6)
 
 # It is very difficult to backport Protocols to these versions due to
 # different generics system. See https://github.com/python/typing/pull/195
-NO_PROTOCOL = sys.version_info[:3] in [(3, 5, 0), (3, 5, 1)]
+NO_PROTOCOL = sys.version_info[:3] == (3, 5, 0)
 
 
 class BaseTestCase(TestCase):

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -834,6 +834,15 @@ class ProtocolTests(BaseTestCase):
         with self.assertRaises(TypeError):
             issubclass(C, PNonCall)
         self.assertIsInstance(C(), PNonCall)
+        # check that non-protocol subclasses are not affected
+        class D(PNonCall): ...
+        self.assertNotIsSubclass(C, D)
+        self.assertNotIsInstance(C(), D)
+        D.register(C)
+        self.assertIsSubclass(C, D)
+        self.assertIsInstance(C(), D)
+        with self.assertRaises(TypeError):
+            issubclass(D, PNonCall)
 
     def test_protocols_isinstance(self):
         T = TypeVar('T')

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -11,7 +11,11 @@ from typing import Tuple, List
 from typing import Generic
 from typing import get_type_hints
 from typing import no_type_check
-from typing_extensions import NoReturn, ClassVar, Type, NewType, Protocol, runtime
+from typing_extensions import NoReturn, ClassVar, Type, NewType
+try:
+    from typing_extensions import Protocol, runtime
+except ImportError:
+    pass
 import typing
 import typing_extensions
 import collections.abc as collections_abc
@@ -47,6 +51,10 @@ ASYNCIO = sys.version_info[:2] >= (3, 5)
 
 # For checks reliant on Python 3.6 syntax changes (e.g. classvar)
 PY36 = sys.version_info[:2] >= (3, 6)
+
+# It is very difficult to backport Protocols to these versions due to
+# different generics system. See https://github.com/python/typing/pull/195
+NO_PROTOCOL = sys.version_info[:3] in [(3, 5, 0), (3, 5, 1)]
 
 
 class BaseTestCase(TestCase):
@@ -1085,6 +1093,10 @@ class ProtocolTests(BaseTestCase):
             class E:
                 x = 1
             self.assertIsInstance(E(), D)
+
+
+if NO_PROTOCOL:
+    ProtocolTests = None
 
 
 class AllTests(BaseTestCase):

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -118,6 +118,7 @@ __all__ = [
     'TYPE_CHECKING',
 ]
 
+# Protocols are hard to backport to the original version of typing 3.5.0
 NO_PROTOCOL = sys.version_info[:3] == (3, 5, 0)
 
 if not NO_PROTOCOL:
@@ -887,8 +888,8 @@ else:
     class Protocol(metaclass=_ProtocolMeta):
         """Base class for protocol classes. Protocol classes are defined as::
 
-          class Proto(Protocol[T]):
-              def meth(self) -> T:
+          class Proto(Protocol):
+              def meth(self) -> int:
                   ...
 
         Such classes are primarily used with static type checkers that recognize
@@ -898,7 +899,7 @@ else:
               def meth(self) -> int:
                   return 0
 
-          def func(x: Proto[int]) -> int:
+          def func(x: Proto) -> int:
               return x.meth()
 
           func(C())  # Passes static type check
@@ -906,6 +907,12 @@ else:
         See PEP 544 for details. Protocol classes decorated with @typing_extensions.runtime
         act as simple-minded runtime protocols that checks only the presence of
         given attributes, ignoring their type signatures.
+
+        Protocol classes can be generic, they are defined as::
+
+          class GenProto({bases}):
+              def meth(self) -> T:
+                  ...
         """
 
         __slots__ = ()
@@ -918,6 +925,9 @@ else:
             if OLD_GENERICS:
                 return _generic_new(_next_in_mro(cls), cls, *args, **kwds)
             return _generic_new(cls.__next_in_mro__, cls, *args, **kwds)
+
+    Protocol.__doc__ = Protocol.__doc__.format(bases="Protocol, Generic[T]" if
+                                               OLD_GENERICS else "Protocol[T]")
 
 
 def runtime(cls):

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -757,8 +757,8 @@ class _ProtocolMeta(GenericMeta):
                                   super(GenericMeta, self).__hash__())
         return self
     if OLD_GENERICS:
-        def __new__(*args, **kwargs):
-            return super().__new__(*args, **kwars)
+        def __new__(self, *args, **kwargs):
+            return super(self).__new__(*args, **kwars)
 
     def __init__(cls, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -883,8 +883,8 @@ class _ProtocolMeta(GenericMeta):
                               orig_bases=self.__orig_bases__)
 
     if OLD_GENERICS:
-        def __getitem__(*args, **kwargs):
-            return super().__getitem__(*args, **kwars)
+        def __getitem__(self, *args, **kwargs):
+            return super(self).__getitem__(*args, **kwars)
 
 
 if NO_PROTOCOL:

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -8,11 +8,12 @@ import collections.abc as collections_abc
 # These are used by Protocol implementation
 # We use internal typing helpers here, but this significantly reduces
 # code duplication. (Also this is only until Protocol is in typing.)
-from typing import (
-    GenericMeta, TypingMeta, Generic, Callable, TypeVar, Tuple,
-    _type_vars, _next_in_mro, _type_check,
-    _make_subclasshook, _check_generic
-)
+from typing import GenericMeta, TypingMeta, Generic, Callable, TypeVar, Tuple
+NO_PROTOCOL = False
+try:
+    from typing import _type_vars, _next_in_mro, _type_check, _check_generic
+except ImportError:
+    NO_PROTOCOL = True
 try:
     from typing import _no_slots_copy
 except ImportError:
@@ -31,6 +32,10 @@ try:
 except ImportError:
     class _TypingEllipsis: pass
     class _TypingEmpty: pass
+try:
+    from typing import _make_subclasshook
+except ImportError:
+    _make_subclasshook = None
 
 if hasattr(typing, '_generic_new'):
     _generic_new = typing._generic_new
@@ -908,3 +913,7 @@ def runtime(cls):
                         ' got %r' % cls)
     cls._is_runtime_protocol = True
     return cls
+
+
+if NO_PROTOCOL:
+    del Protocol, runtime

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -666,7 +666,7 @@ else:
 
 
 def _gorg(cls):
-    """This function exists for compatibility with old typing versions"""
+    """This function exists for compatibility with old typing versions."""
     assert isinstance(cls, GenericMeta)
     if hasattr(cls, '_gorg'):
         return cls._gorg
@@ -677,24 +677,12 @@ def _gorg(cls):
 
 if OLD_GENERICS:
     def _next_in_mro(cls):
+        """This function exists for compatibility with old typing versions."""
         next_in_mro = object
         for i, c in enumerate(cls.__mro__[:-1]):
             if isinstance(c, GenericMeta) and _gorg(c) is Generic:
                 next_in_mro = cls.__mro__[i + 1]
         return next_in_mro
-
-
-def _collection_protocol(cls):
-    # Selected set of collections ABCs that are considered protocols.
-    name = cls.__name__
-    return (name in ('ABC', 'Callable', 'Awaitable',
-                     'Iterable', 'Iterator', 'AsyncIterable', 'AsyncIterator',
-                     'Hashable', 'Sized', 'Container', 'Collection', 'Reversible',
-                     'Sequence', 'MutableSequence', 'Mapping', 'MutableMapping',
-                     'AbstractContextManager', 'ContextManager',
-                     'AbstractAsyncContextManager', 'AsyncContextManager',) and
-            cls.__module__ in ('collections.abc', 'typing', 'contextlib',
-                               '_abcoll', 'abc'))
 
 
 class _ProtocolMeta(GenericMeta):
@@ -777,8 +765,7 @@ class _ProtocolMeta(GenericMeta):
             for base in cls.__mro__[1:]:
                 if not (base in (object, Generic, Callable) or
                         isinstance(base, TypingMeta) and base._is_protocol or
-                        isinstance(base, GenericMeta) and base.__origin__ is Generic or
-                        _collection_protocol(base)):
+                        isinstance(base, GenericMeta) and base.__origin__ is Generic):
                     raise TypeError('Protocols can only inherit from other protocols,'
                                     ' got %r' % base)
 
@@ -845,8 +832,7 @@ class _ProtocolMeta(GenericMeta):
                         '__next_in_mro__', '__parameters__', '__origin__',
                         '__orig_bases__', '__extra__', '__tree_hash__',
                         '__doc__', '__subclasshook__', '__init__', '__new__',
-                        '__module__', '_MutableMapping__marker', '_gorg') and
-                        getattr(base, attr, object()) is not None):
+                        '__module__', '_MutableMapping__marker', '_gorg')):
                     attrs.add(attr)
         return attrs
 

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -5,6 +5,15 @@ import sys
 import typing
 import collections.abc as collections_abc
 
+# These are used by Protocol implementation
+# We use internal typing helpers here, but this significantly reduces
+# code duplication. (Also this is only until Protocol is in typing.)
+from typing import (
+    GenericMeta, TypingMeta, Generic, Callable, TypeVar, Tuple,
+    _no_slots_copy, _type_vars, _next_in_mro, _tp_cache, _type_check,
+    _TypingEllipsis, _TypingEmpty, _make_subclasshook, _check_generic
+)
+
 if hasattr(typing, '_generic_new'):
     _generic_new = typing._generic_new
 else:
@@ -54,6 +63,7 @@ __all__ = [
     # Super-special typing primitives.
     'ClassVar',
     'Type',
+    'Protocol',
 
     # ABCs (from collections.abc).
     # The following are added depending on presence
@@ -75,6 +85,7 @@ __all__ = [
     # One-off things.
     'NewType',
     'overload',
+    'runtime',
     'Text',
     'TYPE_CHECKING',
 ]
@@ -620,3 +631,256 @@ if hasattr(typing, 'TYPE_CHECKING'):
 else:
     # Constant that's True when type checking, but False here.
     TYPE_CHECKING = False
+
+
+def _collection_protocol(cls):
+    # Selected set of collections ABCs that are considered protocols.
+    name = cls.__name__
+    return (name in ('ABC', 'Callable', 'Awaitable',
+                     'Iterable', 'Iterator', 'AsyncIterable', 'AsyncIterator',
+                     'Hashable', 'Sized', 'Container', 'Collection', 'Reversible',
+                     'Sequence', 'MutableSequence', 'Mapping', 'MutableMapping',
+                     'AbstractContextManager', 'ContextManager',
+                     'AbstractAsyncContextManager', 'AsyncContextManager',) and
+            cls.__module__ in ('collections.abc', 'typing', 'contextlib',
+                               '_abcoll', 'abc'))
+
+
+class ProtocolMeta(GenericMeta):
+    """Internal metaclass for Protocol.
+
+    This exists so Protocol classes can be generic without deriving
+    from Generic.
+    """
+    def __new__(cls, name, bases, namespace,
+                tvars=None, args=None, origin=None, extra=None, orig_bases=None):
+        # This is just a version copied from GenericMeta.__new__ that
+        # includes "Protocol" special treatment. (Comments removed for brevity.)
+        if tvars is not None:
+            assert origin is not None
+            assert all(isinstance(t, TypeVar) for t in tvars), tvars
+        else:
+            tvars = _type_vars(bases)
+            gvars = None
+            for base in bases:
+                if base is Generic:
+                    raise TypeError("Cannot inherit from plain Generic")
+                if (isinstance(base, GenericMeta) and
+                        base.__origin__ in (Generic, Protocol)):
+                    if gvars is not None:
+                        raise TypeError(
+                            "Cannot inherit from Generic[...] or"
+                            " Protocol[...] multiple types.")
+                    gvars = base.__parameters__
+            if gvars is None:
+                gvars = tvars
+            else:
+                tvarset = set(tvars)
+                gvarset = set(gvars)
+                if not tvarset <= gvarset:
+                    raise TypeError(
+                        "Some type variables (%s) "
+                        "are not listed in %s[%s]" %
+                        (", ".join(str(t) for t in tvars if t not in gvarset),
+                         "Generic" if any(b.__origin__ is Generic
+                                          for b in bases) else "Protocol",
+                         ", ".join(str(g) for g in gvars)))
+                tvars = gvars
+
+        initial_bases = bases
+        if extra is not None and type(extra) is abc.ABCMeta and extra not in bases:
+            bases = (extra,) + bases
+        bases = tuple(b._gorg if isinstance(b, GenericMeta) else b for b in bases)
+        if any(isinstance(b, GenericMeta) and b is not Generic for b in bases):
+            bases = tuple(b for b in bases if b is not Generic)
+        namespace.update({'__origin__': origin, '__extra__': extra})
+        self = super(GenericMeta, cls).__new__(cls, name, bases, namespace, _root=True)
+        super(GenericMeta, self).__setattr__('_gorg',
+                                             self if not origin else origin._gorg)
+        self.__parameters__ = tvars
+        self.__args__ = tuple(... if a is _TypingEllipsis else
+                              () if a is _TypingEmpty else
+                              a for a in args) if args else None
+        self.__next_in_mro__ = _next_in_mro(self)
+        if orig_bases is None:
+            self.__orig_bases__ = initial_bases
+        if (
+            '__subclasshook__' not in namespace and extra or
+            getattr(self.__subclasshook__, '__name__', '') == '__extrahook__'
+        ):
+            self.__subclasshook__ = _make_subclasshook(self)
+        if isinstance(extra, abc.ABCMeta):
+            self._abc_registry = extra._abc_registry
+            self._abc_cache = extra._abc_cache
+        elif origin is not None:
+            self._abc_registry = origin._abc_registry
+            self._abc_cache = origin._abc_cache
+        self.__tree_hash__ = (hash(self._subs_tree()) if origin else
+                              super(GenericMeta, self).__hash__())
+        return self
+
+    def __init__(cls, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if not cls.__dict__.get('_is_protocol', None):
+            cls._is_protocol = any(b is Protocol or
+                                   isinstance(b, ProtocolMeta) and
+                                   b.__origin__ is Protocol
+                                   for b in cls.__bases__)
+        if cls._is_protocol:
+            for base in cls.__mro__[1:]:
+                if not (base in (object, Generic, Callable) or
+                        isinstance(base, TypingMeta) and base._is_protocol or
+                        isinstance(base, GenericMeta) and base.__origin__ is Generic or
+                        _collection_protocol(base)):
+                    raise TypeError('Protocols can only inherit from other protocols,'
+                                    ' got %r' % base)
+
+            def _no_init(self, *args, **kwargs):
+                if type(self)._is_protocol:
+                    raise TypeError('Protocols cannot be instantiated')
+            cls.__init__ = _no_init
+
+        def _proto_hook(other):
+            if not cls.__dict__.get('_is_protocol', None):
+                return NotImplemented
+            for attr in cls._get_protocol_attrs():
+                for base in other.__mro__:
+                    if attr in base.__dict__:
+                        if base.__dict__[attr] is None:
+                            return NotImplemented
+                        break
+                    if (attr in getattr(base, '__annotations__', {}) and
+                            isinstance(other, ProtocolMeta) and other._is_protocol):
+                        break
+                else:
+                    return NotImplemented
+            return True
+        if '__subclasshook__' not in cls.__dict__:
+            cls.__subclasshook__ = _proto_hook
+
+    def __instancecheck__(self, instance):
+        # We need this method for situations where attributes are assigned in __init__
+        if issubclass(instance.__class__, self):
+            return True
+        if self._is_protocol:
+            return all(hasattr(instance, attr) and getattr(instance, attr) is not None
+                       for attr in self._get_protocol_attrs())
+        return False
+
+    def __subclasscheck__(self, cls):
+        if (self.__dict__.get('_is_protocol', None) and
+                not self.__dict__.get('_is_runtime_protocol', None)):
+            if sys._getframe(1).f_globals['__name__'] in ['abc', 'functools']:
+                return False
+            raise TypeError("Instance and class checks can only be used with"
+                            " @runtime protocols")
+        return super().__subclasscheck__(cls)
+
+    def _get_protocol_attrs(self):
+        attrs = set()
+        for base in self.__mro__[:-1]:  # without object
+            if base.__name__ in ('Protocol', 'Generic'):
+                continue
+            annotations = getattr(base, '__annotations__', {})
+            for attr in list(base.__dict__.keys()) + list(annotations.keys()):
+                if (not attr.startswith('_abc_') and attr not in (
+                        '__abstractmethods__', '__annotations__', '__weakref__',
+                        '_is_protocol', '_is_runtime_protocol', '__dict__',
+                        '__args__', '__slots__', '_get_protocol_attrs',
+                        '__next_in_mro__', '__parameters__', '__origin__',
+                        '__orig_bases__', '__extra__', '__tree_hash__',
+                        '__doc__', '__subclasshook__', '__init__', '__new__',
+                        '__module__', '_MutableMapping__marker', '_gorg') and
+                        getattr(base, attr, object()) is not None):
+                    attrs.add(attr)
+        return attrs
+
+    @_tp_cache
+    def __getitem__(self, params):
+        # We also need to copy this from GenericMeta.__getitem__ to get
+        # special treatment of "Protocol". (Comments removed for brevity.)
+        if not isinstance(params, tuple):
+            params = (params,)
+        if not params and self._gorg is not Tuple:
+            raise TypeError(
+                "Parameter list to %s[...] cannot be empty" % self.__qualname__)
+        msg = "Parameters to generic types must be types."
+        params = tuple(_type_check(p, msg) for p in params)
+        if self in (Generic, Protocol):
+            if not all(isinstance(p, TypeVar) for p in params):
+                raise TypeError(
+                    "Parameters to %r[...] must all be type variables" % self)
+            if len(set(params)) != len(params):
+                raise TypeError(
+                    "Parameters to %r[...] must all be unique" % self)
+            tvars = params
+            args = params
+        elif self in (Tuple, Callable):
+            tvars = _type_vars(params)
+            args = params
+        elif self.__origin__ in (Generic, Protocol):
+            raise TypeError("Cannot subscript already-subscripted %s" %
+                            repr(self))
+        else:
+            _check_generic(self, params)
+            tvars = _type_vars(params)
+            args = params
+
+        prepend = (self,) if self.__origin__ is None else ()
+        return self.__class__(self.__name__,
+                              prepend + self.__bases__,
+                              _no_slots_copy(self.__dict__),
+                              tvars=tvars,
+                              args=args,
+                              origin=self,
+                              extra=self.__extra__,
+                              orig_bases=self.__orig_bases__)
+
+
+class Protocol(metaclass=ProtocolMeta):
+    """Base class for protocol classes. Protocol classes are defined as::
+
+      class Proto(Protocol[T]):
+          def meth(self) -> T:
+              ...
+
+    Such classes are primarily used with static type checkers that recognize
+    structural subtyping (static duck-typing), for example::
+
+      class C:
+          def meth(self) -> int:
+              return 0
+
+      def func(x: Proto[int]) -> int:
+          return x.meth()
+
+      func(C())  # Passes static type check
+
+    See PEP 544 for details. Protocol classes decorated with @typing_extensions.runtime
+    act as simple-minded runtime protocols that checks only the presence of
+    given attributes, ignoring their type signatures.
+    """
+
+    __slots__ = ()
+    _is_protocol = True
+
+    def __new__(cls, *args, **kwds):
+        if cls._gorg is Protocol:
+            raise TypeError("Type Protocol cannot be instantiated; "
+                            "it can be used only as a base class")
+        return _generic_new(cls.__next_in_mro__, cls, *args, **kwds)
+
+
+def runtime(cls):
+    """Mark a protocol class as a runtime protocol, so that it
+    can be used with isinstance() and issubclass(). Raise TypeError
+    if applied to a non-protocol class.
+
+    This allows a simple-minded structural check very similar to the
+    one-offs in collections.abc such as Hashable.
+    """
+    if not isinstance(cls, ProtocolMeta) or not cls._is_protocol:
+        raise TypeError('@runtime can be only applied to protocol classes,'
+                        ' got %r' % cls)
+    cls._is_runtime_protocol = True
+    return cls

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -15,15 +15,6 @@ try:
 except ImportError:
     OLD_GENERICS = True
 try:
-    from typing import _no_slots_copy
-except ImportError:
-    def _no_slots_copy(dct):
-        dict_copy = dict(dct)
-        if '__slots__' in dict_copy:
-            for slot in dict_copy['__slots__']:
-                dict_copy.pop(slot, None)
-        return dict_copy
-try:
     from typing import _tp_cache
 except ImportError:
     _tp_cache = lambda x: x
@@ -32,17 +23,29 @@ try:
 except ImportError:
     class _TypingEllipsis: pass
     class _TypingEmpty: pass
-try:
-    from typing import _check_generic
-except ImportError:
-    def _check_generic(cls, parameters):
-        if not cls.__parameters__:
-            raise TypeError("%s is not a generic class" % repr(cls))
-        alen = len(parameters)
-        elen = len(cls.__parameters__)
-        if alen != elen:
-            raise TypeError("Too %s parameters for %s; actual %s, expected %s" %
-                            ("many" if alen > elen else "few", repr(cls), alen, elen))
+
+
+# The two functions below are copies of typing internal helpers.
+# They are needed by _ProtocolMeta
+
+
+def _no_slots_copy(dct):
+    dict_copy = dict(dct)
+    if '__slots__' in dict_copy:
+        for slot in dict_copy['__slots__']:
+            dict_copy.pop(slot, None)
+    return dict_copy
+
+
+def _check_generic(cls, parameters):
+    if not cls.__parameters__:
+        raise TypeError("%s is not a generic class" % repr(cls))
+    alen = len(parameters)
+    elen = len(cls.__parameters__)
+    if alen != elen:
+        raise TypeError("Too %s parameters for %s; actual %s, expected %s" %
+                        ("many" if alen > elen else "few", repr(cls), alen, elen))
+
 
 if hasattr(typing, '_generic_new'):
     _generic_new = typing._generic_new
@@ -119,9 +122,9 @@ __all__ = [
 ]
 
 # Protocols are hard to backport to the original version of typing 3.5.0
-NO_PROTOCOL = sys.version_info[:3] == (3, 5, 0)
+HAVE_PROTOCOLS = sys.version_info[:3] != (3, 5, 0)
 
-if not NO_PROTOCOL:
+if HAVE_PROTOCOLS:
     __all__.extend(['Protocol', 'runtime'])
 
 # TODO
@@ -685,220 +688,219 @@ if OLD_GENERICS:
                 next_in_mro = cls.__mro__[i + 1]
         return next_in_mro
 
+if HAVE_PROTOCOLS:
+    class _ProtocolMeta(GenericMeta):
+        """Internal metaclass for Protocol.
 
-class _ProtocolMeta(GenericMeta):
-    """Internal metaclass for Protocol.
-
-    This exists so Protocol classes can be generic without deriving
-    from Generic.
-    """
-    def __new__(cls, name, bases, namespace,
-                tvars=None, args=None, origin=None, extra=None, orig_bases=None):
-        # This is just a version copied from GenericMeta.__new__ that
-        # includes "Protocol" special treatment. (Comments removed for brevity.)
-        assert extra is None  # Protocols should not have extra
-        if tvars is not None:
-            assert origin is not None
-            assert all(isinstance(t, TypeVar) for t in tvars), tvars
-        else:
-            tvars = _type_vars(bases)
-            gvars = None
-            for base in bases:
-                if base is Generic:
-                    raise TypeError("Cannot inherit from plain Generic")
-                if (isinstance(base, GenericMeta) and
-                        base.__origin__ in (Generic, Protocol)):
-                    if gvars is not None:
-                        raise TypeError(
-                            "Cannot inherit from Generic[...] or"
-                            " Protocol[...] multiple times.")
-                    gvars = base.__parameters__
-            if gvars is None:
-                gvars = tvars
-            else:
-                tvarset = set(tvars)
-                gvarset = set(gvars)
-                if not tvarset <= gvarset:
-                    raise TypeError(
-                        "Some type variables (%s) "
-                        "are not listed in %s[%s]" %
-                        (", ".join(str(t) for t in tvars if t not in gvarset),
-                         "Generic" if any(b.__origin__ is Generic
-                                          for b in bases) else "Protocol",
-                         ", ".join(str(g) for g in gvars)))
-                tvars = gvars
-
-        initial_bases = bases
-        if extra is not None and type(extra) is abc.ABCMeta and extra not in bases:
-            bases = (extra,) + bases
-        bases = tuple(_gorg(b) if isinstance(b, GenericMeta) else b for b in bases)
-        if any(isinstance(b, GenericMeta) and b is not Generic for b in bases):
-            bases = tuple(b for b in bases if b is not Generic)
-        namespace.update({'__origin__': origin, '__extra__': extra})
-        self = super(GenericMeta, cls).__new__(cls, name, bases, namespace, _root=True)
-        super(GenericMeta, self).__setattr__('_gorg',
-                                             self if not origin else _gorg(origin))
-        self.__parameters__ = tvars
-        self.__args__ = tuple(... if a is _TypingEllipsis else
-                              () if a is _TypingEmpty else
-                              a for a in args) if args else None
-        self.__next_in_mro__ = _next_in_mro(self)
-        if orig_bases is None:
-            self.__orig_bases__ = initial_bases
-        elif origin is not None:
-            self._abc_registry = origin._abc_registry
-            self._abc_cache = origin._abc_cache
-        if hasattr(self, '_subs_tree'):
-            self.__tree_hash__ = (hash(self._subs_tree()) if origin else
-                                  super(GenericMeta, self).__hash__())
-        return self
-    if OLD_GENERICS:
-        del __new__
-
-    def __init__(cls, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        if not cls.__dict__.get('_is_protocol', None):
-            cls._is_protocol = any(b is Protocol or
-                                   isinstance(b, _ProtocolMeta) and
-                                   b.__origin__ is Protocol
-                                   for b in cls.__bases__)
-        if cls._is_protocol:
-            for base in cls.__mro__[1:]:
-                if not (base in (object, Generic, Callable) or
-                        isinstance(base, TypingMeta) and base._is_protocol or
-                        isinstance(base, GenericMeta) and base.__origin__ is Generic):
-                    raise TypeError('Protocols can only inherit from other protocols,'
-                                    ' got %r' % base)
-            cls._callable_members_only = all(callable(getattr(cls, attr, None))
-                                             for attr in cls._get_protocol_attrs())
-
-            def _no_init(self, *args, **kwargs):
-                if type(self)._is_protocol:
-                    raise TypeError('Protocols cannot be instantiated')
-            cls.__init__ = _no_init
-
-        def _proto_hook(other):
-            if not cls.__dict__.get('_is_protocol', None):
-                return NotImplemented
-            if not isinstance(other, type):
-                # Same error as for issubclass(1, int)
-                raise TypeError('issubclass() arg 1 must be a class')
-            for attr in cls._get_protocol_attrs():
-                for base in other.__mro__:
-                    if attr in base.__dict__:
-                        if base.__dict__[attr] is None:
-                            return NotImplemented
-                        break
-                    if (attr in getattr(base, '__annotations__', {}) and
-                            isinstance(other, _ProtocolMeta) and other._is_protocol):
-                        break
+        This exists so Protocol classes can be generic without deriving
+        from Generic.
+        """
+        if not OLD_GENERICS:
+            def __new__(cls, name, bases, namespace,
+                        tvars=None, args=None, origin=None, extra=None, orig_bases=None):
+                # This is just a version copied from GenericMeta.__new__ that
+                # includes "Protocol" special treatment. (Comments removed for brevity.)
+                assert extra is None  # Protocols should not have extra
+                if tvars is not None:
+                    assert origin is not None
+                    assert all(isinstance(t, TypeVar) for t in tvars), tvars
                 else:
+                    tvars = _type_vars(bases)
+                    gvars = None
+                    for base in bases:
+                        if base is Generic:
+                            raise TypeError("Cannot inherit from plain Generic")
+                        if (isinstance(base, GenericMeta) and
+                                base.__origin__ in (Generic, Protocol)):
+                            if gvars is not None:
+                                raise TypeError(
+                                    "Cannot inherit from Generic[...] or"
+                                    " Protocol[...] multiple times.")
+                            gvars = base.__parameters__
+                    if gvars is None:
+                        gvars = tvars
+                    else:
+                        tvarset = set(tvars)
+                        gvarset = set(gvars)
+                        if not tvarset <= gvarset:
+                            raise TypeError(
+                                "Some type variables (%s) "
+                                "are not listed in %s[%s]" %
+                                (", ".join(str(t) for t in tvars if t not in gvarset),
+                                 "Generic" if any(b.__origin__ is Generic
+                                                  for b in bases) else "Protocol",
+                                 ", ".join(str(g) for g in gvars)))
+                        tvars = gvars
+
+                initial_bases = bases
+                if (extra is not None and type(extra) is abc.ABCMeta and
+                        extra not in bases):
+                    bases = (extra,) + bases
+                bases = tuple(_gorg(b) if isinstance(b, GenericMeta) else b
+                              for b in bases)
+                if any(isinstance(b, GenericMeta) and b is not Generic for b in bases):
+                    bases = tuple(b for b in bases if b is not Generic)
+                namespace.update({'__origin__': origin, '__extra__': extra})
+                self = super(GenericMeta, cls).__new__(cls, name, bases, namespace,
+                                                       _root=True)
+                super(GenericMeta, self).__setattr__('_gorg',
+                                                     self if not origin else
+                                                     _gorg(origin))
+                self.__parameters__ = tvars
+                self.__args__ = tuple(... if a is _TypingEllipsis else
+                                      () if a is _TypingEmpty else
+                                      a for a in args) if args else None
+                self.__next_in_mro__ = _next_in_mro(self)
+                if orig_bases is None:
+                    self.__orig_bases__ = initial_bases
+                elif origin is not None:
+                    self._abc_registry = origin._abc_registry
+                    self._abc_cache = origin._abc_cache
+                if hasattr(self, '_subs_tree'):
+                    self.__tree_hash__ = (hash(self._subs_tree()) if origin else
+                                          super(GenericMeta, self).__hash__())
+                return self
+
+        def __init__(cls, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            if not cls.__dict__.get('_is_protocol', None):
+                cls._is_protocol = any(b is Protocol or
+                                       isinstance(b, _ProtocolMeta) and
+                                       b.__origin__ is Protocol
+                                       for b in cls.__bases__)
+            if cls._is_protocol:
+                for base in cls.__mro__[1:]:
+                    if not (base in (object, Generic, Callable) or
+                            isinstance(base, TypingMeta) and base._is_protocol or
+                            isinstance(base, GenericMeta) and
+                            base.__origin__ is Generic):
+                        raise TypeError('Protocols can only inherit from other'
+                                        ' protocols, got %r' % base)
+                cls._callable_members_only = all(callable(getattr(cls, attr, None))
+                                                 for attr in cls._get_protocol_attrs())
+
+                def _no_init(self, *args, **kwargs):
+                    if type(self)._is_protocol:
+                        raise TypeError('Protocols cannot be instantiated')
+                cls.__init__ = _no_init
+
+            def _proto_hook(other):
+                if not cls.__dict__.get('_is_protocol', None):
                     return NotImplemented
-            return True
-        if '__subclasshook__' not in cls.__dict__:
-            cls.__subclasshook__ = _proto_hook
-
-    def __instancecheck__(self, instance):
-        # We need this method for situations where attributes are assigned in __init__
-        if ((not getattr(self, '_is_protocol', False) or
-                self._callable_members_only) and
-                issubclass(instance.__class__, self)):
-            return True
-        if self._is_protocol:
-            if all(hasattr(instance, attr) and
-                    (not callable(getattr(self, attr, None)) or
-                     getattr(instance, attr) is not None)
-                    for attr in self._get_protocol_attrs()):
+                if not isinstance(other, type):
+                    # Same error as for issubclass(1, int)
+                    raise TypeError('issubclass() arg 1 must be a class')
+                for attr in cls._get_protocol_attrs():
+                    for base in other.__mro__:
+                        if attr in base.__dict__:
+                            if base.__dict__[attr] is None:
+                                return NotImplemented
+                            break
+                        if (attr in getattr(base, '__annotations__', {}) and
+                                isinstance(other, _ProtocolMeta) and other._is_protocol):
+                            break
+                    else:
+                        return NotImplemented
                 return True
-        return super(GenericMeta, self).__instancecheck__(instance)
+            if '__subclasshook__' not in cls.__dict__:
+                cls.__subclasshook__ = _proto_hook
 
-    def __subclasscheck__(self, cls):
-        if self.__origin__ is not None:
-            if sys._getframe(1).f_globals['__name__'] not in ['abc', 'functools']:
-                raise TypeError("Parameterized generics cannot be used with class "
-                                "or instance checks")
-            return False
-        if (self.__dict__.get('_is_protocol', None) and
-                not self.__dict__.get('_is_runtime_protocol', None)):
-            if sys._getframe(1).f_globals['__name__'] in ['abc', 'functools']:
+        def __instancecheck__(self, instance):
+            # We need this method for situations where attributes are
+            # assigned in __init__.
+            if ((not getattr(self, '_is_protocol', False) or
+                    self._callable_members_only) and
+                    issubclass(instance.__class__, self)):
+                return True
+            if self._is_protocol:
+                if all(hasattr(instance, attr) and
+                        (not callable(getattr(self, attr, None)) or
+                         getattr(instance, attr) is not None)
+                        for attr in self._get_protocol_attrs()):
+                    return True
+            return super(GenericMeta, self).__instancecheck__(instance)
+
+        def __subclasscheck__(self, cls):
+            if self.__origin__ is not None:
+                if sys._getframe(1).f_globals['__name__'] not in ['abc', 'functools']:
+                    raise TypeError("Parameterized generics cannot be used with class "
+                                    "or instance checks")
                 return False
-            raise TypeError("Instance and class checks can only be used with"
-                            " @runtime protocols")
-        if (self.__dict__.get('_is_runtime_protocol', None) and
-                not self._callable_members_only):
-            if sys._getframe(1).f_globals['__name__'] in ['abc', 'functools']:
-                return super(GenericMeta, self).__subclasscheck__(cls)
-            raise TypeError("Protocols with non-method members"
-                            " don't support issubclass()")
-        return super(GenericMeta, self).__subclasscheck__(cls)
+            if (self.__dict__.get('_is_protocol', None) and
+                    not self.__dict__.get('_is_runtime_protocol', None)):
+                if sys._getframe(1).f_globals['__name__'] in ['abc', 'functools']:
+                    return False
+                raise TypeError("Instance and class checks can only be used with"
+                                " @runtime protocols")
+            if (self.__dict__.get('_is_runtime_protocol', None) and
+                    not self._callable_members_only):
+                if sys._getframe(1).f_globals['__name__'] in ['abc', 'functools']:
+                    return super(GenericMeta, self).__subclasscheck__(cls)
+                raise TypeError("Protocols with non-method members"
+                                " don't support issubclass()")
+            return super(GenericMeta, self).__subclasscheck__(cls)
 
-    def _get_protocol_attrs(self):
-        attrs = set()
-        for base in self.__mro__[:-1]:  # without object
-            if base.__name__ in ('Protocol', 'Generic'):
-                continue
-            annotations = getattr(base, '__annotations__', {})
-            for attr in list(base.__dict__.keys()) + list(annotations.keys()):
-                if (not attr.startswith('_abc_') and attr not in (
-                        '__abstractmethods__', '__annotations__', '__weakref__',
-                        '_is_protocol', '_is_runtime_protocol', '__dict__',
-                        '__args__', '__slots__', '_get_protocol_attrs',
-                        '__next_in_mro__', '__parameters__', '__origin__',
-                        '__orig_bases__', '__extra__', '__tree_hash__',
-                        '__doc__', '__subclasshook__', '__init__', '__new__',
-                        '__module__', '_MutableMapping__marker', '_gorg',
-                        '_callable_members_only')):
-                    attrs.add(attr)
-        return attrs
+        def _get_protocol_attrs(self):
+            attrs = set()
+            for base in self.__mro__[:-1]:  # without object
+                if base.__name__ in ('Protocol', 'Generic'):
+                    continue
+                annotations = getattr(base, '__annotations__', {})
+                for attr in list(base.__dict__.keys()) + list(annotations.keys()):
+                    if (not attr.startswith('_abc_') and attr not in (
+                            '__abstractmethods__', '__annotations__', '__weakref__',
+                            '_is_protocol', '_is_runtime_protocol', '__dict__',
+                            '__args__', '__slots__', '_get_protocol_attrs',
+                            '__next_in_mro__', '__parameters__', '__origin__',
+                            '__orig_bases__', '__extra__', '__tree_hash__',
+                            '__doc__', '__subclasshook__', '__init__', '__new__',
+                            '__module__', '_MutableMapping__marker', '_gorg',
+                            '_callable_members_only')):
+                        attrs.add(attr)
+            return attrs
 
-    @_tp_cache
-    def __getitem__(self, params):
-        # We also need to copy this from GenericMeta.__getitem__ to get
-        # special treatment of "Protocol". (Comments removed for brevity.)
-        if not isinstance(params, tuple):
-            params = (params,)
-        if not params and _gorg(self) is not Tuple:
-            raise TypeError(
-                "Parameter list to %s[...] cannot be empty" % self.__qualname__)
-        msg = "Parameters to generic types must be types."
-        params = tuple(_type_check(p, msg) for p in params)
-        if self in (Generic, Protocol):
-            if not all(isinstance(p, TypeVar) for p in params):
-                raise TypeError(
-                    "Parameters to %r[...] must all be type variables" % self)
-            if len(set(params)) != len(params):
-                raise TypeError(
-                    "Parameters to %r[...] must all be unique" % self)
-            tvars = params
-            args = params
-        elif self in (Tuple, Callable):
-            tvars = _type_vars(params)
-            args = params
-        elif self.__origin__ in (Generic, Protocol):
-            raise TypeError("Cannot subscript already-subscripted %s" %
-                            repr(self))
-        else:
-            _check_generic(self, params)
-            tvars = _type_vars(params)
-            args = params
+        if not OLD_GENERICS:
+            @_tp_cache
+            def __getitem__(self, params):
+                # We also need to copy this from GenericMeta.__getitem__ to get
+                # special treatment of "Protocol". (Comments removed for brevity.)
+                if not isinstance(params, tuple):
+                    params = (params,)
+                if not params and _gorg(self) is not Tuple:
+                    raise TypeError(
+                        "Parameter list to %s[...] cannot be empty" % self.__qualname__)
+                msg = "Parameters to generic types must be types."
+                params = tuple(_type_check(p, msg) for p in params)
+                if self in (Generic, Protocol):
+                    if not all(isinstance(p, TypeVar) for p in params):
+                        raise TypeError(
+                            "Parameters to %r[...] must all be type variables" % self)
+                    if len(set(params)) != len(params):
+                        raise TypeError(
+                            "Parameters to %r[...] must all be unique" % self)
+                    tvars = params
+                    args = params
+                elif self in (Tuple, Callable):
+                    tvars = _type_vars(params)
+                    args = params
+                elif self.__origin__ in (Generic, Protocol):
+                    raise TypeError("Cannot subscript already-subscripted %s" %
+                                    repr(self))
+                else:
+                    _check_generic(self, params)
+                    tvars = _type_vars(params)
+                    args = params
 
-        prepend = (self,) if self.__origin__ is None else ()
-        return self.__class__(self.__name__,
-                              prepend + self.__bases__,
-                              _no_slots_copy(self.__dict__),
-                              tvars=tvars,
-                              args=args,
-                              origin=self,
-                              extra=self.__extra__,
-                              orig_bases=self.__orig_bases__)
+                prepend = (self,) if self.__origin__ is None else ()
+                return self.__class__(self.__name__,
+                                      prepend + self.__bases__,
+                                      _no_slots_copy(self.__dict__),
+                                      tvars=tvars,
+                                      args=args,
+                                      origin=self,
+                                      extra=self.__extra__,
+                                      orig_bases=self.__orig_bases__)
 
-    if OLD_GENERICS:
-        del __getitem__
-
-
-if NO_PROTOCOL:
-    del _ProtocolMeta
-else:
     class Protocol(metaclass=_ProtocolMeta):
         """Base class for protocol classes. Protocol classes are defined as::
 
@@ -918,9 +920,9 @@ else:
 
           func(C())  # Passes static type check
 
-        See PEP 544 for details. Protocol classes decorated with @typing_extensions.runtime
-        act as simple-minded runtime protocols that checks only the presence of
-        given attributes, ignoring their type signatures.
+        See PEP 544 for details. Protocol classes decorated with
+        @typing_extensions.runtime act as simple-minded runtime protocol that checks
+        only the presence of given attributes, ignoring their type signatures.
 
         Protocol classes can be generic, they are defined as::
 
@@ -928,7 +930,6 @@ else:
               def meth(self) -> T:
                   ...
         """
-
         __slots__ = ()
         _is_protocol = True
 
@@ -943,21 +944,16 @@ else:
     Protocol.__doc__ = Protocol.__doc__.format(bases="Protocol, Generic[T]" if
                                                OLD_GENERICS else "Protocol[T]")
 
+    def runtime(cls):
+        """Mark a protocol class as a runtime protocol, so that it
+        can be used with isinstance() and issubclass(). Raise TypeError
+        if applied to a non-protocol class.
 
-def runtime(cls):
-    """Mark a protocol class as a runtime protocol, so that it
-    can be used with isinstance() and issubclass(). Raise TypeError
-    if applied to a non-protocol class.
-
-    This allows a simple-minded structural check very similar to the
-    one-offs in collections.abc such as Hashable.
-    """
-    if not isinstance(cls, _ProtocolMeta) or not cls._is_protocol:
-        raise TypeError('@runtime can be only applied to protocol classes,'
-                        ' got %r' % cls)
-    cls._is_runtime_protocol = True
-    return cls
-
-
-if NO_PROTOCOL:
-    del runtime
+        This allows a simple-minded structural check very similar to the
+        one-offs in collections.abc such as Hashable.
+        """
+        if not isinstance(cls, _ProtocolMeta) or not cls._is_protocol:
+            raise TypeError('@runtime can be only applied to protocol classes,'
+                            ' got %r' % cls)
+        cls._is_runtime_protocol = True
+        return cls

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -757,8 +757,7 @@ class _ProtocolMeta(GenericMeta):
                                   super(GenericMeta, self).__hash__())
         return self
     if OLD_GENERICS:
-        def __new__(cls, name, bases, namespace, **kwargs):
-            return super(_ProtocolMeta, cls).__new__(name, bases, namespace, **kwargs)
+        del __new__
 
     def __init__(cls, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -883,8 +882,7 @@ class _ProtocolMeta(GenericMeta):
                               orig_bases=self.__orig_bases__)
 
     if OLD_GENERICS:
-        def __getitem__(self, params):
-            return super(_ProtocolMeta, self).__getitem__(params)
+        del __getitem__
 
 
 if NO_PROTOCOL:

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -675,6 +675,15 @@ def _gorg(cls):
     return cls
 
 
+if OLD_GENERICS:
+    def _next_in_mro(cls):
+        next_in_mro = object
+        for i, c in enumerate(cls.__mro__[:-1]):
+            if isinstance(c, GenericMeta) and _gorg(c) is Generic:
+                next_in_mro = cls.__mro__[i + 1]
+        return next_in_mro
+
+
 def _collection_protocol(cls):
     # Selected set of collections ABCs that are considered protocols.
     name = cls.__name__
@@ -917,6 +926,8 @@ else:
             if _gorg(cls) is Protocol:
                 raise TypeError("Type Protocol cannot be instantiated; "
                                 "it can be used only as a base class")
+            if OLD_GENERICS:
+                return _generic_new(_next_in_mro(cls), cls, *args, **kwds)
             return _generic_new(cls.__next_in_mro__, cls, *args, **kwds)
 
 

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -757,8 +757,8 @@ class _ProtocolMeta(GenericMeta):
                                   super(GenericMeta, self).__hash__())
         return self
     if OLD_GENERICS:
-        def __new__(self, *args, **kwargs):
-            return super(self).__new__(*args, **kwargs)
+        def __new__(cls, *args, **kwargs):
+            return super(_ProtocolMeta, cls).__new__(*args, **kwargs)
 
     def __init__(cls, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -884,7 +884,7 @@ class _ProtocolMeta(GenericMeta):
 
     if OLD_GENERICS:
         def __getitem__(self, *args, **kwargs):
-            return super(self).__getitem__(*args, **kwargs)
+            return super(_ProtocolMeta, self).__getitem__(*args, **kwargs)
 
 
 if NO_PROTOCOL:

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -790,6 +790,9 @@ class _ProtocolMeta(GenericMeta):
         def _proto_hook(other):
             if not cls.__dict__.get('_is_protocol', None):
                 return NotImplemented
+            if not isinstance(other, type):
+                # Same error as for issubclass(1, int)
+                raise TypeError('issubclass() arg 1 must be a class')
             for attr in cls._get_protocol_attrs():
                 for base in other.__mro__:
                     if attr in base.__dict__:

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -9,11 +9,11 @@ import collections.abc as collections_abc
 # We use internal typing helpers here, but this significantly reduces
 # code duplication. (Also this is only until Protocol is in typing.)
 from typing import GenericMeta, TypingMeta, Generic, Callable, TypeVar, Tuple
-NO_PROTOCOL = False
+OLD_GENERICS = False
 try:
     from typing import _type_vars, _next_in_mro, _type_check
 except ImportError:
-    NO_PROTOCOL = True
+    OLD_GENERICS = True
 try:
     from typing import _no_slots_copy
 except ImportError:
@@ -754,6 +754,9 @@ class _ProtocolMeta(GenericMeta):
             self.__tree_hash__ = (hash(self._subs_tree()) if origin else
                                   super(GenericMeta, self).__hash__())
         return self
+    if OLD_GENERICS:
+        def __new__(*args, **kwargs):
+            return super().__new__(*args, **kwars)
 
     def __init__(cls, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -876,6 +879,13 @@ class _ProtocolMeta(GenericMeta):
                               origin=self,
                               extra=self.__extra__,
                               orig_bases=self.__orig_bases__)
+
+    if OLD_GENERICS:
+        def __getitem__(*args, **kwargs):
+            return super().__getitem__(*args, **kwars)
+
+
+NO_PROTOCOL = sys.version_info[:3] == (3, 5, 0)
 
 if NO_PROTOCOL:
     del _ProtocolMeta

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -758,7 +758,7 @@ class _ProtocolMeta(GenericMeta):
         return self
     if OLD_GENERICS:
         def __new__(self, *args, **kwargs):
-            return super(self).__new__(*args, **kwars)
+            return super(self).__new__(*args, **kwargs)
 
     def __init__(cls, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -884,7 +884,7 @@ class _ProtocolMeta(GenericMeta):
 
     if OLD_GENERICS:
         def __getitem__(self, *args, **kwargs):
-            return super(self).__getitem__(*args, **kwars)
+            return super(self).__getitem__(*args, **kwargs)
 
 
 if NO_PROTOCOL:

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -122,6 +122,8 @@ __all__ = [
     'TYPE_CHECKING',
 ]
 
+NO_PROTOCOL = sys.version_info[:3] == (3, 5, 0)
+
 if not NO_PROTOCOL:
     __all__.extend(['Protocol', 'runtime'])
 
@@ -884,8 +886,6 @@ class _ProtocolMeta(GenericMeta):
         def __getitem__(*args, **kwargs):
             return super().__getitem__(*args, **kwars)
 
-
-NO_PROTOCOL = sys.version_info[:3] == (3, 5, 0)
 
 if NO_PROTOCOL:
     del _ProtocolMeta

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -804,7 +804,8 @@ class _ProtocolMeta(GenericMeta):
                 issubclass(instance.__class__, self)):
             return True
         if self._is_protocol:
-            if all(hasattr(instance, attr) and getattr(instance, attr) is not None
+            if all(hasattr(instance, attr) and
+                    (not callable(getattr(self, attr)) or getattr(instance, attr) is not None)
                     for attr in self._get_protocol_attrs()):
                 return True
         return super(GenericMeta, self).__instancecheck__(instance)

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -771,6 +771,7 @@ class _ProtocolMeta(GenericMeta):
                                     ' got %r' % base)
             cls._callable_members_only = all(callable(getattr(cls, attr))
                                              for attr in cls._get_protocol_attrs())
+
             def _no_init(self, *args, **kwargs):
                 if type(self)._is_protocol:
                     raise TypeError('Protocols cannot be instantiated')
@@ -805,7 +806,8 @@ class _ProtocolMeta(GenericMeta):
             return True
         if self._is_protocol:
             if all(hasattr(instance, attr) and
-                    (not callable(getattr(self, attr)) or getattr(instance, attr) is not None)
+                    (not callable(getattr(self, attr)) or
+                     getattr(instance, attr) is not None)
                     for attr in self._get_protocol_attrs()):
                 return True
         return super(GenericMeta, self).__instancecheck__(instance)
@@ -826,7 +828,8 @@ class _ProtocolMeta(GenericMeta):
                 not self._callable_members_only):
             if sys._getframe(1).f_globals['__name__'] in ['abc', 'functools']:
                 return super(GenericMeta, self).__subclasscheck__(cls)
-            raise TypeError("Protocols with non-method members don't support issubclass()")
+            raise TypeError("Protocols with non-method members"
+                            " don't support issubclass()")
         return super(GenericMeta, self).__subclasscheck__(cls)
 
     def _get_protocol_attrs(self):

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -769,7 +769,8 @@ class _ProtocolMeta(GenericMeta):
                         isinstance(base, GenericMeta) and base.__origin__ is Generic):
                     raise TypeError('Protocols can only inherit from other protocols,'
                                     ' got %r' % base)
-
+            cls._callable_members_only = all(callable(getattr(cls, attr))
+                                             for attr in cls._get_protocol_attrs())
             def _no_init(self, *args, **kwargs):
                 if type(self)._is_protocol:
                     raise TypeError('Protocols cannot be instantiated')
@@ -798,12 +799,15 @@ class _ProtocolMeta(GenericMeta):
 
     def __instancecheck__(self, instance):
         # We need this method for situations where attributes are assigned in __init__
-        if issubclass(instance.__class__, self):
+        if ((not getattr(self, '_is_protocol', False) or
+                self._callable_members_only) and
+                issubclass(instance.__class__, self)):
             return True
         if self._is_protocol:
-            return all(hasattr(instance, attr) and getattr(instance, attr) is not None
-                       for attr in self._get_protocol_attrs())
-        return False
+            if all(hasattr(instance, attr) and getattr(instance, attr) is not None
+                    for attr in self._get_protocol_attrs()):
+                return True
+        return super(GenericMeta, self).__instancecheck__(instance)
 
     def __subclasscheck__(self, cls):
         if self.__origin__ is not None:
@@ -817,6 +821,11 @@ class _ProtocolMeta(GenericMeta):
                 return False
             raise TypeError("Instance and class checks can only be used with"
                             " @runtime protocols")
+        if (self.__dict__.get('_is_runtime_protocol', None) and
+                not self._callable_members_only):
+            if sys._getframe(1).f_globals['__name__'] in ['abc', 'functools']:
+                return super(GenericMeta, self).__subclasscheck__(cls)
+            raise TypeError("Protocols with non-method members don't support issubclass()")
         return super(GenericMeta, self).__subclasscheck__(cls)
 
     def _get_protocol_attrs(self):
@@ -833,7 +842,8 @@ class _ProtocolMeta(GenericMeta):
                         '__next_in_mro__', '__parameters__', '__origin__',
                         '__orig_bases__', '__extra__', '__tree_hash__',
                         '__doc__', '__subclasshook__', '__init__', '__new__',
-                        '__module__', '_MutableMapping__marker', '_gorg')):
+                        '__module__', '_MutableMapping__marker', '_gorg',
+                        '_callable_members_only')):
                     attrs.add(attr)
         return attrs
 

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -10,9 +10,18 @@ import collections.abc as collections_abc
 # code duplication. (Also this is only until Protocol is in typing.)
 from typing import (
     GenericMeta, TypingMeta, Generic, Callable, TypeVar, Tuple,
-    _no_slots_copy, _type_vars, _next_in_mro, _tp_cache, _type_check,
+    _type_vars, _next_in_mro, _tp_cache, _type_check,
     _TypingEllipsis, _TypingEmpty, _make_subclasshook, _check_generic
 )
+try:
+    from typing import _no_slots_copy
+except ImportError:
+    def _no_slots_copy(dct):
+        dict_copy = dict(dct)
+        if '__slots__' in dict_copy:
+            for slot in dict_copy['__slots__']:
+                dict_copy.pop(slot, None)
+        return dict_copy
 
 if hasattr(typing, '_generic_new'):
     _generic_new = typing._generic_new

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -10,7 +10,7 @@ import collections.abc as collections_abc
 # code duplication. (Also this is only until Protocol is in typing.)
 from typing import (
     GenericMeta, TypingMeta, Generic, Callable, TypeVar, Tuple,
-    _type_vars, _next_in_mro, _type_check, _TypingEllipsis, _TypingEmpty,
+    _type_vars, _next_in_mro, _type_check,
     _make_subclasshook, _check_generic
 )
 try:
@@ -26,6 +26,11 @@ try:
     from typing import _tp_cache
 except ImportError:
     _tp_cache = lambda x: x
+try:
+    from typing import _TypingEllipsis, _TypingEmpty
+except ImportError:
+    class _TypingEllipsis: pass
+    class _TypingEmpty: pass
 
 if hasattr(typing, '_generic_new'):
     _generic_new = typing._generic_new
@@ -721,7 +726,8 @@ class ProtocolMeta(GenericMeta):
             '__subclasshook__' not in namespace and extra or
             getattr(self.__subclasshook__, '__name__', '') == '__extrahook__'
         ):
-            self.__subclasshook__ = _make_subclasshook(self)
+            if _make_subclasshook:
+                self.__subclasshook__ = _make_subclasshook(self)
         if isinstance(extra, abc.ABCMeta):
             self._abc_registry = extra._abc_registry
             self._abc_cache = extra._abc_cache

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -806,7 +806,7 @@ class _ProtocolMeta(GenericMeta):
             return True
         if self._is_protocol:
             if all(hasattr(instance, attr) and
-                    (not callable(getattr(self, attr)) or
+                    (not callable(getattr(self, attr, None)) or
                      getattr(instance, attr) is not None)
                     for attr in self._get_protocol_attrs()):
                 return True

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -680,7 +680,7 @@ def _collection_protocol(cls):
                                '_abcoll', 'abc'))
 
 
-class ProtocolMeta(GenericMeta):
+class _ProtocolMeta(GenericMeta):
     """Internal metaclass for Protocol.
 
     This exists so Protocol classes can be generic without deriving
@@ -704,7 +704,7 @@ class ProtocolMeta(GenericMeta):
                     if gvars is not None:
                         raise TypeError(
                             "Cannot inherit from Generic[...] or"
-                            " Protocol[...] multiple types.")
+                            " Protocol[...] multiple times.")
                     gvars = base.__parameters__
             if gvars is None:
                 gvars = tvars
@@ -759,7 +759,7 @@ class ProtocolMeta(GenericMeta):
         super().__init__(*args, **kwargs)
         if not cls.__dict__.get('_is_protocol', None):
             cls._is_protocol = any(b is Protocol or
-                                   isinstance(b, ProtocolMeta) and
+                                   isinstance(b, _ProtocolMeta) and
                                    b.__origin__ is Protocol
                                    for b in cls.__bases__)
         if cls._is_protocol:
@@ -786,7 +786,7 @@ class ProtocolMeta(GenericMeta):
                             return NotImplemented
                         break
                     if (attr in getattr(base, '__annotations__', {}) and
-                            isinstance(other, ProtocolMeta) and other._is_protocol):
+                            isinstance(other, _ProtocolMeta) and other._is_protocol):
                         break
                 else:
                     return NotImplemented
@@ -878,9 +878,9 @@ class ProtocolMeta(GenericMeta):
                               orig_bases=self.__orig_bases__)
 
 if NO_PROTOCOL:
-    del ProtocolMeta
+    del _ProtocolMeta
 else:
-    class Protocol(metaclass=ProtocolMeta):
+    class Protocol(metaclass=_ProtocolMeta):
         """Base class for protocol classes. Protocol classes are defined as::
 
           class Proto(Protocol[T]):
@@ -922,7 +922,7 @@ def runtime(cls):
     This allows a simple-minded structural check very similar to the
     one-offs in collections.abc such as Hashable.
     """
-    if not isinstance(cls, ProtocolMeta) or not cls._is_protocol:
+    if not isinstance(cls, _ProtocolMeta) or not cls._is_protocol:
         raise TypeError('@runtime can be only applied to protocol classes,'
                         ' got %r' % cls)
     cls._is_runtime_protocol = True

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -750,8 +750,9 @@ class ProtocolMeta(GenericMeta):
         elif origin is not None:
             self._abc_registry = origin._abc_registry
             self._abc_cache = origin._abc_cache
-        self.__tree_hash__ = (hash(self._subs_tree()) if origin else
-                              super(GenericMeta, self).__hash__())
+        if hasattr(self, '_subs_tree'):
+            self.__tree_hash__ = (hash(self._subs_tree()) if origin else
+                                  super(GenericMeta, self).__hash__())
         return self
 
     def __init__(cls, *args, **kwargs):

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -97,7 +97,6 @@ __all__ = [
     # Super-special typing primitives.
     'ClassVar',
     'Type',
-    'Protocol',
 
     # ABCs (from collections.abc).
     # The following are added depending on presence
@@ -119,11 +118,12 @@ __all__ = [
     # One-off things.
     'NewType',
     'overload',
-    'runtime',
     'Text',
     'TYPE_CHECKING',
 ]
 
+if not NO_PROTOCOL:
+    __all__.extend(['Protocol', 'runtime'])
 
 # TODO
 if hasattr(typing, 'NoReturn'):

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -768,13 +768,18 @@ class ProtocolMeta(GenericMeta):
         return False
 
     def __subclasscheck__(self, cls):
+        if self.__origin__ is not None:
+            if sys._getframe(1).f_globals['__name__'] not in ['abc', 'functools']:
+                raise TypeError("Parameterized generics cannot be used with class "
+                                "or instance checks")
+            return False
         if (self.__dict__.get('_is_protocol', None) and
                 not self.__dict__.get('_is_runtime_protocol', None)):
             if sys._getframe(1).f_globals['__name__'] in ['abc', 'functools']:
                 return False
             raise TypeError("Instance and class checks can only be used with"
                             " @runtime protocols")
-        return super().__subclasscheck__(cls)
+        return super(GenericMeta, self).__subclasscheck__(cls)
 
     def _get_protocol_attrs(self):
         attrs = set()

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -757,8 +757,8 @@ class _ProtocolMeta(GenericMeta):
                                   super(GenericMeta, self).__hash__())
         return self
     if OLD_GENERICS:
-        def __new__(cls, *args, **kwargs):
-            return super(_ProtocolMeta, cls).__new__(*args, **kwargs)
+        def __new__(cls, name, bases, namespace, **kwargs):
+            return super(_ProtocolMeta, cls).__new__(name, bases, namespace, **kwargs)
 
     def __init__(cls, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -883,8 +883,8 @@ class _ProtocolMeta(GenericMeta):
                               orig_bases=self.__orig_bases__)
 
     if OLD_GENERICS:
-        def __getitem__(self, *args, **kwargs):
-            return super(_ProtocolMeta, self).__getitem__(*args, **kwargs)
+        def __getitem__(self, params):
+            return super(_ProtocolMeta, self).__getitem__(params)
 
 
 if NO_PROTOCOL:

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -769,7 +769,7 @@ class _ProtocolMeta(GenericMeta):
                         isinstance(base, GenericMeta) and base.__origin__ is Generic):
                     raise TypeError('Protocols can only inherit from other protocols,'
                                     ' got %r' % base)
-            cls._callable_members_only = all(callable(getattr(cls, attr))
+            cls._callable_members_only = all(callable(getattr(cls, attr, None))
                                              for attr in cls._get_protocol_attrs())
 
             def _no_init(self, *args, **kwargs):

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -10,8 +10,8 @@ import collections.abc as collections_abc
 # code duplication. (Also this is only until Protocol is in typing.)
 from typing import (
     GenericMeta, TypingMeta, Generic, Callable, TypeVar, Tuple,
-    _type_vars, _next_in_mro, _tp_cache, _type_check,
-    _TypingEllipsis, _TypingEmpty, _make_subclasshook, _check_generic
+    _type_vars, _next_in_mro, _type_check, _TypingEllipsis, _TypingEmpty,
+    _make_subclasshook, _check_generic
 )
 try:
     from typing import _no_slots_copy
@@ -22,6 +22,10 @@ except ImportError:
             for slot in dict_copy['__slots__']:
                 dict_copy.pop(slot, None)
         return dict_copy
+try:
+    from typing import _tp_cache
+except ImportError:
+    _tp_cache = lambda x: x
 
 if hasattr(typing, '_generic_new'):
     _generic_new = typing._generic_new


### PR DESCRIPTION
This PR is essentially an adaptation of #417, here are some comments:
* There is only infrastructure for user-defined protocols, all existing ABCs like ``Iterable`` etc. will be kept nominal for some time.
* I tried to support all versions of ``typing``, but it looks like 3.5.0 and 3.5.1 are too hard.
* There is some code duplication and recourse to private API, I tried to minimize this, but ``Protocol`` really needs to be special in many aspects (like ``Generic``).
* The implementation is on conservative/safe side with respect to structural subtyping, i.e. attributes should be actually _defined_, not just _declared_ in a subclass, see examples in the description of #417 

@Michael0x2a @vlasovskikh I will be grateful for a code review and/or playing with this and commenting whether the behaviour matches your expectations.

cc @JukkaL @ambv @gvanrossum 