### PR TITLE
Fix ForwardRef hash and equality checks

### DIFF
--- a/src/test_typing.py
+++ b/src/test_typing.py
@@ -1497,6 +1497,65 @@ class ForwardRefTests(BaseTestCase):
         self.assertEqual(fr, typing._ForwardRef('int'))
         self.assertNotEqual(List['int'], List[int])
 
+    def test_forward_equality_gth(self):
+        c1 = typing._ForwardRef('C')
+        c1_gth = typing._ForwardRef('C')
+        c2 = typing._ForwardRef('C')
+        c2_gth = typing._ForwardRef('C')
+
+        class C:
+            pass
+        def foo(a: c1_gth, b: c2_gth):
+            pass
+
+        self.assertEqual(get_type_hints(foo, globals(), locals()), {'a': C, 'b': C})
+        self.assertEqual(c1, c2)
+        self.assertEqual(c1, c1_gth)
+        self.assertEqual(c1_gth, c2_gth)
+        self.assertEqual(List[c1], List[c1_gth])
+        self.assertNotEqual(List[c1], List[C])
+        self.assertNotEqual(List[c1_gth], List[C])
+        self.assertEquals(Union[c1, c1_gth], Union[c1])
+        self.assertEquals(Union[c1, c1_gth, int], Union[c1, int])
+
+    def test_forward_equality_hash(self):
+        c1 = typing._ForwardRef('int')
+        c1_gth = typing._ForwardRef('int')
+        c2 = typing._ForwardRef('int')
+        c2_gth = typing._ForwardRef('int')
+
+        def foo(a: c1_gth, b: c2_gth):
+            pass
+        get_type_hints(foo, globals(), locals())
+
+        self.assertEqual(hash(c1), hash(c2))
+        self.assertEqual(hash(c1_gth), hash(c2_gth))
+        self.assertEqual(hash(c1), hash(c1_gth))
+
+    def test_forward_equality_namespace(self):
+        class A:
+            pass
+        def namespace1():
+            a = typing._ForwardRef('A')
+            def fun(x: a):
+                pass
+            get_type_hints(fun, globals(), locals())
+            return a
+
+        def namespace2():
+            a = typing._ForwardRef('A')
+
+            class A:
+                pass
+            def fun(x: a):
+                pass
+
+            get_type_hints(fun, globals(), locals())
+            return a
+
+        self.assertEqual(namespace1(), namespace1())
+        self.assertNotEqual(namespace1(), namespace2())
+
     def test_forward_repr(self):
         self.assertEqual(repr(List['int']), "typing.List[_ForwardRef('int')]")
 
@@ -1515,6 +1574,67 @@ class ForwardRefTests(BaseTestCase):
 
         self.assertEqual(get_type_hints(foo, globals(), locals()),
                          {'a': Tuple[T]})
+
+    def test_forward_recursion_actually(self):
+        def namespace1():
+            a = typing._ForwardRef('A')
+            A = a
+            def fun(x: a): pass
+
+            ret = get_type_hints(fun, globals(), locals())
+            return a
+
+        def namespace2():
+            a = typing._ForwardRef('A')
+            A = a
+            def fun(x: a): pass
+
+            ret = get_type_hints(fun, globals(), locals())
+            return a
+
+        def cmp(o1, o2):
+            return o1 == o2
+
+        r1 = namespace1()
+        r2 = namespace2()
+        self.assertIsNot(r1, r2)
+
+        try:
+            exc = RecursionError
+        except NameError:
+            exc = RuntimeError
+        self.assertRaises(exc, cmp, r1, r2)
+
+    def test_union_forward_recursion(self):
+        ValueList = List['Value']
+        Value = Union[str, ValueList]
+
+        def c(foo: List[Value]):
+            pass
+        def d(foo: Union[Value, ValueList]):
+            pass
+        def e(foo: Union[List[Value], ValueList]):
+            pass
+        def f(foo: Union[Value, List[Value], ValueList]):
+            pass
+
+        self.assertEqual(get_type_hints(c, globals(), locals()),
+                         get_type_hints(c, globals(), locals()))
+        self.assertEqual(get_type_hints(c, globals(), locals()),
+                         {'foo': List[Union[str, List[Union[str, List['Value']]]]]})
+        self.assertEqual(get_type_hints(d, globals(), locals()),
+                         {'foo': Union[str, List[Union[str, List['Value']]]]})
+        self.assertEqual(get_type_hints(e, globals(), locals()),
+                         {'foo': Union[
+                             List[Union[str, List[Union[str, List['Value']]]]],
+                             List[Union[str, List['Value']]]
+                         ]})
+        self.assertEqual(get_type_hints(f, globals(), locals()),
+                         {'foo': Union[
+                             str,
+                             List[Union[str, List['Value']]],
+                             List[Union[str, List[Union[str, List['Value']]]]]
+                         ]})
 
     def test_callable_forward(self):
 

--- a/src/typing.py
+++ b/src/typing.py
@@ -252,11 +252,13 @@ class _ForwardRef(_TypingBase, _root=True):
     def __eq__(self, other):
         if not isinstance(other, _ForwardRef):
             return NotImplemented
-        return (self.__forward_arg__ == other.__forward_arg__ and
-                self.__forward_value__ == other.__forward_value__)
+        if self.__forward_evaluated__ and other.__forward_evaluated__:
+            return (self.__forward_arg__ == other.__forward_arg__ and
+                    self.__forward_value__ == other.__forward_value__)
+        return self.__forward_arg__ == other.__forward_arg__
 
     def __hash__(self):
-        return hash((self.__forward_arg__, self.__forward_value__))
+        return hash(self.__forward_arg__)
 
     def __instancecheck__(self, obj):
         raise TypeError("Forward references cannot be used with isinstance().")


### PR DESCRIPTION
This backports python/cpython#15400 to this typing module and fixes #667.

> Ideally if we stick a ForwardRef in a dictionary we would like to reliably be able to get it out again.
> 
> https://bugs.python.org/issue37953
> (cherry picked from commit e082e7c in python/cpython)
> 
> Co-authored-by: plokmijnuhby 39633434+plokmijnuhby@users.noreply.github.com