### PR TITLE
Fix interaction between generics and __init_subclass__

### DIFF
--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -653,7 +653,6 @@ class GenericTests(BaseTestCase):
             pass
         class W(X[int]):
             pass
-        self.assertEqual(X.attr, 1)
         self.assertEqual(Y.attr, 2)
         self.assertEqual(Z.attr, 42)
         self.assertEqual(W.attr, 42)

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -37,6 +37,9 @@ except ImportError:
     from test import mod_generics_cache
 
 
+PY36 = sys.version_info[:2] >= (3, 6)
+
+
 class BaseTestCase(TestCase):
 
     def assertIsSubclass(self, cls, class_or_tuple, msg=None):
@@ -632,6 +635,28 @@ class GenericTests(BaseTestCase):
             Generic[T, T]
         with self.assertRaises(TypeError):
             Generic[T, S, T]
+
+    @skipUnless(PY36, "__init_subclass__ support required")
+    def test_init_subclass(self):
+        class X(typing.Generic[T]):
+            def __init_subclass__(cls, **kwargs):
+                super().__init_subclass__(**kwargs)
+                cls.attr = 42
+        class Y(X):
+            pass
+        self.assertEqual(Y.attr, 42)
+        with self.assertRaises(AttributeError):
+            X.attr
+        X.attr = 1
+        Y.attr = 2
+        class Z(Y):
+            pass
+        class W(X[int]):
+            pass
+        self.assertEqual(X.attr, 1)
+        self.assertEqual(Y.attr, 2)
+        self.assertEqual(Z.attr, 42)
+        self.assertEqual(W.attr, 42)
 
     def test_repr(self):
         self.assertEqual(repr(SimpleMapping),
@@ -1603,8 +1628,6 @@ else:
     # fake names for the sake of static analysis
     asyncio = None
     AwaitableWrapper = AsyncIteratorWrapper = ACM = object
-
-PY36 = sys.version_info[:2] >= (3, 6)
 
 PY36_TESTS = """
 from test import ann_module, ann_module2, ann_module3

--- a/src/typing.py
+++ b/src/typing.py
@@ -973,7 +973,7 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
         # remove bare Generic from bases if there are other generic bases
         if any(isinstance(b, GenericMeta) and b is not Generic for b in bases):
             bases = tuple(b for b in bases if b is not Generic)
-        namespace.update({'__origin__': origin, '__extra__': extra})
+        namespace.update({'__origin__': origin, '__extra__': extra, '_gorg': None})
         self = super().__new__(cls, name, bases, namespace, _root=True)
         super(GenericMeta, self).__setattr__('_gorg',
                                              self if not origin else origin._gorg)

--- a/src/typing.py
+++ b/src/typing.py
@@ -973,7 +973,8 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
         # remove bare Generic from bases if there are other generic bases
         if any(isinstance(b, GenericMeta) and b is not Generic for b in bases):
             bases = tuple(b for b in bases if b is not Generic)
-        namespace.update({'__origin__': origin, '__extra__': extra, '_gorg': None})
+        namespace.update({'__origin__': origin, '__extra__': extra,
+                          '_gorg': None if not origin else origin._gorg})
         self = super().__new__(cls, name, bases, namespace, _root=True)
         super(GenericMeta, self).__setattr__('_gorg',
                                              self if not origin else origin._gorg)
@@ -1164,7 +1165,8 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
         # We consider all the subscripted generics as proxies for original class
         if (
             attr.startswith('__') and attr.endswith('__') or
-            attr.startswith('_abc_')
+            attr.startswith('_abc_') or
+            self._gorg is None  # The class is not fully created, see #typing/506
         ):
             super(GenericMeta, self).__setattr__(attr, value)
         else:


### PR DESCRIPTION
Fixes #506 with one caveat.

Note that ``X[int]`` creates an actual new class object which is a subclass of ``X``. Therefore after this code:
```python
class X(Generic[T]):
        def __init_subclass__(cls, **kwargs):
            super().__init_subclass__(**kwargs)
            cls.attr = 42

X.attr =1
X[int]
```
``X.attr == 42``. This is because ``__init_subclass__`` being called on ``X[int]`` will assign ``X[int].attr = 42`` which is equivalent to ``X.attr = 42`` (since current rules are that subscripted generics are proxies for the original class).

This is something hard to fix, unless ``X[int]`` will not be a class object. So that this unfortunate interaction between ``__init_subclass__`` and generics may be another justification for PEP 560.

@gvanrossum I think it makes sense to include this fix (as well as #504) in 3.6.4rc1 which is planned for Monday. What do you think?