### PR TITLE
Type variable value instantiation

### DIFF
--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -1378,6 +1378,30 @@ class GenericTests(BaseTestCase):
         self.assertEqual(c.from_b, 'b')
         self.assertEqual(c.from_c, 'c')
 
+    def test_instantiate_typevar(self):
+        T = TypeVar('T')
+
+        class C(Generic[T]):
+            def __init__(self):
+                self.inner = T()
+
+        c = C[int]
+        x = c()
+        self.assertEqual(x.inner, int())
+
+        U = TypeVar('U')
+        V = TypeVar('V')
+
+        class P(Generic[U, V]):
+            def __init__(self):
+                self.left = U()
+                self.right = V()
+
+        p = P[int, str]
+        y = p()
+        self.assertEqual(y.left, int())
+        self.assertEqual(y.right, str())
+
 
 class ClassVarTests(BaseTestCase):
 


### PR DESCRIPTION
This PR makes it possible to call type variables as constructors within class definitions of subclasses of Generic. Concretely, this enables writing

```python
T = TypeVar('T')

class C(Generic[T]):
    def __init__(self):
        self.inner = T()
```

A realistic use case might be when writing a generic mapping class where you can add keys without specifying a value because a default one is created for you by calling `T()`. This brings type variables more in line with how they can be used in other typed languages.