### PR TITLE
Reuse stdlib PEP 593 implementation in typing_extensions if present

### DIFF
--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -1707,7 +1707,14 @@ else:
         """
 
 
-if PEP_560:
+# Python 3.9+ has PEP 593 (Annotated and modified get_type_hints)
+if hasattr(typing, 'Annotated'):
+    Annotated = typing.Annotated
+    get_type_hints = typing.get_type_hints
+    # Not exported and not a public API, but needed for get_origin() and get_args()
+    # to work.
+    _AnnotatedAlias = typing._AnnotatedAlias
+elif PEP_560:
     class _AnnotatedAlias(typing._GenericAlias, _root=True):
         """Runtime representation of an annotated type.
 


### PR DESCRIPTION
Following [1] this prevents multiple runtime implementations of Annotated
and get_type_hints from existing on Python 3.9 (which has recently
merged PEP 593 changes[2]). Reexporting allows code targetting both
Python pre-3.9 and 3.9+ to be able to import from typing_extensions and
to keep working without changes.

`_AnnotatedAlias` import is needed for https://github.com/python/typing/pull/698 to work.

[1] https://github.com/python/cpython/pull/18260#issuecomment-582486917
[2] https://github.com/python/cpython/pull/18260