### PR TITLE
Fix IO.closed to be property

### DIFF
--- a/python2/typing.py
+++ b/python2/typing.py
@@ -2061,7 +2061,7 @@ class IO(Generic[AnyStr]):
     def close(self):
         pass
 
-    @abstractmethod
+    @abstractproperty
     def closed(self):
         pass
 

--- a/src/typing.py
+++ b/src/typing.py
@@ -2269,7 +2269,7 @@ class IO(Generic[AnyStr]):
     def close(self) -> None:
         pass
 
-    @abstractmethod
+    @abstractproperty
     def closed(self) -> bool:
         pass
 


### PR DESCRIPTION
The `closed` attribute in file objects is actually a property rather than a method.  Fix this in the `IO` base class.

Fixes #575