### PR TITLE
[typing-extensions] Simple implementation for IntVar

### DIFF
--- a/typing_extensions/src_py2/test_typing_extensions.py
+++ b/typing_extensions/src_py2/test_typing_extensions.py
@@ -8,7 +8,7 @@ import subprocess
 import types
 from unittest import TestCase, main, skipUnless
 
-from typing_extensions import NoReturn, ClassVar, Final, Literal, TypedDict
+from typing_extensions import NoReturn, ClassVar, Final, IntVar, Literal, TypedDict
 from typing_extensions import ContextManager, Counter, Deque, DefaultDict
 from typing_extensions import NewType, overload, Protocol, runtime
 import typing
@@ -156,6 +156,19 @@ class FinalTests(BaseTestCase):
             isinstance(1, Final[int])
         with self.assertRaises(TypeError):
             issubclass(int, Final)
+
+
+class IntVarTests(BaseTestCase):
+    def test_valid(self):
+        T_ints = IntVar("T_ints")
+
+    def test_invalid(self):
+        with self.assertRaises(TypeError):
+            T_ints = IntVar("T_ints", int)
+        with self.assertRaises(TypeError):
+            T_ints = IntVar("T_ints", bound=int)
+        with self.assertRaises(TypeError):
+            T_ints = IntVar("T_ints", covariant=True)
 
 
 class LiteralTests(BaseTestCase):

--- a/typing_extensions/src_py2/typing_extensions.py
+++ b/typing_extensions/src_py2/typing_extensions.py
@@ -27,6 +27,7 @@ __all__ = [
 
     # One-off things.
     'final',
+    'IntVar',
     'Literal',
     'NewType',
     'overload',
@@ -195,6 +196,10 @@ def final(f):
     There is no runtime checking of these properties.
     """
     return f
+
+
+def IntVar(name):
+    return TypeVar(name)
 
 
 class _LiteralMeta(TypingMeta):

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -13,7 +13,7 @@ from typing import Tuple, List
 from typing import Generic
 from typing import get_type_hints
 from typing import no_type_check
-from typing_extensions import NoReturn, ClassVar, Final, Literal, Type, NewType, TypedDict
+from typing_extensions import NoReturn, ClassVar, Final, IntVar, Literal, Type, NewType, TypedDict
 try:
     from typing_extensions import Protocol, runtime
 except ImportError:
@@ -211,6 +211,20 @@ class FinalTests(BaseTestCase):
             isinstance(1, Final[int])
         with self.assertRaises(TypeError):
             issubclass(int, Final)
+
+
+class IntVarTests(BaseTestCase):
+    def test_valid(self):
+        T_ints = IntVar("T_ints")
+
+    def test_invalid(self):
+        with self.assertRaises(TypeError):
+            T_ints = IntVar("T_ints", int)
+        with self.assertRaises(TypeError):
+            T_ints = IntVar("T_ints", bound=int)
+        with self.assertRaises(TypeError):
+            T_ints = IntVar("T_ints", covariant=True)
+
 
 class LiteralTests(BaseTestCase):
     def test_basics(self):

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -126,6 +126,7 @@ __all__ = [
 
     # One-off things.
     'final',
+    'IntVar',
     'Literal',
     'NewType',
     'overload',
@@ -502,6 +503,10 @@ def final(f):
     There is no runtime checking of these properties.
     """
     return f
+
+
+def IntVar(name):
+    return TypeVar(name)
 
 
 if hasattr(typing, 'Literal'):


### PR DESCRIPTION
We have IntVar implemented in Pyre as described in one of @ilevkivskyi 's talks at the typing meetup at Google.
In order to use it, we need the runtime behavior in typing_extensions, and will need to add it to typeshed.

We have a couple other extensions we have only been able to release internally that we would like to release through typing_extensions if possible, so if this goes well those will be forthcoming :).
I'm having trouble running the tests as described in the README, due to problems with ann_module, so apologies if I have something wrong.