### PR TITLE
Fix typing_extensions to support PEP 560

### DIFF
--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -1148,19 +1148,9 @@ if HAVE_PROTOCOLS:
                 self.assertFalse(P._is_runtime_protocol)
             self.assertTrue(PR._is_runtime_protocol)
             self.assertTrue(PG[int]._is_protocol)
-            if not PEP_560:
-                self.assertEqual(P._get_protocol_attrs(), {'meth'})
-                self.assertEqual(PR._get_protocol_attrs(), {'x'})
-                self.assertEqual(frozenset(PG._get_protocol_attrs()),
-                                 frozenset({'x', 'meth'}))
-                self.assertEqual(frozenset(PG[int]._get_protocol_attrs()),
-                                 frozenset({'x', 'meth'}))
-            else:
-                self.assertEqual(P._protocol_attrs, {'meth'})
-                self.assertEqual(PR._protocol_attrs, {'x'})
-                self.assertEqual(frozenset(PG._protocol_attrs),
-                                 frozenset({'x', 'meth'}))
-                self.assertEqual(frozenset(PG[int]._protocol_attrs),
+            self.assertEqual(typing_extensions._get_protocol_attrs(P), {'meth'})
+            self.assertEqual(typing_extensions._get_protocol_attrs(PR), {'x'})
+            self.assertEqual(frozenset(typing_extensions._get_protocol_attrs(PG)),
                                  frozenset({'x', 'meth'}))
 
         def test_no_runtime_deco_on_nominal(self):

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -1102,7 +1102,7 @@ if HAVE_PROTOCOLS:
             T = TypeVar('T')
             S = TypeVar('S')
             class P(Protocol[T, S]): pass
-            # After PEP 560 unsubscripted generics have standard repr.
+            # After PEP 560 unsubscripted generics have a standard repr.
             if not PEP_560:
                 self.assertTrue(repr(P).endswith('P'))
             self.assertTrue(repr(P[T, S]).endswith('P[~T, ~S]'))
@@ -1151,6 +1151,9 @@ if HAVE_PROTOCOLS:
             self.assertEqual(typing_extensions._get_protocol_attrs(P), {'meth'})
             self.assertEqual(typing_extensions._get_protocol_attrs(PR), {'x'})
             self.assertEqual(frozenset(typing_extensions._get_protocol_attrs(PG)),
+                             frozenset({'x', 'meth'}))
+            if not PEP_560:
+                self.assertEqual(frozenset(typing_extensions._get_protocol_attrs(PG[int])),
                                  frozenset({'x', 'meth'}))
 
         def test_no_runtime_deco_on_nominal(self):

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -20,6 +20,9 @@ except ImportError:
 import typing
 import typing_extensions
 import collections.abc as collections_abc
+
+PEP_560 = sys.version_info[:3] >= (3, 7, 0)
+
 OLD_GENERICS = False
 try:
     from typing import _type_vars, _next_in_mro, _type_check
@@ -471,7 +474,10 @@ class CollectionsAbcTests(BaseTestCase):
         class C(typing_extensions.Counter[T]): ...
         if TYPING_3_5_3:
             self.assertIs(type(C[int]()), C)
-            self.assertEqual(C.__bases__, (typing_extensions.Counter,))
+            if not PEP_560:
+                self.assertEqual(C.__bases__, (typing_extensions.Counter,))
+            else:
+                self.assertEqual(C.__bases__, (collections.Counter, typing.Generic))
 
     def test_counter_subclass_instantiation(self):
 
@@ -818,9 +824,10 @@ if HAVE_PROTOCOLS:
             self.assertIsSubclass(C, P)
             self.assertIsSubclass(C, PG)
             self.assertIsSubclass(BadP, PG)
-            self.assertIsSubclass(PG[int], PG)
-            self.assertIsSubclass(BadPG[int], P)
-            self.assertIsSubclass(BadPG[T], PG)
+            if not PEP_560:
+                self.assertIsSubclass(PG[int], PG)
+                self.assertIsSubclass(BadPG[int], P)
+                self.assertIsSubclass(BadPG[T], PG)
             with self.assertRaises(TypeError):
                 issubclass(C, PG[T])
             with self.assertRaises(TypeError):
@@ -1043,7 +1050,11 @@ if HAVE_PROTOCOLS:
                 def meth(self): pass
             class P(PR[int, str], Protocol):
                 y = 1
-            self.assertIsSubclass(PR[int, str], PR)
+            if not PEP_560:
+                self.assertIsSubclass(PR[int, str], PR)
+            else:
+                with self.assertRaises(TypeError):
+                    self.assertIsSubclass(PR[int, str], PR)
             self.assertIsSubclass(P, PR)
             with self.assertRaises(TypeError):
                 PR[int]
@@ -1091,7 +1102,9 @@ if HAVE_PROTOCOLS:
             T = TypeVar('T')
             S = TypeVar('S')
             class P(Protocol[T, S]): pass
-            self.assertTrue(repr(P).endswith('P'))
+            # After PEP 560 unsubscripted generics have standard repr.
+            if not PEP_560:
+                self.assertTrue(repr(P).endswith('P'))
             self.assertTrue(repr(P[T, S]).endswith('P[~T, ~S]'))
             self.assertTrue(repr(P[int, str]).endswith('P[int, str]'))
 
@@ -1135,12 +1148,20 @@ if HAVE_PROTOCOLS:
                 self.assertFalse(P._is_runtime_protocol)
             self.assertTrue(PR._is_runtime_protocol)
             self.assertTrue(PG[int]._is_protocol)
-            self.assertEqual(P._get_protocol_attrs(), {'meth'})
-            self.assertEqual(PR._get_protocol_attrs(), {'x'})
-            self.assertEqual(frozenset(PG._get_protocol_attrs()),
-                             frozenset({'x', 'meth'}))
-            self.assertEqual(frozenset(PG[int]._get_protocol_attrs()),
-                             frozenset({'x', 'meth'}))
+            if not PEP_560:
+                self.assertEqual(P._get_protocol_attrs(), {'meth'})
+                self.assertEqual(PR._get_protocol_attrs(), {'x'})
+                self.assertEqual(frozenset(PG._get_protocol_attrs()),
+                                 frozenset({'x', 'meth'}))
+                self.assertEqual(frozenset(PG[int]._get_protocol_attrs()),
+                                 frozenset({'x', 'meth'}))
+            else:
+                self.assertEqual(P._protocol_attrs, {'meth'})
+                self.assertEqual(PR._protocol_attrs, {'x'})
+                self.assertEqual(frozenset(PG._protocol_attrs),
+                                 frozenset({'x', 'meth'}))
+                self.assertEqual(frozenset(PG[int]._protocol_attrs),
+                                 frozenset({'x', 'meth'}))
 
         def test_no_runtime_deco_on_nominal(self):
             with self.assertRaises(TypeError):

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -997,24 +997,10 @@ if HAVE_PROTOCOLS:
         Protocol.__doc__ = Protocol.__doc__.format(bases="Protocol, Generic[T]" if
                                                    OLD_GENERICS else "Protocol[T]")
 
-    def runtime(cls):
-        """Mark a protocol class as a runtime protocol, so that it
-        can be used with isinstance() and issubclass(). Raise TypeError
-        if applied to a non-protocol class.
-
-        This allows a simple-minded structural check very similar to the
-        one-offs in collections.abc such as Hashable.
-        """
-        if not isinstance(cls, _ProtocolMeta) or not cls._is_protocol:
-            raise TypeError('@runtime can be only applied to protocol classes,'
-                            ' got %r' % cls)
-        cls._is_runtime_protocol = True
-        return cls
-
 
 if PEP_560:
     # We need to rewrite these from scratch.
-    del _ProtocolMeta, Protocol, runtime
+    del _ProtocolMeta, Protocol
 
     from typing import _type_check, _GenericAlias, _collect_type_vars
 

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -1019,7 +1019,8 @@ if PEP_560:
     from typing import _type_check, _GenericAlias, _collect_type_vars
 
     class _ProtocolMeta(abc.ABCMeta):
-        # This is a bit unfortunate and exists only because of lack of __instancehook__.
+        # This metaclass is a bit unfortunate and exists only because of the lack
+        # of __instancehook__.
         def __instancecheck__(cls, instance):
             # We need this method for situations where attributes are
             # assigned in __init__.

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -1017,20 +1017,20 @@ if PEP_560:
 
     class _ProtocolMeta(abc.ABCMeta):
         # This is a bit unfortunate and exists only because of lack of __instancehook__.
-            def __instancecheck__(cls, instance):
-                # We need this method for situations where attributes are
-                # assigned in __init__.
-                if ((not getattr(cls, '_is_protocol', False) or
-                        cls._callable_members_only) and
-                        issubclass(instance.__class__, cls)):
+        def __instancecheck__(cls, instance):
+            # We need this method for situations where attributes are
+            # assigned in __init__.
+            if ((not getattr(cls, '_is_protocol', False) or
+                    cls._callable_members_only) and
+                    issubclass(instance.__class__, cls)):
+                return True
+            if cls._is_protocol:
+                if all(hasattr(instance, attr) and
+                        (not callable(getattr(cls, attr, None)) or
+                         getattr(instance, attr) is not None)
+                        for attr in cls._protocol_attrs):
                     return True
-                if cls._is_protocol:
-                    if all(hasattr(instance, attr) and
-                            (not callable(getattr(cls, attr, None)) or
-                             getattr(instance, attr) is not None)
-                            for attr in cls._protocol_attrs):
-                        return True
-                return super().__instancecheck__(instance)
+            return super().__instancecheck__(instance)
 
 
     class Protocol(metaclass=_ProtocolMeta):
@@ -1144,12 +1144,12 @@ if PEP_560:
                 if not cls.__dict__.get('_is_protocol', None):
                     return NotImplemented
                 if not getattr(cls, '_is_runtime_protocol', False):
-                    if sys._getframe(2).f_globals['__name__'] in ['abc', 'functools', 'typing']:
+                    if sys._getframe(2).f_globals['__name__'] in ['abc', 'functools']:
                         return NotImplemented
                     raise TypeError("Instance and class checks can only be used with"
                                     " @runtime protocols")
                 if not cls._callable_members_only:
-                    if sys._getframe(2).f_globals['__name__'] in ['abc', 'functools', 'typing']:
+                    if sys._getframe(2).f_globals['__name__'] in ['abc', 'functools']:
                         return NotImplemented
                     raise TypeError("Protocols with non-method members"
                                     " don't support issubclass()")

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -1080,7 +1080,7 @@ if PEP_560:
                 params = (params,)
             if not params and cls is not Tuple:
                 raise TypeError(
-                    "Parameter list to {[...] cannot be empty".format(cls.__qualname__}))
+                    "Parameter list to {}[...] cannot be empty".format(cls.__qualname__))
             msg = "Parameters to generic types must be types."
             params = tuple(_type_check(p, msg) for p in params)
             if cls is Protocol:

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -5,10 +5,19 @@ import sys
 import typing
 import collections.abc as collections_abc
 
+# After PEP 560, internal typing API was substantially reworked.
+# This is especially important for Protocol class which uses internal APIs
+# quite extensivelly.
+PEP_560 = sys.version_info[:3] >= (3, 7, 0)
+
 # These are used by Protocol implementation
 # We use internal typing helpers here, but this significantly reduces
 # code duplication. (Also this is only until Protocol is in typing.)
-from typing import GenericMeta, TypingMeta, Generic, Callable, TypeVar, Tuple
+from typing import Generic, Callable, TypeVar, Tuple
+if PEP_560:
+    GenericMeta = TypingMeta = type
+else:
+    from typing import GenericMeta, TypingMeta
 OLD_GENERICS = False
 try:
     from typing import _type_vars, _next_in_mro, _type_check
@@ -998,3 +1007,221 @@ if HAVE_PROTOCOLS:
                             ' got %r' % cls)
         cls._is_runtime_protocol = True
         return cls
+
+
+if PEP_560:
+    # We need to rewrite these from scratch.
+    del _ProtocolMeta, Protocol, runtime
+
+from typing import _type_check, _GenericAlias, _collect_type_vars
+
+class _ProtocolMeta(abc.ABCMeta):
+    # This is a bit unfortunate and exists only because of lack of __instancehook__.
+        def __instancecheck__(cls, instance):
+            # We need this method for situations where attributes are
+            # assigned in __init__.
+            if ((not getattr(cls, '_is_protocol', False) or
+                    cls._callable_members_only) and
+                    issubclass(instance.__class__, cls)):
+                return True
+            if cls._is_protocol:
+                if all(hasattr(instance, attr) and
+                        (not callable(getattr(cls, attr, None)) or
+                         getattr(instance, attr) is not None)
+                        for attr in cls._protocol_attrs):
+                    return True
+            return super().__instancecheck__(instance)
+
+
+class Protocol(metaclass=_ProtocolMeta):
+    # There is quite a few overlapping code with typing.Generic.
+    # Unfortunarely it is hard to avoid this while these live in two different modules.
+    # The duplicated code will be removed when Protocol is moved to typing.
+    """Base class for protocol classes. Protocol classes are defined as::
+
+        class Proto(Protocol):
+            def meth(self) -> int:
+                ...
+
+    Such classes are primarily used with static type checkers that recognize
+    structural subtyping (static duck-typing), for example::
+
+        class C:
+            def meth(self) -> int:
+                return 0
+
+        def func(x: Proto) -> int:
+            return x.meth()
+
+        func(C())  # Passes static type check
+
+    See PEP 544 for details. Protocol classes decorated with
+    @typing_extensions.runtime act as simple-minded runtime protocol that checks
+    only the presence of given attributes, ignoring their type signatures.
+
+    Protocol classes can be generic, they are defined as::
+
+        class GenProto(Protocol[T]):
+            def meth(self) -> T:
+                ...
+    """
+    __slots__ = ()
+    _is_protocol = True
+
+    def __new__(cls, *args, **kwds):
+        if cls is Protocol:
+            raise TypeError("Type Protocol cannot be instantiated; "
+                            "it can be used only as a base class")
+        return super().__new__(cls)
+
+    @_tp_cache
+    def __class_getitem__(cls, params):
+        if not isinstance(params, tuple):
+            params = (params,)
+        if not params and cls is not Tuple:
+            raise TypeError(
+                f"Parameter list to {cls.__qualname__}[...] cannot be empty")
+        msg = "Parameters to generic types must be types."
+        params = tuple(_type_check(p, msg) for p in params)
+        if cls is Protocol:
+            # Generic can only be subscripted with unique type variables.
+            if not all(isinstance(p, TypeVar) for p in params):
+                raise TypeError(
+                    "Parameters to Protocol[...] must all be type variables")
+            if len(set(params)) != len(params):
+                raise TypeError(
+                    "Parameters to Protocol[...] must all be unique")
+        else:
+            # Subscripting a regular Generic subclass.
+            _check_generic(cls, params)
+        return _GenericAlias(cls, params)
+
+    def __init_subclass__(cls, *args, **kwargs):
+        tvars = []
+        if '__orig_bases__' in cls.__dict__:
+            error = Generic in cls.__orig_bases__
+        else:
+            error = Generic in cls.__bases__
+        if error:
+            raise TypeError("Cannot inherit from plain Generic")
+        if '__orig_bases__' in cls.__dict__:
+            tvars = _collect_type_vars(cls.__orig_bases__)
+            # Look for Generic[T1, ..., Tn] or Protocol[T1, ..., Tn].
+            # If found, tvars must be a subset of it.
+            # If not found, tvars is it.
+            # Also check for and reject plain Generic,
+            # and reject multiple Generic[...] and/or Protocol[...].
+            gvars = None
+            for base in cls.__orig_bases__:
+                if (isinstance(base, _GenericAlias) and
+                        base.__origin__ in (Generic, Protocol)):
+                    # for error messages
+                    the_base = 'Generic' if base.__origin__ is Generic else 'Protocol'
+                    if gvars is not None:
+                        raise TypeError(
+                            "Cannot inherit from Generic[...]"
+                            " and/or Protocol[...] multiple types.")
+                    gvars = base.__parameters__
+            if gvars is None:
+                gvars = tvars
+            else:
+                tvarset = set(tvars)
+                gvarset = set(gvars)
+                if not tvarset <= gvarset:
+                    s_vars = ', '.join(str(t) for t in tvars if t not in gvarset)
+                    s_args = ', '.join(str(g) for g in gvars)
+                    raise TypeError(f"Some type variables ({s_vars}) are"
+                                    f" not listed in {the_base}[{s_args}]")
+                tvars = gvars
+        cls.__parameters__ = tuple(tvars)
+
+        # Determine if this is a protocol or a concrete subclass.
+        if not cls.__dict__.get('_is_protocol', None):
+            cls._is_protocol = any(b is Protocol for b in cls.__bases__)
+
+        # Set (or override) the protocol subclass hook.
+        def _proto_hook(other):
+            if not cls.__dict__.get('_is_protocol', None):
+                return NotImplemented
+            if not getattr(cls, '_is_runtime_protocol', False):
+                if sys._getframe(2).f_globals['__name__'] in ['abc', 'functools', 'typing']:
+                    return NotImplemented
+                raise TypeError("Instance and class checks can only be used with"
+                                " @runtime protocols")
+            if not cls._callable_members_only:
+                if sys._getframe(2).f_globals['__name__'] in ['abc', 'functools', 'typing']:
+                    return NotImplemented
+                raise TypeError("Protocols with non-method members"
+                                " don't support issubclass()")
+            if not isinstance(other, type):
+                # Same error as for issubclass(1, int)
+                raise TypeError('issubclass() arg 1 must be a class')
+            if getattr(other, '_is_protocol', False):
+                return other._protocol_attrs >= cls._protocol_attrs
+            for attr in cls._protocol_attrs:
+                for base in other.__mro__:
+                    if attr in base.__dict__:
+                        if base.__dict__[attr] is None:
+                            return NotImplemented
+                        break
+                else:
+                    return NotImplemented
+            return True
+        if '__subclasshook__' not in cls.__dict__:
+            cls.__subclasshook__ = _proto_hook
+
+        # We have nothing more to do for non-protocols.
+        if not cls._is_protocol:
+            return
+
+        # Check consistency of bases.
+        for base in cls.__bases__:
+            if not (base in (object, Generic, Callable) or
+                    isinstance(base, _ProtocolMeta) and base._is_protocol):
+                raise TypeError('Protocols can only inherit from other'
+                                ' protocols, got %r' % base)
+
+        def _no_init(self, *args, **kwargs):
+            if type(self)._is_protocol:
+                raise TypeError('Protocols cannot be instantiated')
+        cls.__init__ = _no_init
+
+        # Caculate protocol members, and the all callable flag.
+        attrs = set()
+        for base in cls.__bases__:
+            if base.__name__ in ('Protocol', 'Generic'):
+                continue
+            attrs.update(base._protocol_attrs)
+        own_attrs = set()
+        annotations = getattr(cls, '__annotations__', {})
+        for attr in list(cls.__dict__.keys()) + list(annotations.keys()):
+            if (not attr.startswith('_abc_') and attr not in (
+                    '__abstractmethods__', '__annotations__', '__weakref__',
+                    '_is_protocol', '_is_runtime_protocol', '__dict__',
+                    '__args__', '__slots__', '_get_protocol_attrs',
+                    '__next_in_mro__', '__parameters__', '__origin__',
+                    '__orig_bases__', '__extra__', '__tree_hash__',
+                    '__doc__', '__subclasshook__', '__init__', '__new__',
+                    '__module__', '_MutableMapping__marker', '_gorg',
+                    '_callable_members_only')):
+                own_attrs.add(attr)
+        cls._protocol_attrs = attrs | own_attrs
+        cls._callable_members_only = (all(callable(getattr(cls, attr, None))
+                                                 for attr in own_attrs) and
+                                      all(base._callable_members_only for base in cls.__bases__
+                                          if base.__name__ not in ('Protocol', 'Generic')))
+
+
+def runtime(cls):
+    """Mark a protocol class as a runtime protocol, so that it
+    can be used with isinstance() and issubclass(). Raise TypeError
+    if applied to a non-protocol class.
+
+    This allows a simple-minded structural check very similar to the
+    one-offs in collections.abc such as Hashable.
+    """
+    if not isinstance(cls, _ProtocolMeta) or not cls._is_protocol:
+        raise TypeError('@runtime can be only applied to protocol classes,'
+                        ' got %r' % cls)
+    cls._is_runtime_protocol = True
+    return cls

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -1080,7 +1080,7 @@ if PEP_560:
                 params = (params,)
             if not params and cls is not Tuple:
                 raise TypeError(
-                    f"Parameter list to {cls.__qualname__}[...] cannot be empty")
+                    "Parameter list to {[...] cannot be empty".format(cls.__qualname__}))
             msg = "Parameters to generic types must be types."
             params = tuple(_type_check(p, msg) for p in params)
             if cls is Protocol:
@@ -1130,8 +1130,8 @@ if PEP_560:
                     if not tvarset <= gvarset:
                         s_vars = ', '.join(str(t) for t in tvars if t not in gvarset)
                         s_args = ', '.join(str(g) for g in gvars)
-                        raise TypeError(f"Some type variables ({s_vars}) are"
-                                        f" not listed in {the_base}[{s_args}]")
+                        raise TypeError("Some type variables ({}) are"
+                                        " not listed in {}[{}]".format(s_vars, the_base, s_args))
                     tvars = gvars
             cls.__parameters__ = tuple(tvars)
 


### PR DESCRIPTION
The main fix is rewriting `Protocol`. Although the fix is straightforward, there are some observations/details I wanted to discuss before moving `Protocol` to `typing`:
* It looks like we still need a metaclass for `Protocol` even with PEP 560. The problem is a certain asymmetry in ABCs API, there is `__subclasshook__`, but there is no such thing as `__instancehook__`. Because of this we need a metaclass with a single method. `__instancehook__` (or currently the metaclass) is needed to support structural `isinstance()` checks for concrete classes that set attributes on `self` so that fallback to `issubclass()` is not possible. Although protocols with non-method members are relatively rare, in view of planned support for static type checking in Bazel (and other modular build systems) protocols describing certain data will be needed. So we have two options here:
  - Continue to use metaclass, since explicitly subclassing protocols (and thus having metaclass conflicts) is rare. **(-0)**
  - Just add `__instancehook__` exactly the same way there is `__subclasshook__`, then we can keep `typing` metaclass-free even with protocols. **(+1)**
* Currently behaviour of `.register()` with protocols is not specified. As a result it is determined by the current implementation and has some (weird) corner cases. Maybe `.register()` should be actually prohibited for protocols (normal ABCs can still use it)? Protocols are supposed to be purely structural, allowing `.register()` breaks this logic and may introduce some type un-safety. So the options here are simple:
  - Specify the rules for how `.register()` should work for protocols and try to implement these rules. **(-1)**
  - Prohibit using `.register()` on protocols (still OK for normal ABCs). **(+0)**
* Third question is about what to do with extending "built-in" protocols? Existing implementation actually prohibits `class FancyIter(Iterable[str], Protocol): ...` (because protocols can only inherit form other protocols, but technically `collections.abc.Iterable` is a nominal class). However allowing this is not easy because machinery in `abc` (and `functools`) indiscriminately calls `issubclass()` on all subclasses of `Iterable`, but it is prohibited for non-runtime protocols. Here we have three options:
  - Don't allow extending built-in protocols. I don't like this because it reminds me `UserDict` and `UserList`. **(-1)**
  - Allow this and just continue to use the "good old" `sys._getframe()` hack (which I wanted to remove). **(-0)**
  - Allow this and patch `__bases__` in `__init_subclass__` to remove built-in protocols from there. We will also need to copy the methods to allow using them by explicit subclasses. **(+0)**

For clarity I added my votes for all options. @gvanrossum what is your opinion on these points. It is not urgent to discuss them, (I didn't act on any of these points in the PR, it just mirrors the pre-PEP 560 implementation so can be merged before we agree on these points) but we should discuss these before moving protocols to `typing`.