### PR TITLE
Add Final to the README

### DIFF
--- a/typing_extensions/README.rst
+++ b/typing_extensions/README.rst
@@ -38,6 +38,7 @@ All Python versions:
 - ``Counter``
 - ``DefaultDict``
 - ``Deque``
+- ``Final``
 - ``NewType``
 - ``NoReturn``
 - ``overload`` (note that older versions of ``typing`` only let you use ``overload`` in stubs)


### PR DESCRIPTION
It looks like `Final` fell between the cracks. It's my favorite experimental type. Adding it to the list.