### PR TITLE
Make tests for Annotated work with Python 3.9

### DIFF
--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -1588,13 +1588,17 @@ class TypedDictTests(BaseTestCase):
 class AnnotatedTests(BaseTestCase):
 
     def test_repr(self):
+        if hasattr(typing, 'Annotated'):
+            mod_name = 'typing'
+        else:
+            mod_name = "typing_extensions"
         self.assertEqual(
             repr(Annotated[int, 4, 5]),
-            "typing_extensions.Annotated[int, 4, 5]"
+            mod_name + ".Annotated[int, 4, 5]"
         )
         self.assertEqual(
             repr(Annotated[List[int], 4, 5]),
-            "typing_extensions.Annotated[typing.List[int], 4, 5]"
+            mod_name + ".Annotated[typing.List[int], 4, 5]"
         )
 
     def test_flatten(self):


### PR DESCRIPTION
Python 3.9+ has its own version of Annotated. Its tests now take it
into account similarly to how it's already done for other backported
typing constructs.