### PR TITLE
Fix unions of protocols on Python 2

### DIFF
--- a/python2/test_typing.py
+++ b/python2/test_typing.py
@@ -988,12 +988,12 @@ class ProtocolTests(BaseTestCase):
         self.assertIsInstance(C(), P)
         self.assertIsInstance(D(), P)
 
-        def test_protocols_in_unions(self):
-            class P(Protocol):
-                x = None  # type: int
-            Alias = typing.Union[typing.Iterable, P]
-            Alias2 = typing.Union[P, typing.Iterable]
-            self.assertEqual(Alias, Alias2)
+    def test_protocols_in_unions(self):
+        class P(Protocol):
+            x = None  # type: int
+        Alias = typing.Union[typing.Iterable, P]
+        Alias2 = typing.Union[P, typing.Iterable]
+        self.assertEqual(Alias, Alias2)
 
     def test_protocols_pickleable(self):
         global P, CP  # pickle wants to reference the class by name

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -1834,7 +1834,8 @@ class _ProtocolMeta(GenericMeta):
     def __subclasscheck__(self, cls):
         if (self.__dict__.get('_is_protocol', None) and
                 not self.__dict__.get('_is_runtime_protocol', None)):
-            if sys._getframe(1).f_globals['__name__'] in ['abc', 'functools']:
+            if (sys._getframe(1).f_globals['__name__'] in ['abc', 'functools'] or
+                    sys._getframe(2).f_globals['__name__'] == 'typing'):
                 return False
             raise TypeError("Instance and class checks can only be used with"
                             " @runtime_checkable protocols")

--- a/python2/typing.py
+++ b/python2/typing.py
@@ -1835,6 +1835,7 @@ class _ProtocolMeta(GenericMeta):
         if (self.__dict__.get('_is_protocol', None) and
                 not self.__dict__.get('_is_runtime_protocol', None)):
             if (sys._getframe(1).f_globals['__name__'] in ['abc', 'functools'] or
+                    # This is needed because we remove subclasses from unions on Python 2.
                     sys._getframe(2).f_globals['__name__'] == 'typing'):
                 return False
             raise TypeError("Instance and class checks can only be used with"

--- a/typing_extensions/src_py2/test_typing_extensions.py
+++ b/typing_extensions/src_py2/test_typing_extensions.py
@@ -1,16 +1,13 @@
 import sys
 import os
-import abc
 import contextlib
 import collections
-import pickle
 import subprocess
-import types
-from unittest import TestCase, main, skipUnless
+from unittest import TestCase, main
 
 from typing_extensions import Annotated, NoReturn, ClassVar, Final, IntVar, Literal, TypedDict
 from typing_extensions import ContextManager, Counter, Deque, DefaultDict
-from typing_extensions import NewType, overload, Protocol, runtime
+from typing_extensions import NewType, overload
 from typing import Dict, List
 import typing
 import typing_extensions


### PR DESCRIPTION
Fixes https://github.com/python/typing/issues/488 (again).

The fix is a hack, but on the other hand it was always a hack.

Using this opportunity I also remove some unused imports in Python 2 tests.