### PR TITLE
Fix instance/subclass checks of functions against runtime protocols.

### DIFF
--- a/typing_extensions/src_py2/test_typing_extensions.py
+++ b/typing_extensions/src_py2/test_typing_extensions.py
@@ -5,6 +5,7 @@ import contextlib
 import collections
 import pickle
 import subprocess
+import types
 from unittest import TestCase, main, skipUnless
 
 from typing_extensions import NoReturn, ClassVar
@@ -234,19 +235,34 @@ class ProtocolTests(BaseTestCase):
         class D(object):
             def meth(self):
                 pass
+        def f():
+            pass
         self.assertIsSubclass(D, P)
         self.assertIsInstance(D(), P)
         self.assertNotIsSubclass(C, P)
         self.assertNotIsInstance(C(), P)
+        self.assertNotIsSubclass(types.FunctionType, P)
+        self.assertNotIsInstance(f, P)
 
     def test_everything_implements_empty_protocol(self):
         @runtime
         class Empty(Protocol): pass
         class C(object): pass
-        for thing in (object, type, tuple, C):
+        def f():
+            pass
+        for thing in (object, type, tuple, C, types.FunctionType):
             self.assertIsSubclass(thing, Empty)
-        for thing in (object(), 1, (), typing):
+        for thing in (object(), 1, (), typing, f):
             self.assertIsInstance(thing, Empty)
+
+    def test_function_implements_protocol(self):
+        @runtime
+        class Function(Protocol):
+            def __call__(self, *args, **kwargs):
+                pass
+        def f():
+            pass
+        self.assertIsInstance(f, Function)
 
     def test_no_inheritance_from_nominal(self):
         class C(object): pass

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -319,6 +319,11 @@ class XRepr(NamedTuple):
     def __add__(self, other):
         return 0
 
+@runtime
+class FunctionProtocol(Protocol):
+    __call__: typing.Callable
+
+
 async def g_with(am: AsyncContextManager[int]):
     x: int
     async with am as x:
@@ -761,12 +766,9 @@ if HAVE_PROTOCOLS:
                 self.assertIsInstance(thing, Empty)
 
         def test_function_implements_protocol(self):
-            @runtime
-            class Function(Protocol):
-                __call__: typing.Callable
             def f():
                 pass
-            self.assertIsInstance(f, Function)
+            self.assertIsInstance(f, FunctionProtocol)
 
         def test_no_inheritance_from_nominal(self):
             class C: pass

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -320,7 +320,7 @@ class XRepr(NamedTuple):
         return 0
 
 @runtime
-class FunctionProtocol(Protocol):
+class HasCallProtocol(Protocol):
     __call__: typing.Callable
 
 
@@ -341,7 +341,7 @@ else:
     # fake names for the sake of static analysis
     ann_module = ann_module2 = ann_module3 = None
     A = B = CSub = G = CoolEmployee = CoolEmployeeWithDefault = object
-    XMeth = XRepr = NoneAndForward = Loop = object
+    XMeth = XRepr = HasCallProtocol = NoneAndForward = Loop = object
 
 gth = get_type_hints
 
@@ -765,10 +765,11 @@ if HAVE_PROTOCOLS:
             for thing in (object(), 1, (), typing, f):
                 self.assertIsInstance(thing, Empty)
 
+        @skipUnless(PY36, 'Python 3.6 required')
         def test_function_implements_protocol(self):
             def f():
                 pass
-            self.assertIsInstance(f, FunctionProtocol)
+            self.assertIsInstance(f, HasCallProtocol)
 
         def test_no_inheritance_from_nominal(self):
             class C: pass

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -5,6 +5,7 @@ import contextlib
 import collections
 import pickle
 import subprocess
+import types
 from unittest import TestCase, main, skipUnless
 from typing import TypeVar, Optional
 from typing import T, KT, VT  # Not in __all__.
@@ -690,19 +691,33 @@ if HAVE_PROTOCOLS:
             class D:
                 def meth(self):
                     pass
+            def f():
+                pass
             self.assertIsSubclass(D, P)
             self.assertIsInstance(D(), P)
             self.assertNotIsSubclass(C, P)
             self.assertNotIsInstance(C(), P)
+            self.assertNotIsSubclass(types.FunctionType, P)
+            self.assertNotIsInstance(f, P)
 
         def test_everything_implements_empty_protocol(self):
             @runtime
             class Empty(Protocol): pass
             class C: pass
-            for thing in (object, type, tuple, C):
+            def f():
+                pass
+            for thing in (object, type, tuple, C, types.FunctionType):
                 self.assertIsSubclass(thing, Empty)
-            for thing in (object(), 1, (), typing):
+            for thing in (object(), 1, (), typing, f):
                 self.assertIsInstance(thing, Empty)
+
+        def test_function_implements_protocol(self):
+            @runtime
+            class Function(Protocol):
+                __call__: typing.Callable
+            def f():
+                pass
+            self.assertIsInstance(f, Function)
 
         def test_no_inheritance_from_nominal(self):
             class C: pass

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -1329,7 +1329,8 @@ elif PEP_560:
                             if base.__dict__[attr] is None:
                                 return NotImplemented
                             break
-                        if (attr in getattr(base, '__annotations__', {}) and
+                        annotations = getattr(base, '__annotations__', {})
+                        if (isinstance(annotations, typing.Mapping) and attr in annotations and
                                 isinstance(other, _ProtocolMeta) and other._is_protocol):
                             break
                     else:

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -868,7 +868,8 @@ if HAVE_PROTOCOLS and not PEP_560:
                             if base.__dict__[attr] is None:
                                 return NotImplemented
                             break
-                        if (attr in getattr(base, '__annotations__', {}) and
+                        annotations = getattr(base, '__annotations__', {})
+                        if (isinstance(annotations, typing.Mapping) and attr in annotations and
                                 isinstance(other, _ProtocolMeta) and other._is_protocol):
                             break
                     else:


### PR DESCRIPTION
Fixes #579 .

When performing an `issubclass` check of a type against a protocol, the `__annotations__` member of the type is accessed and assumed to be iterable. `__annotations__` is a descriptor in the case of `types.FunctionType`, so while it is iterable when accessed on a function instance it is not iterable when accessed on the type of a function. This causes the `issubclass` check to fail with an exception.

In some cases (AFAICT, non-data protocols), an `isinstance` check of an object will use, internally, a subclass check of the object's type. As a result, `isinstance` will also fail with an exception in these conditions.

The above only seemed to occur in Python 3.

This PR fixes the issue in the Python 3 implementation while adding test coverage for both Python 2 and 3 that ensures that functions (and `types.FunctionType`) can be correctly compared both against protocols that they legitimately implement as well as those that they do not implement.