### PR TITLE
Replace asyncio.coroutine with async-await

### DIFF
--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -328,7 +328,6 @@ class OverloadTests(BaseTestCase):
 
 
 ASYNCIO_TESTS = """
-import asyncio
 from typing import Iterable
 from typing_extensions import Awaitable, AsyncIterator
 
@@ -351,9 +350,8 @@ class AsyncIteratorWrapper(AsyncIterator[T_a]):
     def __aiter__(self) -> AsyncIterator[T_a]:
         return self
 
-    @asyncio.coroutine
-    def __anext__(self) -> T_a:
-        data = yield from self.value
+    async def __anext__(self) -> T_a:
+        data = await self.value
         if data:
             return data
         else:


### PR DESCRIPTION
`asyncio.coroutine` decorator is deprecated in Python 3.8. I replaced it with `async`-`await` syntax. This change only affects unit tests.

New syntax should work in Python 3.5+, but I checked only 3.8.1.

### Fixed

- DeprecationWarning in `AsyncIteratorWrapper` in unit tests
