### PR TITLE
Apply get_args fix from bpo-40398 to typing_extensions

### DIFF
--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -2065,7 +2065,7 @@ elif PEP_560:
         """
         if isinstance(tp, _AnnotatedAlias):
             return (tp.__origin__,) + tp.__metadata__
-        if isinstance(tp, _GenericAlias):
+        if isinstance(tp, _GenericAlias) and not tp._special:
             res = tp.__args__
             if get_origin(tp) is collections.abc.Callable and res[0] is not Ellipsis:
                 res = (list(res[:-1]), res[-1])


### PR DESCRIPTION
Applies the fix from https://bugs.python.org/issue40398 to typing_extensions: typing.get_args() now always returns an empty tuple for special generic aliases.