### PR TITLE
Support PEP 612 in typing_extensions (Python 3)

### DIFF
--- a/typing_extensions/README.rst
+++ b/typing_extensions/README.rst
@@ -49,6 +49,7 @@ All Python versions:
 - ``Text``
 - ``Type``
 - ``TypedDict``
+- ``TypeAlias``
 - ``TYPE_CHECKING``
 
 Python 3.4+ only:
@@ -79,6 +80,12 @@ subclass ``typing.Reversible`` as of Python 3.5.3.
 
 These changes are _not_ backported to prevent subtle compatibility
 issues when mixing the differing implementations of modified classes.
+
+Certain types have incorrect runtime behavior due to limitations of older
+versions of the typing module.  For example, ``ParamSpec`` and ``Concatenate``
+will not work with ``get_args``, ``get_origin`` or user-defined ``Generic``\ s
+because they need to be lists to work with older versions of ``Callable``.
+These types are only guaranteed to work for static type checking.
 
 Running tests
 =============

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -51,6 +51,7 @@ TYPING_LATEST = sys.version_info[:3] < (3, 5, 0)
 TYPING_3_5_1 = TYPING_LATEST or sys.version_info[:3] >= (3, 5, 1)
 TYPING_3_5_3 = TYPING_LATEST or sys.version_info[:3] >= (3, 5, 3)
 TYPING_3_6_1 = TYPING_LATEST or sys.version_info[:3] >= (3, 6, 1)
+TYPING_3_10_0 = TYPING_LATEST or sys.version_info[:3] >= (3, 10, 0)
 
 # For typing versions where issubclass(...) and
 # isinstance(...) checks are forbidden.
@@ -1240,8 +1241,9 @@ if HAVE_PROTOCOLS:
             self.assertIsSubclass(P, PR)
             with self.assertRaises(TypeError):
                 PR[int]
-            with self.assertRaises(TypeError):
-                PR[int, 1]
+            if not TYPING_3_10_0:
+                with self.assertRaises(TypeError):
+                    PR[int, 1]
             class P1(Protocol, Generic[T]):
                 def bar(self, x: T) -> str: ...
             class P2(Generic[T], Protocol):
@@ -1254,7 +1256,7 @@ if HAVE_PROTOCOLS:
                 def bar(self, x: str) -> str:
                     return x
             self.assertIsInstance(Test(), PSub)
-            if TYPING_3_5_3:
+            if TYPING_3_5_3 and not TYPING_3_10_0:
                 with self.assertRaises(TypeError):
                     PR[int, ClassVar]
 

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -1935,6 +1935,18 @@ class ParamSpecTests(BaseTestCase):
                     self.assertEqual(z.__contravariant__, paramspec.__contravariant__)
                     self.assertEqual(z.__bound__, paramspec.__bound__)
 
+    def test_eq(self):
+        P = ParamSpec('P')
+        self.assertEqual(P, P)
+        self.assertEqual(hash(P), hash(P))
+        # ParamSpec should compare by id similar to TypeVar in CPython
+        self.assertNotEqual(ParamSpec('P'), P)
+        self.assertIsNot(ParamSpec('P'), P)
+        # Note: normally you don't test this as it breaks when there's
+        # a hash collision. However, ParamSpec *must* guarantee that
+        # as long as two objects don't have the same ID, their hashes
+        # won't be the same.
+        self.assertNotEqual(hash(ParamSpec('P')), hash(P))
 
 class ConcatenateTests(BaseTestCase):
     def test_basics(self):
@@ -1964,6 +1976,13 @@ class ConcatenateTests(BaseTestCase):
         self.assertEqual(C1.__args__, (int, P))
         self.assertEqual(C2.__origin__, Concatenate)
         self.assertEqual(C2.__args__, (int, T, P))
+
+    def test_eq(self):
+        P = ParamSpec('P')
+        C1 = Concatenate[int, P]
+        C2 = Concatenate[int, P]
+        self.assertEqual(C1, C2)
+        self.assertEqual(hash(C1), hash(C2))
 
 class AllTests(BaseTestCase):
 

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -1948,6 +1948,7 @@ class ParamSpecTests(BaseTestCase):
         # won't be the same.
         self.assertNotEqual(hash(ParamSpec('P')), hash(P))
 
+
 class ConcatenateTests(BaseTestCase):
     def test_basics(self):
         P = ParamSpec('P')
@@ -1981,8 +1982,11 @@ class ConcatenateTests(BaseTestCase):
         P = ParamSpec('P')
         C1 = Concatenate[int, P]
         C2 = Concatenate[int, P]
+        C3 = Concatenate[int, T, P]
         self.assertEqual(C1, C2)
         self.assertEqual(hash(C1), hash(C2))
+        self.assertNotEqual(C1, C3)
+
 
 class AllTests(BaseTestCase):
 

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -1889,6 +1889,10 @@ class ParamSpecTests(BaseTestCase):
         C1 = typing.Callable[P, int]
         C2 = typing.Callable[P, T]
 
+        # Note: no tests for Callable.__args__ and Callable.__parameters__ here
+        # because pre-3.10 Callable sees ParamSpec as a plain list, not a
+        # TypeVar.
+
         # Test collections.abc.Callable too.
         if sys.version_info[:2] >= (3, 9):
             C3 = collections.abc.Callable[P, int]
@@ -1900,6 +1904,8 @@ class ParamSpecTests(BaseTestCase):
         P.args
         P.kwargs
 
+        # Note: ParamSpec doesn't work for pre-3.10 user-defined Generics due
+        # to type checks inside Generic.
 
 class ConcatenateTests(BaseTestCase):
     def test_basics(self):

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -13,7 +13,8 @@ from typing import Tuple, List, Dict, Iterator
 from typing import Generic
 from typing import no_type_check
 from typing_extensions import NoReturn, ClassVar, Final, IntVar, Literal, Type, NewType, TypedDict
-from typing_extensions import TypeAlias
+from typing_extensions import TypeAlias, ParamSpec, Concatenate
+
 try:
     from typing_extensions import Protocol, runtime, runtime_checkable
 except ImportError:
@@ -1875,6 +1876,52 @@ class TypeAliasTests(BaseTestCase):
             TypeAlias[int]
 
 
+class ParamSpecTests(BaseTestCase):
+
+    def test_basic_plain(self):
+        P = ParamSpec('P')
+        self.assertEqual(P, P)
+        self.assertIsInstance(P, ParamSpec)
+
+    def test_valid_uses(self):
+        P = ParamSpec('P')
+        T = TypeVar('T')
+        C1 = typing.Callable[P, int]
+        C2 = typing.Callable[P, T]
+
+        # Test collections.abc.Callable too.
+        if sys.version_info[:2] >= (3, 9):
+            C3 = collections.abc.Callable[P, int]
+            C4 = collections.abc.Callable[P, T]
+
+        # ParamSpec instances should also have args and kwargs attributes.
+        self.assertIn('args', dir(P))
+        self.assertIn('kwargs', dir(P))
+        P.args
+        P.kwargs
+
+
+class ConcatenateTests(BaseTestCase):
+    def test_basics(self):
+        P = ParamSpec('P')
+
+        class MyClass: ...
+
+        c = Concatenate[MyClass, P]
+        self.assertNotEqual(c, Concatenate)
+
+    def test_valid_uses(self):
+        P = ParamSpec('P')
+        T = TypeVar('T')
+        C1 = typing.Callable[Concatenate[int, P], int]
+        C2 = typing.Callable[Concatenate[int, T, P], T]
+
+        # Test collections.abc.Callable too.
+        if sys.version_info[:2] >= (3, 9):
+            C3 = collections.abc.Callable[Concatenate[int, P], int]
+            C4 = collections.abc.Callable[Concatenate[int, T, P], T]
+
+
 class AllTests(BaseTestCase):
 
     def test_typing_extensions_includes_standard(self):
@@ -1890,6 +1937,10 @@ class AllTests(BaseTestCase):
         self.assertIn('overload', a)
         self.assertIn('Text', a)
         self.assertIn('TYPE_CHECKING', a)
+        self.assertIn('TypeAlias', a)
+        self.assertIn('ParamSpec', a)
+        self.assertIn("Concatenate", a)
+
         if TYPING_3_5_3:
             self.assertIn('Annotated', a)
         if PEP_560:

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -1923,7 +1923,7 @@ class ParamSpecTests(BaseTestCase):
     def test_pickle(self):
         global P, P_co, P_contra
         for proto in range(pickle.HIGHEST_PROTOCOL):
-            with self.subTest(f"Pickle protocol {proto}"):
+            with self.subTest('Pickle protocol {proto}'.format(proto=proto)):
                 for paramspec in (P, P_co, P_contra):
                     z = pickle.loads(pickle.dumps(paramspec, proto))
                     self.assertEqual(z.__name__, paramspec.__name__)
@@ -1952,6 +1952,13 @@ class ConcatenateTests(BaseTestCase):
             C3 = collections.abc.Callable[Concatenate[int, P], int]
             C4 = collections.abc.Callable[Concatenate[int, T, P], T]
 
+    def test_basic_introspection(self):
+        C1 = Concatenate[int, P]
+        C2 = Concatenate[int, T, P]
+        self.assertEqual(C1.__origin__, Concatenate)
+        self.assertEqual(C1.__args__, (int, P))
+        self.assertEqual(C2.__origin__, Concatenate)
+        self.assertEqual(C2.__args__, (int, T, P))
 
 class AllTests(BaseTestCase):
 

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -1875,18 +1875,17 @@ class TypeAliasTests(BaseTestCase):
         with self.assertRaises(TypeError):
             TypeAlias[int]
 
-P = ParamSpec('P')
-P_co = ParamSpec('P_co', covariant=True)
-P_contra = ParamSpec('P_contra', contravariant=True)
 class ParamSpecTests(BaseTestCase):
 
     def test_basic_plain(self):
-        global P
+        P = ParamSpec('P')
         self.assertEqual(P, P)
         self.assertIsInstance(P, ParamSpec)
 
     def test_repr(self):
-        global P, P_co, P_contra
+        P = ParamSpec('P')
+        P_co = ParamSpec('P_co', covariant=True)
+        P_contra = ParamSpec('P_contra', contravariant=True)
         P_2 = ParamSpec('P_2')
         self.assertEqual(repr(P), '~P')
         self.assertEqual(repr(P_2), '~P_2')
@@ -1922,6 +1921,9 @@ class ParamSpecTests(BaseTestCase):
 
     def test_pickle(self):
         global P, P_co, P_contra
+        P = ParamSpec('P')
+        P_co = ParamSpec('P_co', covariant=True)
+        P_contra = ParamSpec('P_contra', contravariant=True)
         for proto in range(pickle.HIGHEST_PROTOCOL):
             with self.subTest('Pickle protocol {proto}'.format(proto=proto)):
                 for paramspec in (P, P_co, P_contra):
@@ -1953,6 +1955,7 @@ class ConcatenateTests(BaseTestCase):
             C4 = collections.abc.Callable[Concatenate[int, T, P], T]
 
     def test_basic_introspection(self):
+        P = ParamSpec('P')
         C1 = Concatenate[int, P]
         C2 = Concatenate[int, T, P]
         self.assertEqual(C1.__origin__, Concatenate)

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -1881,6 +1881,8 @@ class ParamSpecTests(BaseTestCase):
         P = ParamSpec('P')
         self.assertEqual(P, P)
         self.assertIsInstance(P, ParamSpec)
+        # Should be hashable
+        hash(P)
 
     def test_repr(self):
         P = ParamSpec('P')

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -2252,6 +2252,12 @@ else:
                 prefix = '~'
             return prefix + self.__name__
 
+        def __hash__(self):
+            return hash((self.__name__,
+                         self.__covariant__,
+                         self.__contravariant__,
+                         self.__bound__))
+
         def __reduce__(self):
             return self.__name__
 

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -2224,8 +2224,23 @@ else:
         args = object()
         kwargs = object()
 
-        def __init__(self, *args, **kwargs):
-            pass
+        def __init__(self, name, *, bound=None, covariant=False, contravariant=False):
+            self.__name__ = name
+            self.__covariant__ = bool(covariant)
+            self.__contravariant__ = bool(contravariant)
+            if bound:
+                self.__bound__ = typing._type_check(bound, "Bound must be a type.")
+            else:
+                self.__bound__ = None
+
+        def __repr__(self):
+            if self.__covariant__:
+                prefix = '+'
+            elif self.__contravariant__:
+                prefix = '-'
+            else:
+                prefix = '~'
+            return prefix + self.__name__
 
 
 # Inherits from list as a workaround for Callable checks in Python < 3.9.2.

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -2233,7 +2233,7 @@ class _ConcatenateGenericAlias(list):
     def __init__(self, *args, **kwargs):
         pass
 
-
+@_tp_cache
 def _concatenate_getitem(self, parameters):
     if parameters == ():
         raise TypeError("Cannot take a Concatenate of no types.")

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -2226,6 +2226,7 @@ else:
         kwargs = object()
 
         def __init__(self, name, *, bound=None, covariant=False, contravariant=False):
+            super().__init__([self])
             self.__name__ = name
             self.__covariant__ = bool(covariant)
             self.__contravariant__ = bool(contravariant)
@@ -2267,6 +2268,7 @@ else:
 # Inherits from list as a workaround for Callable checks in Python < 3.9.2.
 class _ConcatenateGenericAlias(list):
     def __init__(self, origin, args):
+        super().__init___(args)
         self.__origin__ = origin
         self.__args__ = args
 

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -115,7 +115,9 @@ else:
 __all__ = [
     # Super-special typing primitives.
     'ClassVar',
+    'Concatenate',
     'Final',
+    'ParamSpec',
     'Type',
 
     # ABCs (from collections.abc).
@@ -146,6 +148,7 @@ __all__ = [
     'NewType',
     'overload',
     'Text',
+    'TypeAlias',
     'TYPE_CHECKING',
 ]
 
@@ -2164,5 +2167,183 @@ else:
             Predicate: TypeAlias = Callable[..., bool]
 
         It's invalid when used anywhere except as in the example above.
+        """
+        __slots__ = ()
+
+
+# Python 3.10+ has PEP 612
+if hasattr(typing, 'ParamSpec'):
+    ParamSpec = typing.ParamSpec
+else:
+    # Inherits from list as a workaround for Callable checks in Python < 3.9.2.
+    class ParamSpec(list):
+        """Parameter specification variable.
+
+        Usage::
+
+           P = ParamSpec('P')
+
+        Parameter specification variables exist primarily for the benefit of static
+        type checkers.  They are used to forward the parameter types of one
+        callable to another callable, a pattern commonly found in higher order
+        functions and decorators.  They are only valid when used in ``Concatenate``,
+        or s the first argument to ``Callable``, or as parameters for user-defined
+        Generics.  See class Generic for more information on generic types.  An
+        example for annotating a decorator::
+
+           T = TypeVar('T')
+           P = ParamSpec('P')
+
+           def add_logging(f: Callable[P, T]) -> Callable[P, T]:
+               '''A type-safe decorator to add logging to a function.'''
+               def inner(*args: P.args, **kwargs: P.kwargs) -> T:
+                   logging.info(f'{f.__name__} was called')
+                   return f(*args, **kwargs)
+               return inner
+
+           @add_logging
+           def add_two(x: float, y: float) -> float:
+               '''Add two numbers together.'''
+               return x + y
+
+        Parameter specification variables defined with covariant=True or
+        contravariant=True can be used to declare covariant or contravariant
+        generic types.  These keyword arguments are valid, but their actual semantics
+        are yet to be decided.  See PEP 612 for details.
+
+        Parameter specification variables can be introspected. e.g.:
+
+           P.__name__ == 'T'
+           P.__bound__ == None
+           P.__covariant__ == False
+           P.__contravariant__ == False
+
+        Note that only parameter specification variables defined in global scope can
+        be pickled.
+        """
+        args = object()
+        kwargs = object()
+
+        def __init__(self, *args, **kwargs):
+            pass
+
+
+# Inherits from list as a workaround for Callable checks in Python < 3.9.2.
+class _ConcatenateGenericAlias(list):
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+def _concatenate_getitem(self, parameters):
+    if parameters == ():
+        raise TypeError("Cannot take a Concatenate of no types.")
+    if not isinstance(parameters, tuple):
+        parameters = (parameters,)
+    if not isinstance(parameters[-1], ParamSpec):
+        raise TypeError("The last parameter to Concatenate should be a "
+                        "ParamSpec variable.")
+    return _ConcatenateGenericAlias(self, parameters)
+
+
+if hasattr(typing, 'Concatenate'):
+    Concatenate = typing.Concatenate
+    _ConcatenateGenericAlias = typing._ConcatenateGenericAlias # noqa
+elif sys.version_info[:2] >= (3, 9):
+    @_TypeAliasForm
+    def Concatenate(self, parameters):
+        """Used in conjunction with ``ParamSpec`` and ``Callable`` to represent a
+        higher order function which adds, removes or transforms parameters of a
+        callable.
+
+        For example::
+
+           Callable[Concatenate[int, P], int]
+
+        See PEP 612 for detailed information.
+        """
+        return _concatenate_getitem(self, parameters)
+
+elif sys.version_info[:2] >= (3, 7):
+    class _ConcatenateForm(typing._SpecialForm, _root=True):
+        def __repr__(self):
+            return 'typing_extensions.' + self._name
+
+        def __getitem__(self, parameters):
+            return _concatenate_getitem(self, parameters)
+
+    Concatenate = _ConcatenateForm('Concatenate',
+        doc="""Used in conjunction with ``ParamSpec`` and ``Callable`` to represent a
+        higher order function which adds, removes or transforms parameters of a
+        callable.
+
+        For example::
+
+           Callable[Concatenate[int, P], int]
+
+        See PEP 612 for detailed information.
+        """)
+
+elif hasattr(typing, '_FinalTypingBase'):
+    class _ConcatenateAliasMeta(typing.TypingMeta):
+        """Metaclass for Concatenate."""
+
+        def __repr__(self):
+            return 'typing_extensions.Concatenate'
+
+    class _ConcatenateAliasBase(typing._FinalTypingBase,
+                                metaclass=_ConcatenateAliasMeta,
+                                _root=True):
+        """Used in conjunction with ``ParamSpec`` and ``Callable`` to represent a
+        higher order function which adds, removes or transforms parameters of a
+        callable.
+
+        For example::
+
+           Callable[Concatenate[int, P], int]
+
+        See PEP 612 for detailed information.
+        """
+        __slots__ = ()
+
+        def __instancecheck__(self, obj):
+            raise TypeError("Concatenate cannot be used with isinstance().")
+
+        def __subclasscheck__(self, cls):
+            raise TypeError("Concatenate cannot be used with issubclass().")
+
+        def __repr__(self):
+            return 'typing_extensions.Concatenate'
+
+        def __getitem__(self, parameters):
+            return _concatenate_getitem(self, parameters)
+
+    Concatenate = _ConcatenateAliasBase(_root=True)
+
+else:
+    class _ConcatenateAliasMeta(typing.TypingMeta):
+        """Metaclass for Concatenate."""
+
+        def __instancecheck__(self, obj):
+            raise TypeError("TypeAlias cannot be used with isinstance().")
+
+        def __subclasscheck__(self, cls):
+            raise TypeError("TypeAlias cannot be used with issubclass().")
+
+        def __call__(self, *args, **kwargs):
+            raise TypeError("Cannot instantiate TypeAlias")
+
+        def __getitem__(self, parameters):
+            return _concatenate_getitem(self, parameters)
+
+    class Concatenate(metaclass=_ConcatenateAliasMeta, _root=True):
+        """Used in conjunction with ``ParamSpec`` and ``Callable`` to represent a
+        higher order function which adds, removes or transforms parameters of a
+        callable.
+
+        For example::
+
+           Callable[Concatenate[int, P], int]
+
+        See PEP 612 for detailed information.
         """
         __slots__ = ()

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -2268,7 +2268,7 @@ else:
 # Inherits from list as a workaround for Callable checks in Python < 3.9.2.
 class _ConcatenateGenericAlias(list):
     def __init__(self, origin, args):
-        super().__init___(args)
+        super().__init__(args)
         self.__origin__ = origin
         self.__args__ = args
 

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -2253,10 +2253,10 @@ else:
             return prefix + self.__name__
 
         def __hash__(self):
-            return hash((self.__name__,
-                         self.__covariant__,
-                         self.__contravariant__,
-                         self.__bound__))
+            return object.__hash__(self)
+
+        def __eq__(self, other):
+            return self is other
 
         def __reduce__(self):
             return self.__name__
@@ -2283,6 +2283,8 @@ class _ConcatenateGenericAlias(list):
         return '{origin}[{args}]' \
                .format(origin=_type_repr(self.__origin__),
                        args=', '.join(_type_repr(arg) for arg in self.__args__))
+    def __hash__(self):
+        return hash((self.__origin__, self.__args__))
 
 @_tp_cache
 def _concatenate_getitem(self, parameters):

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -2363,7 +2363,7 @@ elif hasattr(typing, '_FinalTypingBase'):
             return _concatenate_getitem(self, parameters)
 
     Concatenate = _ConcatenateAliasBase(_root=True)
-
+# For 3.5.0 - 3.5.2
 else:
     class _ConcatenateAliasMeta(typing.TypingMeta):
         """Metaclass for Concatenate."""

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -2233,6 +2233,14 @@ else:
             else:
                 self.__bound__ = None
 
+            # for pickling:
+            try:
+                def_mod = sys._getframe(1).f_globals.get('__name__', '__main__')
+            except (AttributeError, ValueError):
+                def_mod = None
+            if def_mod != 'typing_extensions':
+                self.__module__ = def_mod
+
         def __repr__(self):
             if self.__covariant__:
                 prefix = '+'
@@ -2242,6 +2250,8 @@ else:
                 prefix = '~'
             return prefix + self.__name__
 
+        def __reduce__(self):
+            return self.__name__
 
 # Inherits from list as a workaround for Callable checks in Python < 3.9.2.
 class _ConcatenateGenericAlias(list):

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -2283,6 +2283,7 @@ class _ConcatenateGenericAlias(list):
         return '{origin}[{args}]' \
                .format(origin=_type_repr(self.__origin__),
                        args=', '.join(_type_repr(arg) for arg in self.__args__))
+
     def __hash__(self):
         return hash((self.__origin__, self.__args__))
 


### PR DESCRIPTION
Runtime correctness is zero due to wacky list workarounds.  Unfortunately, I'm not enough of an MRO/metaclass wizard to know how to trick ``isinstance(arg, list)`` in ``Callable`` while still returning a ``typing._GenericAlias``.

The first patch is for Python3. I'm mildly reluctant to write one for Python2 since it's EOL-ed for a year already, but we'll see ;).