### PR TITLE
Add utility __pos__ and __neg__ operators to TypeVar

### DIFF
--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -236,6 +236,17 @@ class TypeVarTests(BaseTestCase):
         with self.assertRaises(ValueError):
             TypeVar('T', covariant=True, contravariant=True)
 
+    def test_typevar_unary_operators(self):
+        A = TypeVar('A')
+        self.assertFalse(A.__covariant__)
+        self.assertFalse(A.__contravariant__)
+        A_co = +A
+        self.assertTrue(A_co.__covariant__)
+        self.assertFalse(A_co.__contravariant__)
+        A_contra = -A
+        self.assertFalse(A_contra.__covariant__)
+        self.assertTrue(A_contra.__contravariant__)
+
 
 class UnionTests(BaseTestCase):
 

--- a/src/typing.py
+++ b/src/typing.py
@@ -534,6 +534,12 @@ class TypeVar(_TypingBase, _root=True):
     def __subclasscheck__(self, cls):
         raise TypeError("Type variables cannot be used with issubclass().")
 
+    def __neg__(self):
+        return TypeVar(self.__name__, *self.__constraints__, bound=self.__bound__, covariant=False, contravariant=True)
+
+    def __pos__(self):
+        return TypeVar(self.__name__, *self.__constraints__, bound=self.__bound__, covariant=True, contravariant=False)
+
 
 # Some unconstrained type variables.  These are used by the container types.
 # (These are not for export.)


### PR DESCRIPTION
We already include this in the `__repr__`.
This makes it easier to explicitly just use +/-T to make generics co/contra-variant.