### PR TITLE
Update package metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,4 +66,5 @@ setup(name='typing',
                'checker typehints typehinting typechecking backport',
       package_dir={'': package_dir},
       py_modules=['typing'],
+      python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
       classifiers=classifiers)

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(name='typing',
       author='Guido van Rossum, Jukka Lehtosalo, Łukasz Langa, Ivan Levkivskyi',
       author_email='jukka.lehtosalo@iki.fi',
       url='https://docs.python.org/3/library/typing.html',
+      project_urls={'Source': 'https://github.com/python/typing'},
       license='PSF',
       keywords='typing function annotations type hints hinting checking '
                'checker typehints typehinting typechecking backport',


### PR DESCRIPTION
* Add `python_requires` to help pip only install for Python 2.7 or 3.4+

* Add a link back to this source repo for the package on PyPI
