### PR TITLE
Add SupportsIndex

### DIFF
--- a/python2/test_typing.py
+++ b/python2/test_typing.py
@@ -541,6 +541,10 @@ class ProtocolTests(BaseTestCase):
         self.assertIsSubclass(list, typing.Reversible)
         self.assertNotIsSubclass(int, typing.Reversible)
 
+    def test_supports_index(self):
+        self.assertIsSubclass(int, typing.SupportsIndex)
+        self.assertNotIsSubclass(str, typing.SupportsIndex)
+
     def test_protocol_instance_type_error(self):
         with self.assertRaises(TypeError):
             isinstance(0, typing.SupportsAbs)

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -53,6 +53,7 @@ __all__ = [
     'SupportsAbs',
     'SupportsComplex',
     'SupportsFloat',
+    'SupportsIndex',
     'SupportsInt',
 
     # Concrete collection types.
@@ -1719,6 +1720,14 @@ class SupportsComplex(_Protocol):
 
     @abstractmethod
     def __complex__(self):
+        pass
+
+
+class SupportsIndex(_Protocol):
+    __slots__ = ()
+
+    @abstractmethod
+    def __index__(self):
         pass
 
 

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -582,6 +582,10 @@ class ProtocolTests(BaseTestCase):
         self.assertIsSubclass(list, typing.Reversible)
         self.assertNotIsSubclass(int, typing.Reversible)
 
+    def test_supports_index(self):
+        self.assertIsSubclass(int, typing.SupportsIndex)
+        self.assertNotIsSubclass(str, typing.SupportsIndex)
+
     def test_protocol_instance_type_error(self):
         with self.assertRaises(TypeError):
             isinstance(0, typing.SupportsAbs)

--- a/src/typing.py
+++ b/src/typing.py
@@ -69,6 +69,7 @@ __all__ = [
     'SupportsBytes',
     'SupportsComplex',
     'SupportsFloat',
+    'SupportsIndex',
     'SupportsInt',
     'SupportsRound',
 
@@ -1780,6 +1781,14 @@ class SupportsBytes(_Protocol):
 
     @abstractmethod
     def __bytes__(self) -> bytes:
+        pass
+
+
+class SupportsIndex(_Protocol):
+    __slots__ = ()
+
+    @abstractmethod
+    def __index__(self) -> int:
         pass
 
 


### PR DESCRIPTION
This PR adds a runtime SupportsIndex protocol that can be used to check at runtime if something supports the \_\_index\_\_ function, which is used in python to implement `hex()`, `oct()`, and `bin()`. This would allow typeshed to enhance the code contributed in https://github.com/python/typeshed/pull/2996.

I have run the python2.7 tests locally, but have had trouble getting other versions of python installed to run the 3.3-3.6 tests.  This is a pretty simple copy and modification of SupportsInt, so I imagine it will pass the tests, but still.