### PR TITLE
Pep 593 py3

### DIFF
--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -11,9 +11,8 @@ from typing import TypeVar, Optional
 from typing import T, KT, VT  # Not in __all__.
 from typing import Tuple, List, Dict
 from typing import Generic
-from typing import get_type_hints
 from typing import no_type_check
-from typing_extensions import NoReturn, ClassVar, Final, IntVar, Literal, Type, NewType, TypedDict
+from typing_extensions import NoReturn, ClassVar, Final, IntVar, Literal, Type, NewType, TypedDict, Annotated, get_type_hints
 try:
     from typing_extensions import Protocol, runtime
 except ImportError:
@@ -64,9 +63,6 @@ PY36 = sys.version_info[:2] >= (3, 6)
 
 # Protocols are hard to backport to the original version of typing 3.5.0
 HAVE_PROTOCOLS = sys.version_info[:3] != (3, 5, 0)
-
-# Not backported to older versions yet
-HAVE_ANNOTATED = PEP_560
 
 class BaseTestCase(TestCase):
     def assertIsSubclass(self, cls, class_or_tuple, msg=None):
@@ -1474,180 +1470,244 @@ class TypedDictTests(BaseTestCase):
             self.assertEqual(Options.__total__, False)
 
 
-if HAVE_ANNOTATED:
-    from typing_extensions import Annotated, get_type_hints
+class AnnotatedTests(BaseTestCase):
 
-    class AnnotatedTests(BaseTestCase):
+    def test_repr(self):
+        self.assertEqual(
+            repr(Annotated[int, 4, 5]),
+            "typing_extensions.Annotated[int, 4, 5]"
+        )
+        self.assertEqual(
+            repr(Annotated[List[int], 4, 5]),
+            "typing_extensions.Annotated[typing.List[int], 4, 5]"
+        )
 
-        def test_repr(self):
-            self.assertEqual(
-                repr(Annotated[int, 4, 5]),
-                "typing_extensions.Annotated[int, 4, 5]"
-            )
-
-        def test_flatten(self):
-            A = Annotated[Annotated[int, 4], 5]
-            self.assertEqual(A, Annotated[int, 4, 5])
-            self.assertEqual(A.__metadata__, (4, 5))
+    def test_flatten(self):
+        A = Annotated[Annotated[int, 4], 5]
+        self.assertEqual(A, Annotated[int, 4, 5])
+        if PEP_560:
             self.assertEqual(A.__type__, int)
-            self.assertEqual(A.__origin__, Annotated)
+        self.assertEqual(A.__metadata__, (4, 5))
+        self.assertEqual(A.__origin__, Annotated)
 
-        def test_hash_eq(self):
-            self.assertEqual(len({Annotated[int, 4, 5], Annotated[int, 4, 5]}), 1)
-            self.assertNotEqual(Annotated[int, 4, 5], Annotated[int, 5, 4])
-            self.assertNotEqual(Annotated[int, 4, 5], Annotated[str, 4, 5])
-            self.assertNotEqual(Annotated[int, 4], Annotated[int, 4, 4])
-            self.assertEqual(
-                {Annotated[int, 4, 5], Annotated[int, 4, 5], Annotated[T, 4, 5]},
-                {Annotated[int, 4, 5], Annotated[T, 4, 5]}
-            )
+    def test_specialize(self):
+        L = Annotated[List[T], "my decoration"]
+        LI = Annotated[List[int], "my decoration"]
+        self.assertEqual(L[int], Annotated[List[int], "my decoration"])
+        self.assertEqual(L[int].__metadata__, ("my decoration",))
+        if PEP_560:
+            self.assertEqual(L[int].__type__, List[int])
+        with self.assertRaises(TypeError):
+            LI[int]
+        with self.assertRaises(TypeError):
+            L[int, float]
 
-        def test_instantiate(self):
-            class C:
-                classvar = 4
+    def test_hash_eq(self):
+        self.assertEqual(len({Annotated[int, 4, 5], Annotated[int, 4, 5]}), 1)
+        self.assertNotEqual(Annotated[int, 4, 5], Annotated[int, 5, 4])
+        self.assertNotEqual(Annotated[int, 4, 5], Annotated[str, 4, 5])
+        self.assertNotEqual(Annotated[int, 4], Annotated[int, 4, 4])
+        self.assertEqual(
+            {Annotated[int, 4, 5], Annotated[int, 4, 5], Annotated[T, 4, 5]},
+            {Annotated[int, 4, 5], Annotated[T, 4, 5]}
+        )
 
-                def __init__(self, x):
-                    self.x = x
+    def test_instantiate(self):
+        class C:
+            classvar = 4
 
-                def __eq__(self, other):
-                    if not isinstance(other, C):
-                        return NotImplemented
-                    return other.x == self.x
+            def __init__(self, x):
+                self.x = x
 
-            A = Annotated[C, "a decoration"]
-            a = A(5)
-            c = C(5)
-            self.assertEqual(a, c)
-            self.assertEqual(a.x, c.x)
-            self.assertEqual(A.classvar, C.classvar)
+            def __eq__(self, other):
+                if not isinstance(other, C):
+                    return NotImplemented
+                return other.x == self.x
 
-            MyCount = Annotated[typing_extensions.Counter[T], "my decoration"]
-            self.assertEqual(MyCount([4, 4, 5]), {4: 2, 5: 1})
-            self.assertEqual(MyCount[int]([4, 4, 5]), {4: 2, 5: 1})
+        A = Annotated[C, "a decoration"]
+        a = A(5)
+        c = C(5)
+        self.assertEqual(a, c)
+        self.assertEqual(a.x, c.x)
+        self.assertEqual(a.classvar, c.classvar)
 
+    def test_instantiate_generic(self):
+        MyCount = Annotated[typing_extensions.Counter[T], "my decoration"]
+        self.assertEqual(MyCount([4, 4, 5]), {4: 2, 5: 1})
+        self.assertEqual(MyCount[int]([4, 4, 5]), {4: 2, 5: 1})
 
-        def test_cannot_subclass(self):
-            with self.assertRaises(TypeError):
-                class C(Annotated):
-                    pass
+    def test_cannot_instantiate_forward(self):
+        A = Annotated["int", (5, 6)]
+        with self.assertRaisesRegex(
+            TypeError,
+            "Cannot create an instance .* forward reference"
+        ):
+            A(5)
 
-        def test_pickle(self):
-            samples = [typing.Any, typing.Union[int, str],
-                       typing.Optional[str], Tuple[int, ...],
-                       typing.Callable[[str], bytes]]
+    def test_cannot_instantiate_type_var(self):
+        A = Annotated[T, (5, 6)]
+        with self.assertRaisesRegex(
+            TypeError,
+            "Cannot create an instance .* type variable"
+        ):
+            A(5)
 
-            for t in samples:
-                x = Annotated[t, "a"]
-
-                for prot in range(pickle.HIGHEST_PROTOCOL + 1):
-                    with self.subTest(protocol=prot, type=t):
-                        pickled = pickle.dumps(x, prot)
-                        restored = pickle.loads(pickled)
-                        self.assertEqual(x, restored)
-
-            global _Annotated_test_G
-
-            class _Annotated_test_G(Generic[T]):
-                x = 1
-
-            G = Annotated[_Annotated_test_G[int], "A decoration"]
-            G.foo = 42
-            G.bar = 'abc'
-
-            for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-                z = pickle.dumps(G, proto)
-                x = pickle.loads(z)
-                self.assertEqual(x.foo, 42)
-                self.assertEqual(x.bar, 'abc')
-                self.assertEqual(x.x, 1)
-
-        def test_subst(self):
-            dec = "a decoration"
-
-            S = Annotated[T, dec]
-            self.assertEqual(S[int], Annotated[int, dec])
-
-            L = Annotated[List[T], dec]
-            self.assertEqual(L[int], Annotated[List[int], dec])
-            with self.assertRaises(TypeError):
-                L[int, int]
-
-            D = Annotated[Dict[KT, VT], dec]
-            self.assertEqual(D[str, int], Annotated[Dict[str, int], dec])
-            with self.assertRaises(TypeError):
-                D[int]
-
-            I = Annotated[int, dec]
-            with self.assertRaises(TypeError):
-                I[None]
-
-            LI = L[int]
-            with self.assertRaises(TypeError):
-                LI[None]
-
-        def test_annotated_in_other_types(self):
-            X = List[Annotated[T, 5]]
-            self.assertEqual(X[int], List[Annotated[int, 5]])
+    def test_cannot_getattr_typevar(self):
+        with self.assertRaisesRegex(TypeError, "Cannot access .* type variable"):
+            Annotated[T, (5, 7)].x
 
 
-    class GetTypeHintsTests(BaseTestCase):
-        def test_get_type_hints(self):
-            def foobar(x: List['X']): ...
-            X = Annotated[int, (1, 10)]
-            self.assertEqual(
-                get_type_hints(foobar, globals(), locals()),
-                {'x': List[int]}
-            )
-            self.assertEqual(
-                get_type_hints(foobar, globals(), locals(), include_extras=True),
-                {'x': List[Annotated[int, (1, 10)]]}
-            )
-            BA = Tuple[Annotated[T, (1, 0)], ...]
-            def barfoo(x: BA): ...
-            self.assertEqual(get_type_hints(barfoo, globals(), locals())['x'], Tuple[T, ...])
-            self.assertIs(
-                get_type_hints(barfoo, globals(), locals(), include_extras=True)['x'],
-                BA
-            )
-            def barfoo2(x: typing.Callable[..., Annotated[List[T], "const"]],
-                        y: typing.Union[int, Annotated[T, "mutable"]]): ...
-            self.assertEqual(
-                get_type_hints(barfoo2, globals(), locals()),
-                {'x': typing.Callable[..., List[T]], 'y': typing.Union[int, T]}
-            )
-            BA2 = typing.Callable[..., List[T]]
-            def barfoo3(x: BA2): ...
-            self.assertIs(
-                get_type_hints(barfoo3, globals(), locals(), include_extras=True)["x"],
-                BA2
-            )
+    def test_attr_passthrough(self):
+        class C:
+            classvar = 4
 
-        def test_get_type_hints_refs(self):
+        A = Annotated[C, "a decoration"]
+        self.assertEqual(A.classvar, 4)
 
-            Const = Annotated[T, "Const"]
+    def test_cannot_subclass(self):
+        with self.assertRaisesRegex(TypeError, "Cannot inherit from Annotated"):
+            class C(Annotated):
+                pass
 
-            class MySet(Generic[T]):
+        with self.assertRaisesRegex(TypeError, "Cannot inherit from Annotated"):
+            class C(Annotated[int, (5, 6)]):
+                pass
 
-                def __ior__(self, other: "Const[MySet[T]]") -> "MySet[T]":
-                    ...
+    def test_cannot_check_instance(self):
+        with self.assertRaisesRegex(TypeError, "Annotated cannot be used with isinstance()"):
+            isinstance(5, Annotated[int, "positive"])
 
-                def __iand__(self, other: Const["MySet[T]"]) -> "MySet[T]":
-                    ...
+    def test_cannot_check_subclass(self):
+        with self.assertRaisesRegex(TypeError, "Annotated cannot be used with issubclass()"):
+            issubclass(int, Annotated[int, "positive"])
 
-            self.assertEqual(
-                get_type_hints(MySet.__iand__, globals(), locals()),
-                {'other': MySet[T], 'return': MySet[T]}
-            )
 
-            self.assertEqual(
-                get_type_hints(MySet.__iand__, globals(), locals(), include_extras=True),
-                {'other': Const[MySet[T]], 'return': MySet[T]}
-            )
+    @skipUnless(PEP_560, "pickle support was added with pep_560")
+    def test_pickle(self):
+        samples = [typing.Any, typing.Union[int, str],
+                   typing.Optional[str], Tuple[int, ...],
+                   typing.Callable[[str], bytes]]
 
-            self.assertEqual(
-                get_type_hints(MySet.__ior__, globals(), locals()),
-                {'other': MySet[T], 'return': MySet[T]}
-            )
+        for t in samples:
+            x = Annotated[t, "a"]
+
+            for prot in range(pickle.HIGHEST_PROTOCOL + 1):
+                with self.subTest(protocol=prot, type=t):
+                    pickled = pickle.dumps(x, prot)
+                    restored = pickle.loads(pickled)
+                    self.assertEqual(x, restored)
+
+        global _Annotated_test_G
+
+        class _Annotated_test_G(Generic[T]):
+            x = 1
+
+        G = Annotated[_Annotated_test_G[int], "A decoration"]
+        G.foo = 42
+        G.bar = 'abc'
+
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            z = pickle.dumps(G, proto)
+            x = pickle.loads(z)
+            self.assertEqual(x.foo, 42)
+            self.assertEqual(x.bar, 'abc')
+            self.assertEqual(x.x, 1)
+
+    def test_subst(self):
+        dec = "a decoration"
+        dec2 = "another decoration"
+
+        S = Annotated[T, dec2]
+        self.assertEqual(S[int], Annotated[int, dec2])
+
+        self.assertEqual(S[Annotated[int, dec]], Annotated[int, dec, dec2])
+        L = Annotated[List[T], dec]
+
+        self.assertEqual(L[int], Annotated[List[int], dec])
+        with self.assertRaises(TypeError):
+            L[int, int]
+
+        self.assertEqual(S[L[int]], Annotated[List[int], dec, dec2])
+
+
+
+        D = Annotated[Dict[KT, VT], dec]
+        self.assertEqual(D[str, int], Annotated[Dict[str, int], dec])
+        with self.assertRaises(TypeError):
+            D[int]
+
+        I = Annotated[int, dec]
+        with self.assertRaises(TypeError):
+            I[None]
+
+        LI = L[int]
+        with self.assertRaises(TypeError):
+            LI[None]
+
+    def test_annotated_in_other_types(self):
+        X = List[Annotated[T, 5]]
+        self.assertEqual(X[int], List[Annotated[int, 5]])
+
+
+@skipUnless(PEP_560, "python 3.7 required")
+class GetTypeHintsTests(BaseTestCase):
+    def test_get_type_hints(self):
+        def foobar(x: List['X']): ...
+        X = Annotated[int, (1, 10)]
+        self.assertEqual(
+            get_type_hints(foobar, globals(), locals()),
+            {'x': List[int]}
+        )
+        self.assertEqual(
+            get_type_hints(foobar, globals(), locals(), include_extras=True),
+            {'x': List[Annotated[int, (1, 10)]]}
+        )
+        BA = Tuple[Annotated[T, (1, 0)], ...]
+        def barfoo(x: BA): ...
+        self.assertEqual(get_type_hints(barfoo, globals(), locals())['x'], Tuple[T, ...])
+        self.assertIs(
+            get_type_hints(barfoo, globals(), locals(), include_extras=True)['x'],
+            BA
+        )
+        def barfoo2(x: typing.Callable[..., Annotated[List[T], "const"]],
+                    y: typing.Union[int, Annotated[T, "mutable"]]): ...
+        self.assertEqual(
+            get_type_hints(barfoo2, globals(), locals()),
+            {'x': typing.Callable[..., List[T]], 'y': typing.Union[int, T]}
+        )
+        BA2 = typing.Callable[..., List[T]]
+        def barfoo3(x: BA2): ...
+        self.assertIs(
+            get_type_hints(barfoo3, globals(), locals(), include_extras=True)["x"],
+            BA2
+        )
+
+    def test_get_type_hints_refs(self):
+
+        Const = Annotated[T, "Const"]
+
+        class MySet(Generic[T]):
+
+            def __ior__(self, other: "Const[MySet[T]]") -> "MySet[T]":
+                ...
+
+            def __iand__(self, other: Const["MySet[T]"]) -> "MySet[T]":
+                ...
+
+        self.assertEqual(
+            get_type_hints(MySet.__iand__, globals(), locals()),
+            {'other': MySet[T], 'return': MySet[T]}
+        )
+
+        self.assertEqual(
+            get_type_hints(MySet.__iand__, globals(), locals(), include_extras=True),
+            {'other': Const[MySet[T]], 'return': MySet[T]}
+        )
+
+        self.assertEqual(
+            get_type_hints(MySet.__ior__, globals(), locals()),
+            {'other': MySet[T], 'return': MySet[T]}
+        )
 
 
 
@@ -1666,6 +1726,8 @@ class AllTests(BaseTestCase):
         self.assertIn('overload', a)
         self.assertIn('Text', a)
         self.assertIn('TYPE_CHECKING', a)
+        self.assertIn('Annotated', a)
+        self.assertIn('get_type_hints', a)
 
         if ASYNCIO:
             self.assertIn('Awaitable', a)
@@ -1681,9 +1743,6 @@ class AllTests(BaseTestCase):
             self.assertIn('Protocol', a)
             self.assertIn('runtime', a)
 
-        if HAVE_ANNOTATED:
-            self.assertIn('Annotated', a)
-            self.assertIn('get_type_hints', a)
 
     def test_typing_extensions_defers_when_possible(self):
         exclude = {'overload', 'Text', 'TYPE_CHECKING', 'Final', 'get_type_hints'}

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -1489,7 +1489,8 @@ if HAVE_ANNOTATED:
             A = Annotated[Annotated[int, 4], 5]
             self.assertEqual(A, Annotated[int, 4, 5])
             self.assertEqual(A.__metadata__, (4, 5))
-            self.assertEqual(A.__origin__, int)
+            self.assertEqual(A.__type__, int)
+            self.assertEqual(A.__origin__, Annotated)
 
         def test_hash_eq(self):
             self.assertEqual(len({Annotated[int, 4, 5], Annotated[int, 4, 5]}), 1)


### PR DESCRIPTION
This adds `Annotated` for python [3.4...3.6]. I tried hard to make it behave as closely as possible to the py3.7+ version but was not able to backport the `include_extras` in get_type_hint (we relied on `<type>.copy_with` to implement it).