### PR TITLE
Fix GeneralMeta.__instancecheck__() for old style classes (#612)

### DIFF
--- a/python2/typing.py
+++ b/python2/typing.py
@@ -1255,7 +1255,7 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
         # latter, we must extend __instancecheck__ too. For simplicity
         # we just skip the cache check -- instance checks for generic
         # classes are supposed to be rare anyways.
-        if not isinstance(instance, type):
+        if hasattr(instance, "__class__"):
             return issubclass(instance.__class__, self)
         return False
 


### PR DESCRIPTION
Since we are going to check the attribute, let's just check for its existence.

Fixes #612