### PR TITLE
Use regex to allow `typing` or `typing_extensions` module name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: python
 
 jobs:
   include:
+    - name: "3.9"
+      dist: xenial
+      python: 3.9-dev
     - name: "3.8"
       dist: xenial
       python: 3.8.0

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -1588,13 +1588,13 @@ class TypedDictTests(BaseTestCase):
 class AnnotatedTests(BaseTestCase):
 
     def test_repr(self):
-        self.assertEqual(
+        self.assertRegex(
             repr(Annotated[int, 4, 5]),
-            "typing_extensions.Annotated[int, 4, 5]"
+            r"typing(?:_extensions|)\.Annotated\[int, 4, 5\]"
         )
-        self.assertEqual(
+        self.assertRegex(
             repr(Annotated[List[int], 4, 5]),
-            "typing_extensions.Annotated[typing.List[int], 4, 5]"
+            r"typing(?:_extensions|)\.Annotated\[typing\.List\[int\], 4, 5\]"
         )
 
     def test_flatten(self):


### PR DESCRIPTION
This is useful for testing with Python 3.9 where:

```
>>> repr(Annotated)
"<class 'typing.Annotated'>"
```

but in  Python 3.8 and lower:

```
>>> repr(Annotated)
"<class 'typing_extensions.Annotated'>"
```