### PR TITLE
Fix test failure with non-default Python interpreter

### DIFF
--- a/python2/test_typing.py
+++ b/python2/test_typing.py
@@ -2676,9 +2676,8 @@ class AllTests(BaseTestCase):
         file_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                                  'typing.py')
         try:
-            subprocess.check_output('python -OO {}'.format(file_path),
-                                    stderr=subprocess.STDOUT,
-                                    shell=True)
+            subprocess.check_output([sys.executable, '-OO', file_path],
+                                    stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError:
             self.fail('Module does not compile with optimize=2 (-OO flag).')
 

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -2653,9 +2653,8 @@ class AllTests(BaseTestCase):
         file_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                                  'typing.py')
         try:
-            subprocess.check_output('python -OO {}'.format(file_path),
-                                    stderr=subprocess.STDOUT,
-                                    shell=True)
+            subprocess.check_output([sys.executable, '-OO', file_path],
+                                    stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError:
             self.fail('Module does not compile with optimize=2 (-OO flag).')
 


### PR DESCRIPTION
`test_typing_compiles_with_opt()` is prone to failure if building and testing with an interpreter that doesn't match the default python in $PATH (for example, if running `python3 setup.py ...` when the default system-wide interpreter is Python 2.x).

Using `sys.executable` (vs hardcoded unversioned "python") seems to be the most sensible solution.