### PR TITLE
Add tox.ini for typing_extensions

### DIFF
--- a/typing_extensions/tox.ini
+++ b/typing_extensions/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist = py27, py34, py35, py36, py37, py38, py39
+
+[testenv]
+changedir = src_py3
+commands = python -m unittest discover
+
+[testenv:py27]
+changedir = src_py2


### PR DESCRIPTION
It supports running its tests for all supported Python versions:
2.7 and 3.4-3.9, which are different from those for "typing" package
itself that is intended primarily for 2.7 and 3.4 where "typing"
module is not included in the standard library.