### PR TITLE
Missing objects in typing_extensions/README.rst

### DIFF
--- a/typing_extensions/README.rst
+++ b/typing_extensions/README.rst
@@ -52,7 +52,6 @@ All Python versions:
 - ``TypedDict``
 - ``TYPE_CHECKING``
 
-
 Python 3.4+ only:
 -----------------
 

--- a/typing_extensions/README.rst
+++ b/typing_extensions/README.rst
@@ -38,7 +38,10 @@ All Python versions:
 - ``Counter``
 - ``DefaultDict``
 - ``Deque``
+- ``final``
 - ``Final``
+- ``IntVar``
+- ``Literal``
 - ``NewType``
 - ``NoReturn``
 - ``overload`` (note that older versions of ``typing`` only let you use ``overload`` in stubs)
@@ -46,7 +49,9 @@ All Python versions:
 - ``runtime`` (except on Python 3.5.0)
 - ``Text``
 - ``Type``
+- ``TypedDict``
 - ``TYPE_CHECKING``
+
 
 Python 3.4+ only:
 -----------------

--- a/typing_extensions/README.rst
+++ b/typing_extensions/README.rst
@@ -40,7 +40,6 @@ All Python versions:
 - ``Deque``
 - ``final``
 - ``Final``
-- ``IntVar``
 - ``Literal``
 - ``NewType``
 - ``NoReturn``


### PR DESCRIPTION
Some objects were missing from the splash page of typing_extensions.
I'm in doubt if IntVar should appear, since its purpose is not documented anywhere that I could find...