### PR TITLE
fix __origin__ in annotated types (and a couple of typos)

### DIFF
--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -1489,7 +1489,8 @@ if HAVE_ANNOTATED:
             A = Annotated[Annotated[int, 4], 5]
             self.assertEqual(A, Annotated[int, 4, 5])
             self.assertEqual(A.__metadata__, (4, 5))
-            self.assertEqual(A.__origin__, int)
+            self.assertEqual(A.__type__, int)
+            self.assertEqual(A.__origin__, Annotated)
 
         def test_hash_eq(self):
             self.assertEqual(len({Annotated[int, 4, 5], Annotated[int, 4, 5]}), 1)


### PR DESCRIPTION
The __origin__ field in _AnnotatedAlias should point to `Annotated`, not the underlying type.