### PR TITLE
Use environment marker to specify typing dependency. Fixes #660

### DIFF
--- a/typing_extensions/setup.py
+++ b/typing_extensions/setup.py
@@ -51,10 +51,6 @@ elif sys.version_info.major == 3:
 else:
     raise AssertionError()
 
-install_requires = []
-if sys.version_info < (3, 5):
-    install_requires.append('typing >= 3.7.4')
-
 setup(name='typing_extensions',
       version=version,
       description=description,
@@ -68,4 +64,4 @@ setup(name='typing_extensions',
       package_dir={'': package_dir},
       py_modules=['typing_extensions'],
       classifiers=classifiers,
-      install_requires=install_requires)
+      install_requires=["typing >= 3.7.4; python_version < '3.5'"])


### PR DESCRIPTION
Use environment markers [(PEP-0508)](https://www.python.org/dev/peps/pep-0508/#environment-markers) for `typing_extensions` to specify that `typing` is only required if python < 3.5. Some dependency management tools (including poetry) only work reliable with environment markers instead of conditional checks in `setup.py`.

Fixes #660
