### PR TITLE
Make Annotated's __origin__ behave more like other classes'

### DIFF
--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -1489,7 +1489,7 @@ if HAVE_ANNOTATED:
             A = Annotated[Annotated[int, 4], 5]
             self.assertEqual(A, Annotated[int, 4, 5])
             self.assertEqual(A.__metadata__, (4, 5))
-            self.assertEqual(A.__origin__, int)
+            self.assertEqual(A.__type__, int)
 
         def test_hash_eq(self):
             self.assertEqual(len({Annotated[int, 4, 5], Annotated[int, 4, 5]}), 1)
@@ -1558,7 +1558,7 @@ if HAVE_ANNOTATED:
                 x = pickle.loads(z)
                 self.assertEqual(x.foo, 42)
                 self.assertEqual(x.bar, 'abc')
-                self.assertEqual(x.x, 1)
+                self.assertEqual(x.__type__.x, 1)
 
         def test_subst(self):
             dec = "a decoration"


### PR DESCRIPTION
I'm not sure if it's strictly needed, but I bumped into
_Annotated.__origin__ not pointing to Annotated while testing things out
and thought this could be beneficial. Note that I don't feel comfortable
modifying this code so the changes could be suboptimal. Also there's one
test remaining that's failing and I'm not sure how to tackle this one:

     ================================================================================================================ FAILURES =================================================================================================================
     _____________________________________________________________________________________________________ AnnotatedTests.test_instantiate _____________________________________________________________________________________________________

     self = <test_typing_extensions.AnnotatedTests testMethod=test_instantiate>

         def test_instantiate(self):
             class C:
                 classvar = 4

                 def __init__(self, x):
                     self.x = x

                 def __eq__(self, other):
                     if not isinstance(other, C):
                         return NotImplemented
                     return other.x == self.x

             A = Annotated[C, "a decoration"]
     >       a = A(5)

     test_typing_extensions.py:1517:
     _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
     /usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/typing.py:670: in __call__
         result = self.__origin__(*args, **kwargs)
     _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

     cls = <class 'typing_extensions.Annotated'>, args = (5,), kwargs = {}

         def __new__(cls, *args, **kwargs):
     >       raise TypeError("Type Annotated cannot be instantiated.")
     E       TypeError: Type Annotated cannot be instantiated.

     typing_extensions.py:1694: TypeError