### PR TITLE
Backport Generic.__new__ fix

### DIFF
--- a/python2/test_typing.py
+++ b/python2/test_typing.py
@@ -1274,6 +1274,9 @@ class GenericTests(BaseTestCase):
         class A(Generic[T]):
             pass
 
+        with self.assertRaises(TypeError):
+            A('foo')
+
         class B(object):
             def __new__(cls):
                 # call object

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -1288,13 +1288,15 @@ def _generic_new(base_cls, cls, *args, **kwds):
     # Assure type is erased on instantiation,
     # but attempt to store it in __orig_class__
     if cls.__origin__ is None:
-        if base_cls.__new__ is object.__new__:
+        if (base_cls.__new__ is object.__new__ and
+                cls.__init__ is not object.__init__):
             return base_cls.__new__(cls)
         else:
             return base_cls.__new__(cls, *args, **kwds)
     else:
         origin = cls._gorg
-        if base_cls.__new__ is object.__new__:
+        if (base_cls.__new__ is object.__new__ and
+                cls.__init__ is not object.__init__):
             obj = base_cls.__new__(origin)
         else:
             obj = base_cls.__new__(origin, *args, **kwds)

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -1355,6 +1355,9 @@ class GenericTests(BaseTestCase):
         class A(Generic[T]):
             pass
 
+        with self.assertRaises(TypeError):
+            A('foo')
+
         class B:
             def __new__(cls):
                 # call object

--- a/src/typing.py
+++ b/src/typing.py
@@ -1182,13 +1182,15 @@ def _generic_new(base_cls, cls, *args, **kwds):
     # Assure type is erased on instantiation,
     # but attempt to store it in __orig_class__
     if cls.__origin__ is None:
-        if base_cls.__new__ is object.__new__:
+        if (base_cls.__new__ is object.__new__ and
+                cls.__init__ is not object.__init__):
             return base_cls.__new__(cls)
         else:
             return base_cls.__new__(cls, *args, **kwds)
     else:
         origin = cls._gorg
-        if base_cls.__new__ is object.__new__:
+        if (base_cls.__new__ is object.__new__ and
+                cls.__init__ is not object.__init__):
             obj = base_cls.__new__(origin)
         else:
             obj = base_cls.__new__(origin, *args, **kwds)


### PR DESCRIPTION
This backports to older Python 3 versions and Python 2 the bugfix in https://github.com/python/cpython/pull/6758 for the bug in `Generic.__new__` found by @serhiy-storchaka (see https://github.com/python/cpython/pull/6732/files#r187002617)