### PR TITLE
get_type_hints(): find the right globalns for classes and modules

### DIFF
--- a/src/mod_generics_cache.py
+++ b/src/mod_generics_cache.py
@@ -1,14 +1,21 @@
 """Module for testing the behavior of generics across different modules."""
 
-from typing import TypeVar, Generic
+from typing import TypeVar, Generic, Optional
+
+default_a: Optional['A'] = None
+default_b: Optional['B'] = None
 
 T = TypeVar('T')
 
 
 class A(Generic[T]):
-    pass
+    some_b: 'B'
 
 
 class B(Generic[T]):
     class A(Generic[T]):
         pass
+
+    my_inner_a1: 'B.A'
+    my_inner_a2: A
+    my_outer_a: 'A'  # unless somebody calls get_type_hints with localns=B.__dict__

--- a/src/mod_generics_cache.py
+++ b/src/mod_generics_cache.py
@@ -1,21 +1,53 @@
 """Module for testing the behavior of generics across different modules."""
 
+import sys
+from textwrap import dedent
 from typing import TypeVar, Generic, Optional
 
-default_a: Optional['A'] = None
-default_b: Optional['B'] = None
 
-T = TypeVar('T')
+if sys.version_info[:2] >= (3, 6):
+    exec(dedent("""
+    default_a: Optional['A'] = None
+    default_b: Optional['B'] = None
+
+    T = TypeVar('T')
 
 
-class A(Generic[T]):
-    some_b: 'B'
-
-
-class B(Generic[T]):
     class A(Generic[T]):
-        pass
+        some_b: 'B'
 
-    my_inner_a1: 'B.A'
-    my_inner_a2: A
-    my_outer_a: 'A'  # unless somebody calls get_type_hints with localns=B.__dict__
+
+    class B(Generic[T]):
+        class A(Generic[T]):
+            pass
+
+        my_inner_a1: 'B.A'
+        my_inner_a2: A
+        my_outer_a: 'A'  # unless somebody calls get_type_hints with localns=B.__dict__
+    """))
+else:  # This should stay in sync with the syntax above.
+    __annotations__ = dict(
+        default_a=Optional['A'],
+        default_b=Optional['B'],
+    )
+    default_a = None
+    default_b = None
+
+    T = TypeVar('T')
+
+
+    class A(Generic[T]):
+        __annotations__ = dict(
+            some_b='B'
+        )
+
+
+    class B(Generic[T]):
+        class A(Generic[T]):
+            pass
+
+        __annotations__ = dict(
+            my_inner_a1='B.A',
+            my_inner_a2=A,
+            my_outer_a='A'  # unless somebody calls get_type_hints with localns=B.__dict__
+        )


### PR DESCRIPTION
This makes the default behavior (without specifying `globalns` manually) more
predictable for users.

Implementation for classes assumes has a `__module__` attribute and that module
is present in `sys.modules`.  It does this recursively for all bases in the
MRO.  For modules, the implementation just uses their `__dict__` directly.

This is backwards compatible, will just raise fewer exceptions in naive user
code.