### PR TITLE
Fix interaction between typing_extensions and collections.abc

### DIFF
--- a/typing_extensions/src_py2/test_typing_extensions.py
+++ b/typing_extensions/src_py2/test_typing_extensions.py
@@ -119,7 +119,7 @@ class ClassVarTests(BaseTestCase):
 class CollectionsAbcTests(BaseTestCase):
 
     def test_isinstance_collections(self):
-        self.assertNotIsInstance(1, collections_abc.Mapping)
+        self.assertNotIsInstance(1, collections.Mapping)
 
     def test_contextmanager(self):
         @contextlib.contextmanager

--- a/typing_extensions/src_py2/test_typing_extensions.py
+++ b/typing_extensions/src_py2/test_typing_extensions.py
@@ -120,6 +120,9 @@ class CollectionsAbcTests(BaseTestCase):
 
     def test_isinstance_collections(self):
         self.assertNotIsInstance(1, collections.Mapping)
+        self.assertNotIsInstance(1, collections.Iterable)
+        self.assertNotIsInstance(1, collections.Container)
+        self.assertNotIsInstance(1, collections.Sized)
 
     def test_contextmanager(self):
         @contextlib.contextmanager

--- a/typing_extensions/src_py2/test_typing_extensions.py
+++ b/typing_extensions/src_py2/test_typing_extensions.py
@@ -123,6 +123,10 @@ class CollectionsAbcTests(BaseTestCase):
         self.assertNotIsInstance(1, collections.Iterable)
         self.assertNotIsInstance(1, collections.Container)
         self.assertNotIsInstance(1, collections.Sized)
+        with self.assertRaises(TypeError):
+            isinstance(collections.deque(), typing_extensions.Deque[int])
+        with self.assertRaises(TypeError):
+            issubclass(collections.Counter, typing_extensions.Counter[str])
 
     def test_contextmanager(self):
         @contextlib.contextmanager

--- a/typing_extensions/src_py2/test_typing_extensions.py
+++ b/typing_extensions/src_py2/test_typing_extensions.py
@@ -118,6 +118,9 @@ class ClassVarTests(BaseTestCase):
 
 class CollectionsAbcTests(BaseTestCase):
 
+    def test_isinstance_collections(self):
+        self.assertNotIsInstance(1, collections_abc.Mapping)
+
     def test_contextmanager(self):
         @contextlib.contextmanager
         def manager():

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -346,7 +346,7 @@ class GetTypeHintTests(BaseTestCase):
 class CollectionsAbcTests(BaseTestCase):
 
     def test_isinstance_collections(self):
-        isinstance(1, collections_abc.Mapping)
+        self.assertNotIsInstance(1, collections_abc.Mapping)
 
     @skipUnless(ASYNCIO, 'Python 3.5 and multithreading required')
     def test_awaitable(self):

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -347,6 +347,9 @@ class CollectionsAbcTests(BaseTestCase):
 
     def test_isinstance_collections(self):
         self.assertNotIsInstance(1, collections_abc.Mapping)
+        self.assertNotIsInstance(1, collections_abc.Iterable)
+        self.assertNotIsInstance(1, collections_abc.Container)
+        self.assertNotIsInstance(1, collections_abc.Sized)
 
     @skipUnless(ASYNCIO, 'Python 3.5 and multithreading required')
     def test_awaitable(self):

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -345,6 +345,9 @@ class GetTypeHintTests(BaseTestCase):
 
 class CollectionsAbcTests(BaseTestCase):
 
+    def test_isinstance_collections(self):
+        isinstance(1, collections_abc.Mapping)
+
     @skipUnless(ASYNCIO, 'Python 3.5 and multithreading required')
     def test_awaitable(self):
         ns = {}

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -350,6 +350,11 @@ class CollectionsAbcTests(BaseTestCase):
         self.assertNotIsInstance(1, collections_abc.Iterable)
         self.assertNotIsInstance(1, collections_abc.Container)
         self.assertNotIsInstance(1, collections_abc.Sized)
+        if SUBCLASS_CHECK_FORBIDDEN:
+            with self.assertRaises(TypeError):
+                isinstance(collections.deque(), typing_extensions.Deque[int])
+            with self.assertRaises(TypeError):
+                issubclass(collections.Counter, typing_extensions.Counter[str])
 
     @skipUnless(ASYNCIO, 'Python 3.5 and multithreading required')
     def test_awaitable(self):

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -411,8 +411,16 @@ def _define_guard(type_name):
     else:
         return False
 
+
 class _ExtensionsGenericMeta(GenericMeta):
     def __subclasscheck__(self, subclass):
+        """This mimics a more modern GenericMeta.__subclasscheck__() logic
+        (that does not have problems with recursion) to work around interactions
+        between collections, typing, and typing_extensions on older
+        versions of Python, see https://github.com/python/typing/issues/501.
+        """
+        if not self.__extra__:
+            return super().__subclasscheck__(subclass)
         res = self.__extra__.__subclasshook__(subclass)
         if res is not NotImplemented:
             return res
@@ -425,26 +433,31 @@ class _ExtensionsGenericMeta(GenericMeta):
                 return True
         return False
 
+
 if _define_guard('Awaitable'):
-    class Awaitable(typing.Generic[T_co], metaclass=_ExtensionsGenericMeta, extra=collections_abc.Awaitable):
+    class Awaitable(typing.Generic[T_co], metaclass=_ExtensionsGenericMeta,
+                    extra=collections_abc.Awaitable):
         __slots__ = ()
 
 
 if _define_guard('Coroutine'):
     class Coroutine(Awaitable[V_co], typing.Generic[T_co, T_contra, V_co],
-                    metaclass=_ExtensionsGenericMeta, extra=collections_abc.Coroutine):
+                    metaclass=_ExtensionsGenericMeta,
+                    extra=collections_abc.Coroutine):
         __slots__ = ()
 
 
 if _define_guard('AsyncIterable'):
     class AsyncIterable(typing.Generic[T_co],
-                        metaclass=_ExtensionsGenericMeta, extra=collections_abc.AsyncIterable):
+                        metaclass=_ExtensionsGenericMeta,
+                        extra=collections_abc.AsyncIterable):
         __slots__ = ()
 
 
 if _define_guard('AsyncIterator'):
     class AsyncIterator(AsyncIterable[T_co],
-                        metaclass=_ExtensionsGenericMeta, extra=collections_abc.AsyncIterator):
+                        metaclass=_ExtensionsGenericMeta,
+                        extra=collections_abc.AsyncIterator):
         __slots__ = ()
 
 
@@ -452,7 +465,8 @@ if hasattr(typing, 'Deque'):
     Deque = typing.Deque
 elif _geqv_defined:
     class Deque(collections.deque, typing.MutableSequence[T],
-                metaclass=_ExtensionsGenericMeta, extra=collections.deque):
+                metaclass=_ExtensionsGenericMeta,
+                extra=collections.deque):
         __slots__ = ()
 
         def __new__(cls, *args, **kwds):
@@ -461,7 +475,8 @@ elif _geqv_defined:
             return _generic_new(collections.deque, cls, *args, **kwds)
 else:
     class Deque(collections.deque, typing.MutableSequence[T],
-                metaclass=_ExtensionsGenericMeta, extra=collections.deque):
+                metaclass=_ExtensionsGenericMeta,
+                extra=collections.deque):
         __slots__ = ()
 
         def __new__(cls, *args, **kwds):
@@ -474,7 +489,8 @@ if hasattr(typing, 'ContextManager'):
     ContextManager = typing.ContextManager
 elif hasattr(contextlib, 'AbstractContextManager'):
     class ContextManager(typing.Generic[T_co],
-                         metaclass=_ExtensionsGenericMeta, extra=contextlib.AbstractContextManager):
+                         metaclass=_ExtensionsGenericMeta,
+                         extra=contextlib.AbstractContextManager):
         __slots__ = ()
 else:
     class ContextManager(typing.Generic[T_co]):
@@ -506,7 +522,8 @@ if hasattr(typing, 'AsyncContextManager'):
     __all__.append('AsyncContextManager')
 elif hasattr(contextlib, 'AbstractAsyncContextManager'):
     class AsyncContextManager(typing.Generic[T_co],
-                              metaclass=_ExtensionsGenericMeta, extra=contextlib.AbstractAsyncContextManager):
+                              metaclass=_ExtensionsGenericMeta,
+                              extra=contextlib.AbstractAsyncContextManager):
         __slots__ = ()
 
     __all__.append('AsyncContextManager')
@@ -536,7 +553,8 @@ if hasattr(typing, 'DefaultDict'):
     DefaultDict = typing.DefaultDict
 elif _geqv_defined:
     class DefaultDict(collections.defaultdict, typing.MutableMapping[KT, VT],
-                      metaclass=_ExtensionsGenericMeta, extra=collections.defaultdict):
+                      metaclass=_ExtensionsGenericMeta,
+                      extra=collections.defaultdict):
 
         __slots__ = ()
 
@@ -546,7 +564,8 @@ elif _geqv_defined:
             return _generic_new(collections.defaultdict, cls, *args, **kwds)
 else:
     class DefaultDict(collections.defaultdict, typing.MutableMapping[KT, VT],
-                      metaclass=_ExtensionsGenericMeta, extra=collections.defaultdict):
+                      metaclass=_ExtensionsGenericMeta,
+                      extra=collections.defaultdict):
 
         __slots__ = ()
 
@@ -611,7 +630,8 @@ elif hasattr(collections, 'ChainMap'):
     # ChainMap only exists in 3.3+
     if _geqv_defined:
         class ChainMap(collections.ChainMap, typing.MutableMapping[KT, VT],
-                       metaclass=_ExtensionsGenericMeta, extra=collections.ChainMap):
+                       metaclass=_ExtensionsGenericMeta,
+                       extra=collections.ChainMap):
 
             __slots__ = ()
 
@@ -621,7 +641,8 @@ elif hasattr(collections, 'ChainMap'):
                 return _generic_new(collections.ChainMap, cls, *args, **kwds)
     else:
         class ChainMap(collections.ChainMap, typing.MutableMapping[KT, VT],
-                       metaclass=_ExtensionsGenericMeta, extra=collections.ChainMap):
+                       metaclass=_ExtensionsGenericMeta,
+                       extra=collections.ChainMap):
 
             __slots__ = ()
 
@@ -635,7 +656,8 @@ elif hasattr(collections, 'ChainMap'):
 
 if _define_guard('AsyncGenerator'):
     class AsyncGenerator(AsyncIterator[T_co], typing.Generic[T_co, T_contra],
-                         metaclass=_ExtensionsGenericMeta, extra=collections_abc.AsyncGenerator):
+                         metaclass=_ExtensionsGenericMeta,
+                         extra=collections_abc.AsyncGenerator):
         __slots__ = ()
 
 

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -419,7 +419,9 @@ class _ExtensionsGenericMeta(GenericMeta):
         between collections, typing, and typing_extensions on older
         versions of Python, see https://github.com/python/typing/issues/501.
         """
-        if not self.__extra__:
+        if (sys.version_info[:3] >= (3, 5, 3) or
+                sys.version_info[:3] < (3, 5, 0) or
+                not self.__extra__):
             return super().__subclasscheck__(subclass)
         res = self.__extra__.__subclasshook__(subclass)
         if res is not NotImplemented:

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -411,27 +411,40 @@ def _define_guard(type_name):
     else:
         return False
 
+class _ExtensionsGenericMeta(GenericMeta):
+    def __subclasscheck__(self, subclass):
+        res = self.__extra__.__subclasshook__(sublcass)
+        if res is not NotImplemented:
+            return res
+        if self.__extra__ in subclass.__mro__:
+            return True
+        for scls in self.__extra__.__subclasses__():
+            if isinstance(scls, GenericMeta):
+                continue
+            if issubclass(subclass, scls):
+                return True
+        return False
 
 if _define_guard('Awaitable'):
-    class Awaitable(typing.Generic[T_co], extra=collections_abc.Awaitable):
+    class Awaitable(typing.Generic[T_co], metaclass=_ExtensionsGenericMeta, extra=collections_abc.Awaitable):
         __slots__ = ()
 
 
 if _define_guard('Coroutine'):
     class Coroutine(Awaitable[V_co], typing.Generic[T_co, T_contra, V_co],
-                    extra=collections_abc.Coroutine):
+                    metaclass=_ExtensionsGenericMeta, extra=collections_abc.Coroutine):
         __slots__ = ()
 
 
 if _define_guard('AsyncIterable'):
     class AsyncIterable(typing.Generic[T_co],
-                        extra=collections_abc.AsyncIterable):
+                        metaclass=_ExtensionsGenericMeta, extra=collections_abc.AsyncIterable):
         __slots__ = ()
 
 
 if _define_guard('AsyncIterator'):
     class AsyncIterator(AsyncIterable[T_co],
-                        extra=collections_abc.AsyncIterator):
+                        metaclass=_ExtensionsGenericMeta, extra=collections_abc.AsyncIterator):
         __slots__ = ()
 
 
@@ -461,7 +474,7 @@ if hasattr(typing, 'ContextManager'):
     ContextManager = typing.ContextManager
 elif hasattr(contextlib, 'AbstractContextManager'):
     class ContextManager(typing.Generic[T_co],
-                         extra=contextlib.AbstractContextManager):
+                         metaclass=_ExtensionsGenericMeta, extra=contextlib.AbstractContextManager):
         __slots__ = ()
 else:
     class ContextManager(typing.Generic[T_co]):
@@ -493,7 +506,7 @@ if hasattr(typing, 'AsyncContextManager'):
     __all__.append('AsyncContextManager')
 elif hasattr(contextlib, 'AbstractAsyncContextManager'):
     class AsyncContextManager(typing.Generic[T_co],
-                              extra=contextlib.AbstractAsyncContextManager):
+                              metaclass=_ExtensionsGenericMeta, extra=contextlib.AbstractAsyncContextManager):
         __slots__ = ()
 
     __all__.append('AsyncContextManager')
@@ -622,7 +635,7 @@ elif hasattr(collections, 'ChainMap'):
 
 if _define_guard('AsyncGenerator'):
     class AsyncGenerator(AsyncIterator[T_co], typing.Generic[T_co, T_contra],
-                         extra=collections_abc.AsyncGenerator):
+                         metaclass=_ExtensionsGenericMeta, extra=collections_abc.AsyncGenerator):
         __slots__ = ()
 
 

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -419,9 +419,13 @@ class _ExtensionsGenericMeta(GenericMeta):
         between collections, typing, and typing_extensions on older
         versions of Python, see https://github.com/python/typing/issues/501.
         """
-        if (sys.version_info[:3] >= (3, 5, 3) or
-                sys.version_info[:3] < (3, 5, 0) or
-                not self.__extra__):
+        if sys.version_info[:3] >= (3, 5, 3) or sys.version_info[:3] < (3, 5, 0):
+            if self.__origin__ is not None:
+                if sys._getframe(1).f_globals['__name__'] not in ['abc', 'functools']:
+                    raise TypeError("Parameterized generics cannot be used with class "
+                                    "or instance checks")
+                return False
+        if not self.__extra__:
             return super().__subclasscheck__(subclass)
         res = self.__extra__.__subclasshook__(subclass)
         if res is not NotImplemented:

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -413,7 +413,7 @@ def _define_guard(type_name):
 
 class _ExtensionsGenericMeta(GenericMeta):
     def __subclasscheck__(self, subclass):
-        res = self.__extra__.__subclasshook__(sublcass)
+        res = self.__extra__.__subclasshook__(subclass)
         if res is not NotImplemented:
             return res
         if self.__extra__ in subclass.__mro__:
@@ -452,7 +452,7 @@ if hasattr(typing, 'Deque'):
     Deque = typing.Deque
 elif _geqv_defined:
     class Deque(collections.deque, typing.MutableSequence[T],
-                extra=collections.deque):
+                metaclass=_ExtensionsGenericMeta, extra=collections.deque):
         __slots__ = ()
 
         def __new__(cls, *args, **kwds):
@@ -461,7 +461,7 @@ elif _geqv_defined:
             return _generic_new(collections.deque, cls, *args, **kwds)
 else:
     class Deque(collections.deque, typing.MutableSequence[T],
-                extra=collections.deque):
+                metaclass=_ExtensionsGenericMeta, extra=collections.deque):
         __slots__ = ()
 
         def __new__(cls, *args, **kwds):
@@ -536,7 +536,7 @@ if hasattr(typing, 'DefaultDict'):
     DefaultDict = typing.DefaultDict
 elif _geqv_defined:
     class DefaultDict(collections.defaultdict, typing.MutableMapping[KT, VT],
-                      extra=collections.defaultdict):
+                      metaclass=_ExtensionsGenericMeta, extra=collections.defaultdict):
 
         __slots__ = ()
 
@@ -546,7 +546,7 @@ elif _geqv_defined:
             return _generic_new(collections.defaultdict, cls, *args, **kwds)
 else:
     class DefaultDict(collections.defaultdict, typing.MutableMapping[KT, VT],
-                      extra=collections.defaultdict):
+                      metaclass=_ExtensionsGenericMeta, extra=collections.defaultdict):
 
         __slots__ = ()
 
@@ -582,7 +582,7 @@ elif (3, 5, 0) <= sys.version_info[:3] <= (3, 5, 1):
 elif _geqv_defined:
     class Counter(collections.Counter,
                   typing.Dict[T, int],
-                  extra=collections.Counter):
+                  metaclass=_ExtensionsGenericMeta, extra=collections.Counter):
 
         __slots__ = ()
 
@@ -594,7 +594,7 @@ elif _geqv_defined:
 else:
     class Counter(collections.Counter,
                   typing.Dict[T, int],
-                  extra=collections.Counter):
+                  metaclass=_ExtensionsGenericMeta, extra=collections.Counter):
 
         __slots__ = ()
 
@@ -611,7 +611,7 @@ elif hasattr(collections, 'ChainMap'):
     # ChainMap only exists in 3.3+
     if _geqv_defined:
         class ChainMap(collections.ChainMap, typing.MutableMapping[KT, VT],
-                       extra=collections.ChainMap):
+                       metaclass=_ExtensionsGenericMeta, extra=collections.ChainMap):
 
             __slots__ = ()
 
@@ -621,7 +621,7 @@ elif hasattr(collections, 'ChainMap'):
                 return _generic_new(collections.ChainMap, cls, *args, **kwds)
     else:
         class ChainMap(collections.ChainMap, typing.MutableMapping[KT, VT],
-                       extra=collections.ChainMap):
+                       metaclass=_ExtensionsGenericMeta, extra=collections.ChainMap):
 
             __slots__ = ()
 


### PR DESCRIPTION
Fixes #501 

The idea is straightforward: special classes in ``typing_extensions`` that have ``__extra__`` should use a metaclass that fixes the problem in ``GenericMeta.__subclasscheck__`` on older versions of ``typing``.

Note that overriding ``__subclasscheck__`` tries to mimic the behaviour in the new versions of ``typing``. (I can't just use ``super().__subclasscheck__`` on unaffected versions, since this changes call stack depth and therefore breaks a ``sys._getframe`` hack on some other versions of ``typing``.)

@jabdoa2 Could you please check that this fixes the crash you found in https://github.com/dropbox/pyannotate/issues/36