### PR TITLE
Accept arbitrary keyword names in NamedTuple() and TypedDict()

### DIFF
--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -2513,6 +2513,36 @@ class XMethBad2(NamedTuple):
         with self.assertRaises(TypeError):
             NamedTuple('Name', x=1, y='a')
 
+    def test_namedtuple_special_keyword_names(self):
+        NT = NamedTuple("NT", cls=type, self=object, typename=str, fields=list)
+        self.assertEqual(NT.__name__, 'NT')
+        self.assertEqual(NT._fields, ('cls', 'self', 'typename', 'fields'))
+        a = NT(cls=str, self=42, typename='foo', fields=[('bar', tuple)])
+        self.assertEqual(a.cls, str)
+        self.assertEqual(a.self, 42)
+        self.assertEqual(a.typename, 'foo')
+        self.assertEqual(a.fields, [('bar', tuple)])
+
+    def test_namedtuple_errors(self):
+        with self.assertRaises(TypeError):
+            NamedTuple.__new__()
+        with self.assertRaises(TypeError):
+            NamedTuple()
+        with self.assertRaises(TypeError):
+            NamedTuple('Emp', [('name', str)], None)
+        with self.assertRaises(ValueError):
+            NamedTuple('Emp', [('_name', str)])
+
+        with self.assertWarns(DeprecationWarning):
+            Emp = NamedTuple(typename='Emp', name=str, id=int)
+        self.assertEqual(Emp.__name__, 'Emp')
+        self.assertEqual(Emp._fields, ('name', 'id'))
+
+        with self.assertWarns(DeprecationWarning):
+            Emp = NamedTuple('Emp', fields=[('name', str), ('id', int)])
+        self.assertEqual(Emp.__name__, 'Emp')
+        self.assertEqual(Emp._fields, ('name', 'id'))
+
     def test_pickle(self):
         global Emp  # pickle wants to reference the class by name
         Emp = NamedTuple('Emp', [('name', str), ('id', int)])

--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -2513,6 +2513,7 @@ class XMethBad2(NamedTuple):
         with self.assertRaises(TypeError):
             NamedTuple('Name', x=1, y='a')
 
+    @skipUnless(PY36, 'Python 3.6 required')
     def test_namedtuple_special_keyword_names(self):
         NT = NamedTuple("NT", cls=type, self=object, typename=str, fields=list)
         self.assertEqual(NT.__name__, 'NT')
@@ -2523,6 +2524,7 @@ class XMethBad2(NamedTuple):
         self.assertEqual(a.typename, 'foo')
         self.assertEqual(a.fields, [('bar', tuple)])
 
+    @skipUnless(PY36, 'Python 3.6 required')
     def test_namedtuple_errors(self):
         with self.assertRaises(TypeError):
             NamedTuple.__new__()

--- a/src/typing.py
+++ b/src/typing.py
@@ -2204,7 +2204,7 @@ class NamedTuple(metaclass=NamedTupleMeta):
     """
     _root = True
 
-    def __new__(self, *args, **kwargs):
+    def __new__(*args, **kwargs):
         if kwargs and not _PY36:
             raise TypeError("Keyword syntax for NamedTuple is only supported"
                             " in Python 3.6+")

--- a/src/typing.py
+++ b/src/typing.py
@@ -2210,7 +2210,7 @@ class NamedTuple(metaclass=NamedTupleMeta):
                             " in Python 3.6+")
         if not args:
             raise TypeError('NamedTuple.__new__(): not enough arguments')
-        cls, args = args[0], args[1:]  # allow the "cls" keyword be passed
+        _, args = args[0], args[1:]  # allow the "cls" keyword be passed
         if args:
             typename, args = args[0], args[1:]  # allow the "typename" keyword be passed
         elif 'typename' in kwargs:

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -1446,10 +1446,13 @@ class TypedDictTests(BaseTestCase):
         self.assertEqual(Emp.__total__, True)
 
     def test_typeddict_special_keyword_names(self):
-        TD = TypedDict("TD", cls=type, self=object, typename=str, _typename=int, fields=list, _fields=dict)
+        TD = TypedDict("TD", cls=type, self=object, typename=str, _typename=int,
+                       fields=list, _fields=dict)
         self.assertEqual(TD.__name__, 'TD')
-        self.assertEqual(TD.__annotations__, {'cls': type, 'self': object, 'typename': str, '_typename': int, 'fields': list, '_fields': dict})
-        a = TD(cls=str, self=42, typename='foo', _typename=53, fields=[('bar', tuple)], _fields={'baz', set})
+        self.assertEqual(TD.__annotations__, {'cls': type, 'self': object, 'typename': str,
+                                              '_typename': int, 'fields': list, '_fields': dict})
+        a = TD(cls=str, self=42, typename='foo', _typename=53,
+               fields=[('bar', tuple)], _fields={'baz', set})
         self.assertEqual(a['cls'], str)
         self.assertEqual(a['self'], 42)
         self.assertEqual(a['typename'], 'foo')

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -6,7 +6,7 @@ import collections
 import pickle
 import subprocess
 import types
-from unittest import TestCase, main, skipUnless
+from unittest import TestCase, main, skipUnless, skipIf
 from typing import TypeVar, Optional
 from typing import T, KT, VT  # Not in __all__.
 from typing import Tuple, List, Dict, Iterator
@@ -1457,6 +1457,7 @@ class TypedDictTests(BaseTestCase):
         self.assertEqual(a['fields'], [('bar', tuple)])
         self.assertEqual(a['_fields'], {'baz', set})
 
+    @skipIf(hasattr(typing, 'TypedDict'), "Should be tested by upstream")
     def test_typeddict_create_errors(self):
         with self.assertRaises(TypeError):
             TypedDict.__new__()

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -1445,6 +1445,36 @@ class TypedDictTests(BaseTestCase):
         self.assertEqual(Emp.__annotations__, {'name': str, 'id': int})
         self.assertEqual(Emp.__total__, True)
 
+    def test_typeddict_special_keyword_names(self):
+        TD = TypedDict("TD", cls=type, self=object, typename=str, _typename=int, fields=list, _fields=dict)
+        self.assertEqual(TD.__name__, 'TD')
+        self.assertEqual(TD.__annotations__, {'cls': type, 'self': object, 'typename': str, '_typename': int, 'fields': list, '_fields': dict})
+        a = TD(cls=str, self=42, typename='foo', _typename=53, fields=[('bar', tuple)], _fields={'baz', set})
+        self.assertEqual(a['cls'], str)
+        self.assertEqual(a['self'], 42)
+        self.assertEqual(a['typename'], 'foo')
+        self.assertEqual(a['_typename'], 53)
+        self.assertEqual(a['fields'], [('bar', tuple)])
+        self.assertEqual(a['_fields'], {'baz', set})
+
+    def test_typeddict_create_errors(self):
+        with self.assertRaises(TypeError):
+            TypedDict.__new__()
+        with self.assertRaises(TypeError):
+            TypedDict()
+        with self.assertRaises(TypeError):
+            TypedDict('Emp', [('name', str)], None)
+
+        with self.assertWarns(DeprecationWarning):
+            Emp = TypedDict(_typename='Emp', name=str, id=int)
+        self.assertEqual(Emp.__name__, 'Emp')
+        self.assertEqual(Emp.__annotations__, {'name': str, 'id': int})
+
+        with self.assertWarns(DeprecationWarning):
+            Emp = TypedDict('Emp', _fields={'name': str, 'id': int})
+        self.assertEqual(Emp.__name__, 'Emp')
+        self.assertEqual(Emp.__annotations__, {'name': str, 'id': int})
+
     def test_typeddict_errors(self):
         Emp = TypedDict('Emp', {'name': str, 'id': int})
         if hasattr(typing, 'TypedDict'):

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -1586,7 +1586,7 @@ else:
     def _dict_new(*args, **kwargs):
         if not args:
             raise TypeError('TypedDict.__new__(): not enough arguments')
-        cls, args = args[0], args[1:]  # allow the "cls" keyword be passed
+        _, args = args[0], args[1:]  # allow the "cls" keyword be passed
         return dict(*args, **kwargs)
 
     _dict_new.__text_signature__ = '($cls, _typename, _fields=None, /, **kwargs)'
@@ -1594,7 +1594,7 @@ else:
     def _typeddict_new(*args, total=True, **kwargs):
         if not args:
             raise TypeError('TypedDict.__new__(): not enough arguments')
-        cls, args = args[0], args[1:]  # allow the "cls" keyword be passed
+        _, args = args[0], args[1:]  # allow the "cls" keyword be passed
         if args:
             typename, args = args[0], args[1:]  # allow the "_typename" keyword be passed
         elif '_typename' in kwargs:
@@ -1635,7 +1635,8 @@ else:
 
         return _TypedDictMeta(typename, (), ns)
 
-    _typeddict_new.__text_signature__ = '($cls, _typename, _fields=None, /, *, total=True, **kwargs)'
+    _typeddict_new.__text_signature__ = ('($cls, _typename, _fields=None,'
+                                         ' /, *, total=True, **kwargs)')
 
     class _TypedDictMeta(type):
         def __new__(cls, name, bases, ns, total=True):

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -1583,25 +1583,59 @@ else:
             pass
         return False
 
-    def _dict_new(cls, *args, **kwargs):
+    def _dict_new(*args, **kwargs):
+        if not args:
+            raise TypeError('TypedDict.__new__(): not enough arguments')
+        cls, args = args[0], args[1:]  # allow the "cls" keyword be passed
         return dict(*args, **kwargs)
 
-    def _typeddict_new(cls, _typename, _fields=None, **kwargs):
-        total = kwargs.pop('total', True)
-        if _fields is None:
-            _fields = kwargs
+    _dict_new.__text_signature__ = '($cls, _typename, _fields=None, /, **kwargs)'
+
+    def _typeddict_new(*args, total=True, **kwargs):
+        if not args:
+            raise TypeError('TypedDict.__new__(): not enough arguments')
+        cls, args = args[0], args[1:]  # allow the "cls" keyword be passed
+        if args:
+            typename, args = args[0], args[1:]  # allow the "_typename" keyword be passed
+        elif '_typename' in kwargs:
+            typename = kwargs.pop('_typename')
+            import warnings
+            warnings.warn("Passing '_typename' as keyword argument is deprecated",
+                          DeprecationWarning, stacklevel=2)
+        else:
+            raise TypeError("TypedDict.__new__() missing 1 required positional "
+                            "argument: '_typename'")
+        if args:
+            try:
+                fields, = args  # allow the "_fields" keyword be passed
+            except ValueError:
+                raise TypeError('TypedDict.__new__() takes from 2 to 3 '
+                                'positional arguments but {} '
+                                'were given'.format(len(args) + 2))
+        elif '_fields' in kwargs and len(kwargs) == 1:
+            fields = kwargs.pop('_fields')
+            import warnings
+            warnings.warn("Passing '_fields' as keyword argument is deprecated",
+                          DeprecationWarning, stacklevel=2)
+        else:
+            fields = None
+
+        if fields is None:
+            fields = kwargs
         elif kwargs:
             raise TypeError("TypedDict takes either a dict or keyword arguments,"
                             " but not both")
 
-        ns = {'__annotations__': dict(_fields), '__total__': total}
+        ns = {'__annotations__': dict(fields), '__total__': total}
         try:
             # Setting correct module is necessary to make typed dict classes pickleable.
             ns['__module__'] = sys._getframe(1).f_globals.get('__name__', '__main__')
         except (AttributeError, ValueError):
             pass
 
-        return _TypedDictMeta(_typename, (), ns)
+        return _TypedDictMeta(typename, (), ns)
+
+    _typeddict_new.__text_signature__ = '($cls, _typename, _fields=None, /, *, total=True, **kwargs)'
 
     class _TypedDictMeta(type):
         def __new__(cls, name, bases, ns, total=True):


### PR DESCRIPTION
Fixes https://github.com/python/typing/issues/677

This backports https://github.com/python/cpython/pull/16222 (Python 3 only). The Python 2 backport is more tricky so I skip it for now.