### PR TITLE
Add Final to typing_extensions

### DIFF
--- a/typing_extensions/src_py2/test_typing_extensions.py
+++ b/typing_extensions/src_py2/test_typing_extensions.py
@@ -128,11 +128,11 @@ class FinalTests(BaseTestCase):
             Final[int][str]
 
     def test_repr(self):
-        self.assertEqual(repr(Final), 'typing.Final')
+        self.assertEqual(repr(Final), 'typing_extensions.Final')
         cv = Final[int]
-        self.assertEqual(repr(cv), 'typing.Final[int]')
+        self.assertEqual(repr(cv), 'typing_extensions.Final[int]')
         cv = Final[Employee]
-        self.assertEqual(repr(cv), 'typing.Final[%s.Employee]' % __name__)
+        self.assertEqual(repr(cv), 'typing_extensions.Final[%s.Employee]' % __name__)
 
     def test_cannot_subclass(self):
         with self.assertRaises(TypeError):
@@ -774,7 +774,7 @@ class AllTests(BaseTestCase):
         self.assertIn('TYPE_CHECKING', a)
 
     def test_typing_extensions_defers_when_possible(self):
-        exclude = {'overload', 'Text', 'TYPE_CHECKING'}
+        exclude = {'overload', 'Text', 'TYPE_CHECKING', 'Final'}
         for item in typing_extensions.__all__:
             if item not in exclude and hasattr(typing, item):
                 self.assertIs(

--- a/typing_extensions/src_py2/test_typing_extensions.py
+++ b/typing_extensions/src_py2/test_typing_extensions.py
@@ -7,7 +7,7 @@ import pickle
 import subprocess
 from unittest import TestCase, main, skipUnless
 
-from typing_extensions import NoReturn, ClassVar
+from typing_extensions import NoReturn, ClassVar, Final
 from typing_extensions import ContextManager, Counter, Deque, DefaultDict
 from typing_extensions import NewType, overload, Protocol, runtime
 import typing
@@ -115,6 +115,46 @@ class ClassVarTests(BaseTestCase):
             isinstance(1, ClassVar[int])
         with self.assertRaises(TypeError):
             issubclass(int, ClassVar)
+
+
+class FinalTests(BaseTestCase):
+
+    def test_basics(self):
+        with self.assertRaises(TypeError):
+            Final[1]
+        with self.assertRaises(TypeError):
+            Final[int, str]
+        with self.assertRaises(TypeError):
+            Final[int][str]
+
+    def test_repr(self):
+        self.assertEqual(repr(Final), 'typing.Final')
+        cv = Final[int]
+        self.assertEqual(repr(cv), 'typing.Final[int]')
+        cv = Final[Employee]
+        self.assertEqual(repr(cv), 'typing.Final[%s.Employee]' % __name__)
+
+    def test_cannot_subclass(self):
+        with self.assertRaises(TypeError):
+            class C(type(Final)):
+                pass
+        with self.assertRaises(TypeError):
+            class C(type(Final[int])):
+                pass
+
+    def test_cannot_init(self):
+        with self.assertRaises(TypeError):
+            Final()
+        with self.assertRaises(TypeError):
+            type(Final)()
+        with self.assertRaises(TypeError):
+            type(Final[typing.Optional[int]])()
+
+    def test_no_isinstance(self):
+        with self.assertRaises(TypeError):
+            isinstance(1, Final[int])
+        with self.assertRaises(TypeError):
+            issubclass(int, Final)
 
 
 class CollectionsAbcTests(BaseTestCase):

--- a/typing_extensions/src_py2/typing_extensions.py
+++ b/typing_extensions/src_py2/typing_extensions.py
@@ -108,7 +108,16 @@ def _gorg(cls):
     return cls
 
 
-class _Final(typing._FinalTypingBase, _root=True):
+class FinalMeta(TypingMeta):
+    """Metaclass for _Final"""
+
+    def __new__(cls, name, bases, namespace):
+        cls.assert_no_subclassing(bases)
+        self = super(FinalMeta, cls).__new__(cls, name, bases, namespace)
+        return self
+
+
+class _Final(typing._FinalTypingBase):
     """A special typing construct to indicate that a name
     cannot be re-assigned or overridden in a subclass.
     For example:
@@ -124,6 +133,7 @@ class _Final(typing._FinalTypingBase, _root=True):
     There is no runtime checking of these properties.
     """
 
+    __metaclass__ = FinalMeta
     __slots__ = ('__type__',)
 
     def __init__(self, tp=None, **kwds):

--- a/typing_extensions/src_py2/typing_extensions.py
+++ b/typing_extensions/src_py2/typing_extensions.py
@@ -155,7 +155,7 @@ class _Final(typing._FinalTypingBase):
         return type(self)(new_tp, _root=True)
 
     def __repr__(self):
-        r = super().__repr__()
+        r = super(_Final, self).__repr__()
         if self.__type__ is not None:
             r += '[{}]'.format(typing._type_repr(self.__type__))
         return r

--- a/typing_extensions/src_py2/typing_extensions.py
+++ b/typing_extensions/src_py2/typing_extensions.py
@@ -15,6 +15,7 @@ from typing import (
 __all__ = [
     # Super-special typing primitives.
     'ClassVar',
+    'Final',
     'Protocol',
     'Type',
 
@@ -25,6 +26,7 @@ __all__ = [
     'DefaultDict',
 
     # One-off things.
+    'final',
     'NewType',
     'overload',
     'runtime',
@@ -104,6 +106,84 @@ def _gorg(cls):
     while cls.__origin__ is not None:
         cls = cls.__origin__
     return cls
+
+
+class _Final(typing._FinalTypingBase, _root=True):
+    """A special typing construct to indicate that a name
+    cannot be re-assigned or overridden in a subclass.
+    For example:
+
+        MAX_SIZE: Final = 9000
+        MAX_SIZE += 1  # Error reported by type checker
+
+        class Connection:
+            TIMEOUT: Final[int] = 10
+        class FastConnector(Connection):
+            TIMEOUT = 1  # Error reported by type checker
+
+    There is no runtime checking of these properties.
+    """
+
+    __slots__ = ('__type__',)
+
+    def __init__(self, tp=None, **kwds):
+        self.__type__ = tp
+
+    def __getitem__(self, item):
+        cls = type(self)
+        if self.__type__ is None:
+            return cls(typing._type_check(item,
+                       '{} accepts only single type.'.format(cls.__name__[1:])),
+                       _root=True)
+        raise TypeError('{} cannot be further subscripted'
+                        .format(cls.__name__[1:]))
+
+    def _eval_type(self, globalns, localns):
+        new_tp = typing._eval_type(self.__type__, globalns, localns)
+        if new_tp == self.__type__:
+            return self
+        return type(self)(new_tp, _root=True)
+
+    def __repr__(self):
+        r = super().__repr__()
+        if self.__type__ is not None:
+            r += '[{}]'.format(typing._type_repr(self.__type__))
+        return r
+
+    def __hash__(self):
+        return hash((type(self).__name__, self.__type__))
+
+    def __eq__(self, other):
+        if not isinstance(other, _Final):
+            return NotImplemented
+        if self.__type__ is not None:
+            return self.__type__ == other.__type__
+        return self is other
+
+Final = _Final(_root=True)
+
+
+def final(f):
+    """This decorator can be used to indicate to type checkers that
+    the decorated method cannot be overridden, and decorated class
+    cannot be subclassed. For example:
+
+        class Base:
+            @final
+            def done(self) -> None:
+                ...
+        class Sub(Base):
+            def done(self) -> None:  # Error reported by type checker
+                ...
+        @final
+        class Leaf:
+            ...
+        class Other(Leaf):  # Error reported by type checker
+            ...
+
+    There is no runtime checking of these properties.
+    """
+    return f
 
 
 class _ProtocolMeta(GenericMeta):

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -392,9 +392,9 @@ class GetTypeHintTests(BaseTestCase):
 
     @skipUnless(PY36, 'Python 3.6 required')
     def test_final_forward_ref(self):
-        self.assertEqual(gth(Loop), Final[Loop])
-        self.assertNotEqual(gth(Loop), Final[int])
-        self.assertNotEqual(gth(Loop), Final)
+        self.assertEqual(gth(Loop)['attr'], Final[Loop])
+        self.assertNotEqual(gth(Loop)['attr'], Final[int])
+        self.assertNotEqual(gth(Loop)['attr'], Final)
 
 class CollectionsAbcTests(BaseTestCase):
 

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -182,15 +182,11 @@ class FinalTests(BaseTestCase):
             Final[int][str]
 
     def test_repr(self):
-        if hasattr(typing, 'Final'):
-            mod_name = 'typing'
-        else:
-            mod_name = 'typing_extensions'
-        self.assertEqual(repr(Final), mod_name + '.Final')
+        self.assertEqual(repr(Final), 'typing_extensions.Final')
         cv = Final[int]
-        self.assertEqual(repr(cv), mod_name + '.Final[int]')
+        self.assertEqual(repr(cv), 'typing_extensions.Final[int]')
         cv = Final[Employee]
-        self.assertEqual(repr(cv), mod_name + '.Final[%s.Employee]' % __name__)
+        self.assertEqual(repr(cv), 'typing_extensions.Final[%s.Employee]' % __name__)
 
     @skipUnless(SUBCLASS_CHECK_FORBIDDEN, "Behavior added in typing 3.5.3")
     def test_cannot_subclass(self):
@@ -339,7 +335,7 @@ else:
     # fake names for the sake of static analysis
     ann_module = ann_module2 = ann_module3 = None
     A = B = CSub = G = CoolEmployee = CoolEmployeeWithDefault = object
-    XMeth = XRepr = NoneAndForward = object
+    XMeth = XRepr = NoneAndForward = Loop = object
 
 gth = get_type_hints
 
@@ -1306,7 +1302,7 @@ class AllTests(BaseTestCase):
             self.assertIn('runtime', a)
 
     def test_typing_extensions_defers_when_possible(self):
-        exclude = {'overload', 'Text', 'TYPE_CHECKING'}
+        exclude = {'overload', 'Text', 'TYPE_CHECKING', 'Final'}
         for item in typing_extensions.__all__:
             if item not in exclude and hasattr(typing, item):
                 self.assertIs(

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -12,7 +12,7 @@ from typing import Tuple, List
 from typing import Generic
 from typing import get_type_hints
 from typing import no_type_check
-from typing_extensions import NoReturn, ClassVar, Type, NewType
+from typing_extensions import NoReturn, ClassVar, Final, Type, NewType
 try:
     from typing_extensions import Protocol, runtime
 except ImportError:

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -392,9 +392,9 @@ class GetTypeHintTests(BaseTestCase):
 
     @skipUnless(PY36, 'Python 3.6 required')
     def test_final_forward_ref(self):
-        self.assertEqual(gth(Loop)['attr'], Final[Loop])
-        self.assertNotEqual(gth(Loop)['attr'], Final[int])
-        self.assertNotEqual(gth(Loop)['attr'], Final)
+        self.assertEqual(gth(Loop, globals())['attr'], Final[Loop])
+        self.assertNotEqual(gth(Loop, globals())['attr'], Final[int])
+        self.assertNotEqual(gth(Loop, globals())['attr'], Final)
 
 class CollectionsAbcTests(BaseTestCase):
 

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -104,6 +104,7 @@ else:
 __all__ = [
     # Super-special typing primitives.
     'ClassVar',
+    'Final',
     'Type',
 
     # ABCs (from collections.abc).
@@ -124,6 +125,7 @@ __all__ = [
     'DefaultDict',
 
     # One-off things.
+    'final',
     'NewType',
     'overload',
     'Text',
@@ -326,6 +328,175 @@ else:
         """
 
         __type__ = None
+
+if sys.version_info[:2] >= (3, 7):
+    class _FinalForm(typing._SpecialForm):
+        def __getitem__(self, parameters):
+            item = _type_check(parameters,
+                               '{} accepts only single type'.format(self._name))
+            return _GenericAlias(self, (item,))
+
+    Final = _FinalForm('Final', doc=
+        """A special typing construct to indicate that a name
+        cannot be re-assigned or overridden in a subclass.
+        For example:
+
+            MAX_SIZE: Final = 9000
+            MAX_SIZE += 1  # Error reported by type checker
+
+            class Connection:
+                TIMEOUT: Final[int] = 10
+            class FastConnector(Connection):
+                TIMEOUT = 1  # Error reported by type checker
+
+        There is no runtime checking of these properties.
+        """)
+elif hasattr(typing, '_FinalTypingBase'):
+    class _Final(typing._FinalTypingBase, _root=True):
+        """A special typing construct to indicate that a name
+        cannot be re-assigned or overridden in a subclass.
+        For example:
+
+            MAX_SIZE: Final = 9000
+            MAX_SIZE += 1  # Error reported by type checker
+
+            class Connection:
+                TIMEOUT: Final[int] = 10
+            class FastConnector(Connection):
+                TIMEOUT = 1  # Error reported by type checker
+
+        There is no runtime checking of these properties.
+        """
+
+        __slots__ = ('__type__',)
+
+        def __init__(self, tp=None, **kwds):
+            self.__type__ = tp
+
+        def __getitem__(self, item):
+            cls = type(self)
+            if self.__type__ is None:
+                return cls(typing._type_check(item,
+                           '{} accepts only single type.'.format(cls.__name__[1:])),
+                           _root=True)
+            raise TypeError('{} cannot be further subscripted'
+                            .format(cls.__name__[1:]))
+
+        def _eval_type(self, globalns, localns):
+            new_tp = typing._eval_type(self.__type__, globalns, localns)
+            if new_tp == self.__type__:
+                return self
+            return type(self)(new_tp, _root=True)
+
+        def __repr__(self):
+            r = super().__repr__()
+            if self.__type__ is not None:
+                r += '[{}]'.format(typing._type_repr(self.__type__))
+            return r
+
+        def __hash__(self):
+            return hash((type(self).__name__, self.__type__))
+
+        def __eq__(self, other):
+            if not isinstance(other, _Final):
+                return NotImplemented
+            if self.__type__ is not None:
+                return self.__type__ == other.__type__
+            return self is other
+
+    Final = _Final(_root=True)
+else:
+    class FinalMeta(typing.TypingMeta):
+        """Metaclass for Final"""
+
+        def __new__(cls, name, bases, namespace, tp=None, _root=False):
+            self = super().__new__(cls, name, bases, namespace, _root=_root)
+            if tp is not None:
+                self.__type__ = tp
+            return self
+
+        def __instancecheck__(self, obj):
+            raise TypeError("Final cannot be used with isinstance().")
+
+        def __subclasscheck__(self, cls):
+            raise TypeError("Final cannot be used with issubclass().")
+
+        def __getitem__(self, item):
+            cls = type(self)
+            if self.__type__ is not None:
+                raise TypeError('{} cannot be further subscripted'
+                                .format(cls.__name__[1:]))
+
+            param = typing._type_check(
+                item,
+                '{} accepts only single type.'.format(cls.__name__[1:]))
+            return cls(self.__name__, self.__bases__,
+                       dict(self.__dict__), tp=param, _root=True)
+
+        def _eval_type(self, globalns, localns):
+            new_tp = typing._eval_type(self.__type__, globalns, localns)
+            if new_tp == self.__type__:
+                return self
+            return type(self)(self.__name__, self.__bases__,
+                              dict(self.__dict__), tp=self.__type__,
+                              _root=True)
+
+        def __repr__(self):
+            r = super().__repr__()
+            if self.__type__ is not None:
+                r += '[{}]'.format(typing._type_repr(self.__type__))
+            return r
+
+        def __hash__(self):
+            return hash((type(self).__name__, self.__type__))
+
+        def __eq__(self, other):
+            if not isinstance(other, Final):
+                return NotImplemented
+            if self.__type__ is not None:
+                return self.__type__ == other.__type__
+            return self is other
+
+    class Final(typing.Final, metaclass=FinalMeta, _root=True):
+        """A special typing construct to indicate that a name
+        cannot be re-assigned or overridden in a subclass.
+        For example:
+
+            MAX_SIZE: Final = 9000
+            MAX_SIZE += 1  # Error reported by type checker
+
+            class Connection:
+                TIMEOUT: Final[int] = 10
+            class FastConnector(Connection):
+                TIMEOUT = 1  # Error reported by type checker
+
+        There is no runtime checking of these properties.
+        """
+
+        __type__ = None
+
+
+def final(f):
+    """This decorator can be used to indicate to type checkers that
+    the decorated method cannot be overridden, and decorated class
+    cannot be subclassed. For example:
+
+        class Base:
+            @final
+            def done(self) -> None:
+                ...
+        class Sub(Base):
+            def done(self) -> None:  # Error reported by type checker
+                ...
+        @final
+        class Leaf:
+            ...
+        class Other(Leaf):  # Error reported by type checker
+            ...
+
+    There is no runtime checking of these properties.
+    """
+    return f
 
 
 def _overload_dummy(*args, **kwds):

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -330,7 +330,7 @@ else:
         __type__ = None
 
 if sys.version_info[:2] >= (3, 7):
-    class _FinalForm(typing._SpecialForm):
+    class _FinalForm(typing._SpecialForm, _root=True):
         def __getitem__(self, parameters):
             item = _type_check(parameters,
                                '{} accepts only single type'.format(self._name))

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -331,6 +331,10 @@ else:
 
 if sys.version_info[:2] >= (3, 7):
     class _FinalForm(typing._SpecialForm, _root=True):
+
+        def __repr__(self):
+            return 'typing_extensions.' + self._name
+
         def __getitem__(self, parameters):
             item = _type_check(parameters,
                                '{} accepts only single type'.format(self._name))


### PR DESCRIPTION
This is a runtime counterpart of an experimental feature added to mypy in https://github.com/python/mypy/pull/5522

This implementation just mimics the behaviour of `ClassVar` on all Python/`typing` versions, which is probably the most reasonable thing to do.