### PR TITLE
Fix required and optional keys inheritance for TypedDict

### DIFF
--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -1551,6 +1551,32 @@ class TypedDictTests(BaseTestCase):
         assert Point2Dor3D.__required_keys__ == frozenset(['x', 'y'])
         assert Point2Dor3D.__optional_keys__ == frozenset(['z'])
 
+    @skipUnless(PY36, 'Python 3.6 required')
+    def test_keys_inheritance(self):
+        class _Animal(TypedDict):
+            name: str
+
+        class Animal(_Animal, total=False):
+            voice: str
+            tail: bool
+
+        class Cat(Animal):
+            fur_color: str
+            tail: int
+
+        assert _Animal.__required_keys__ == frozenset(['name'])
+        assert _Animal.__optional_keys__ == frozenset([])
+        assert Animal.__required_keys__ == frozenset(['name'])
+        assert Animal.__optional_keys__ == frozenset(['tail', 'voice'])
+        assert Cat.__required_keys__ == frozenset(['name', 'fur_color', 'tail'])
+        assert Cat.__optional_keys__ == frozenset(['voice'])
+        assert Cat.__annotations__ == {
+            'fur_color': str,
+            'name': str,
+            'tail': int,
+            'voice': str,
+        }
+
 
 @skipUnless(TYPING_3_5_3, "Python >= 3.5.3 required")
 class AnnotatedTests(BaseTestCase):

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -436,6 +436,17 @@ class LabelPoint2D(Point2D, Label): ...
 class Options(TypedDict, total=False):
     log_level: int
     log_path: str
+
+class _Animal(TypedDict):
+    name: str
+
+class Animal(_Animal, total=False):
+    voice: str
+    tail: bool
+
+class Cat(Animal):
+    fur_color: str
+    tail: int
 """
 
 if PY36:
@@ -1553,17 +1564,6 @@ class TypedDictTests(BaseTestCase):
 
     @skipUnless(PY36, 'Python 3.6 required')
     def test_keys_inheritance(self):
-        class _Animal(TypedDict):
-            name: str
-
-        class Animal(_Animal, total=False):
-            voice: str
-            tail: bool
-
-        class Cat(Animal):
-            fur_color: str
-            tail: int
-
         assert _Animal.__required_keys__ == frozenset(['name'])
         assert _Animal.__optional_keys__ == frozenset([])
         assert _Animal.__annotations__ == {'name': str}

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -437,16 +437,15 @@ class Options(TypedDict, total=False):
     log_level: int
     log_path: str
 
-class _Animal(TypedDict):
+class BaseAnimal(TypedDict):
     name: str
 
-class Animal(_Animal, total=False):
+class Animal(BaseAnimal, total=False):
     voice: str
     tail: bool
 
 class Cat(Animal):
     fur_color: str
-    tail: int
 """
 
 if PY36:
@@ -457,7 +456,7 @@ else:
     A = B = CSub = G = CoolEmployee = CoolEmployeeWithDefault = object
     XMeth = XRepr = HasCallProtocol = NoneAndForward = Loop = object
     Point2D = Point2Dor3D = LabelPoint2D = Options = object
-    _Animal = Animal = Cat = object
+    BaseAnimal = Animal = Cat = object
 
 gth = get_type_hints
 
@@ -1565,9 +1564,9 @@ class TypedDictTests(BaseTestCase):
 
     @skipUnless(PY36, 'Python 3.6 required')
     def test_keys_inheritance(self):
-        assert _Animal.__required_keys__ == frozenset(['name'])
-        assert _Animal.__optional_keys__ == frozenset([])
-        assert _Animal.__annotations__ == {'name': str}
+        assert BaseAnimal.__required_keys__ == frozenset(['name'])
+        assert BaseAnimal.__optional_keys__ == frozenset([])
+        assert BaseAnimal.__annotations__ == {'name': str}
 
         assert Animal.__required_keys__ == frozenset(['name'])
         assert Animal.__optional_keys__ == frozenset(['tail', 'voice'])
@@ -1577,12 +1576,12 @@ class TypedDictTests(BaseTestCase):
             'voice': str,
         }
 
-        assert Cat.__required_keys__ == frozenset(['name', 'fur_color', 'tail'])
-        assert Cat.__optional_keys__ == frozenset(['voice'])
+        assert Cat.__required_keys__ == frozenset(['name', 'fur_color'])
+        assert Cat.__optional_keys__ == frozenset(['tail', 'voice'])
         assert Cat.__annotations__ == {
             'fur_color': str,
             'name': str,
-            'tail': int,
+            'tail': bool,
             'voice': str,
         }
 

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -1566,8 +1566,16 @@ class TypedDictTests(BaseTestCase):
 
         assert _Animal.__required_keys__ == frozenset(['name'])
         assert _Animal.__optional_keys__ == frozenset([])
+        assert _Animal.__annotations__ == {'name': str}
+
         assert Animal.__required_keys__ == frozenset(['name'])
         assert Animal.__optional_keys__ == frozenset(['tail', 'voice'])
+        assert Animal.__annotations__ == {
+            'name': str,
+            'tail': bool,
+            'voice': str,
+        }
+
         assert Cat.__required_keys__ == frozenset(['name', 'fur_color', 'tail'])
         assert Cat.__optional_keys__ == frozenset(['voice'])
         assert Cat.__annotations__ == {

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -457,6 +457,7 @@ else:
     A = B = CSub = G = CoolEmployee = CoolEmployeeWithDefault = object
     XMeth = XRepr = HasCallProtocol = NoneAndForward = Loop = object
     Point2D = Point2Dor3D = LabelPoint2D = Options = object
+    _Animal = Animal = Cat = object
 
 gth = get_type_hints
 

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -1653,7 +1653,7 @@ else:
 
             annotations = {}
             own_annotations = ns.get('__annotations__', {})
-            own_annotation_keys = set(annotations.keys())
+            own_annotation_keys = set(own_annotations.keys())
             msg = "TypedDict('Name', {f0: t0, f1: t1, ...}); each t must be a type"
             own_annotations = {
                 n: typing._type_check(tp, msg) for n, tp in own_annotations.items()

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -1669,10 +1669,8 @@ else:
             annotations.update(own_annotations)
             if total:
                 required_keys.update(own_annotation_keys)
-                optional_keys.difference_update(own_annotation_keys)
             else:
                 optional_keys.update(own_annotation_keys)
-                required_keys.difference_update(own_annotation_keys)
 
             tp_dict.__annotations__ = annotations
             tp_dict.__required_keys__ = frozenset(required_keys)

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -1651,23 +1651,32 @@ else:
             ns['__new__'] = _typeddict_new if name == 'TypedDict' else _dict_new
             tp_dict = super(_TypedDictMeta, cls).__new__(cls, name, (dict,), ns)
 
-            anns = ns.get('__annotations__', {})
+            annotations = {}
+            own_annotations = ns.get('__annotations__', {})
+            own_annotation_keys = set(annotations.keys())
             msg = "TypedDict('Name', {f0: t0, f1: t1, ...}); each t must be a type"
-            anns = {n: typing._type_check(tp, msg) for n, tp in anns.items()}
-            required = set(anns if total else ())
-            optional = set(() if total else anns)
+            own_annotations = {
+                n: typing._type_check(tp, msg) for n, tp in own_annotations.items()
+            }
+            required_keys = set()
+            optional_keys = set()
 
             for base in bases:
-                base_anns = base.__dict__.get('__annotations__', {})
-                anns.update(base_anns)
-                if getattr(base, '__total__', True):
-                    required.update(base_anns)
-                else:
-                    optional.update(base_anns)
+                annotations.update(base.__dict__.get('__annotations__', {}))
+                required_keys.update(base.__dict__.get('__required_keys__', ()))
+                optional_keys.update(base.__dict__.get('__optional_keys__', ()))
 
-            tp_dict.__annotations__ = anns
-            tp_dict.__required_keys__ = frozenset(required)
-            tp_dict.__optional_keys__ = frozenset(optional)
+            annotations.update(own_annotations)
+            if total:
+                required_keys.update(own_annotation_keys)
+                optional_keys.difference_update(own_annotation_keys)
+            else:
+                optional_keys.update(own_annotation_keys)
+                required_keys.difference_update(own_annotation_keys)
+
+            tp_dict.__annotations__ = annotations
+            tp_dict.__required_keys__ = frozenset(required_keys)
+            tp_dict.__optional_keys__ = frozenset(optional_keys)
             if not hasattr(tp_dict, '__total__'):
                 tp_dict.__total__ = total
             return tp_dict


### PR DESCRIPTION
I realized that the inheritance of TypedDict does not work as it should.

```python
class _Animal(TypedDict):
     name: str

class Animal(_Animal, total=False):
     voice: str

class Cat(Animal):
     fur_color: str
```

I would assume that `Cat` should have required keys `name` and `fur_color` and optional `voice`.
But in reality, it will have required `fur_color` and optional `name` and `voice`, because `Animal` has `total=False`

### Fixed

- `__required_keys__` and `__optional_keys__` are copied from base classes
- Own `TypedDict` annotations are added to `__annotations__` after base annotations
- Conflicting required and optional keys from base classes are removed if `TypedDict` redefines them