### PR TITLE
Fix subclassing builtin protocols on older Python versions

### DIFF
--- a/python2/typing.py
+++ b/python2/typing.py
@@ -1759,6 +1759,11 @@ def overload(func):
     return _overload_dummy
 
 
+_PROTO_WHITELIST = ['Callable', 'Iterable', 'Iterator',
+                    'Hashable', 'Sized', 'Container', 'Collection',
+                    'Reversible', 'ContextManager']
+
+
 class _ProtocolMeta(GenericMeta):
     """Internal metaclass for Protocol.
 
@@ -1774,7 +1779,8 @@ class _ProtocolMeta(GenericMeta):
                                    for b in cls.__bases__)
         if cls._is_protocol:
             for base in cls.__mro__[1:]:
-                if not (base in (object, Generic, Callable) or
+                if not (base in (object, Generic) or
+                        base.__module__ == '_abcoll' and base.__name__ in _PROTO_WHITELIST or
                         isinstance(base, TypingMeta) and base._is_protocol or
                         isinstance(base, GenericMeta) and base.__origin__ is Generic):
                     raise TypeError('Protocols can only inherit from other protocols,'

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -1391,6 +1391,21 @@ if HAVE_PROTOCOLS:
                     x = 1
                 self.assertIsInstance(E(), D)
 
+        def test_collections_protocols_allowed(self):
+            @runtime
+            class Custom(collections.abc.Iterable, Protocol):
+                def close(self): pass
+
+            class A: ...
+            class B:
+                def __iter__(self):
+                    return []
+                def close(self):
+                    return 0
+
+            self.assertIsSubclass(B, Custom)
+            self.assertNotIsSubclass(A, Custom)
+
 
 class TypedDictTests(BaseTestCase):
 

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -14,7 +14,7 @@ from typing import Generic
 from typing import no_type_check
 from typing_extensions import NoReturn, ClassVar, Final, IntVar, Literal, Type, NewType, TypedDict
 try:
-    from typing_extensions import Protocol, runtime
+    from typing_extensions import Protocol, runtime, runtime_checkable
 except ImportError:
     pass
 try:
@@ -1392,7 +1392,7 @@ if HAVE_PROTOCOLS:
                 self.assertIsInstance(E(), D)
 
         def test_collections_protocols_allowed(self):
-            @runtime
+            @runtime_checkable
             class Custom(collections.abc.Iterable, Protocol):
                 def close(self): pass
 

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -1080,6 +1080,12 @@ if OLD_GENERICS:
         return next_in_mro
 
 
+_PROTO_WHITELIST = ['Callable', 'Awaitable',
+                    'Iterable', 'Iterator', 'AsyncIterable', 'AsyncIterator',
+                    'Hashable', 'Sized', 'Container', 'Collection', 'Reversible',
+                    'ContextManager', 'AsyncContextManager']
+
+
 def _get_protocol_attrs(cls):
     attrs = set()
     for base in cls.__mro__[:-1]:  # without object
@@ -1187,7 +1193,9 @@ elif HAVE_PROTOCOLS and not PEP_560:
                                        for b in cls.__bases__)
             if cls._is_protocol:
                 for base in cls.__mro__[1:]:
-                    if not (base in (object, Generic, Callable) or
+                    if not (base in (object, Generic) or
+                            base.__module__ == 'collections.abc' and
+                            base.__name__ in _PROTO_WHITELIST or
                             isinstance(base, TypingMeta) and base._is_protocol or
                             isinstance(base, GenericMeta) and
                             base.__origin__ is Generic):
@@ -1513,7 +1521,9 @@ elif PEP_560:
 
             # Check consistency of bases.
             for base in cls.__bases__:
-                if not (base in (object, Generic, Callable) or
+                if not (base in (object, Generic) or
+                        base.__module__ == 'collections.abc' and
+                        base.__name__ in _PROTO_WHITELIST or
                         isinstance(base, _ProtocolMeta) and base._is_protocol):
                     raise TypeError('Protocols can only inherit from other'
                                     ' protocols, got %r' % base)


### PR DESCRIPTION
This was recently fixed in CPython repo (while adding `Protocol` there). This PR backports the fix to all the older versions including now Python 2 version in `typing`.

I also removed the unnecessary conditional import in Python 2 tests since I stumbled at it while adding the test.