### PR TITLE
Fixed required/optional keys with old-style TypedDict

### DIFF
--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -1586,11 +1586,15 @@ class TypedDictTests(BaseTestCase):
         self.assertEqual(D(), {})
         self.assertEqual(D(x=1), {'x': 1})
         self.assertEqual(D.__total__, False)
+        self.assertEqual(D.__required_keys__, frozenset())
+        self.assertEqual(D.__optional_keys__, {'x'})
 
         if PY36:
             self.assertEqual(Options(), {})
             self.assertEqual(Options(log_level=2), {'log_level': 2})
             self.assertEqual(Options.__total__, False)
+            self.assertEqual(Options.__required_keys__, frozenset())
+            self.assertEqual(Options.__optional_keys__, {'log_level', 'log_path'})
 
     @skipUnless(PY36, 'Python 3.6 required')
     def test_optional_keys(self):

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -1530,7 +1530,7 @@ class TypedDictTests(BaseTestCase):
 
     def test_typeddict_errors(self):
         Emp = TypedDict('Emp', {'name': str, 'id': int})
-        if sys.version_info[:2] >= (3, 9):
+        if sys.version_info >= (3, 9, 2):
             self.assertEqual(TypedDict.__module__, 'typing')
         else:
             self.assertEqual(TypedDict.__module__, 'typing_extensions')

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -1692,6 +1692,11 @@ else:
                                          ' /, *, total=True, **kwargs)')
 
     class _TypedDictMeta(type):
+        def __init__(cls, name, bases, ns, total=True):
+            # In Python 3.4 and 3.5 the __init__ method also needs to support the keyword arguments.
+            # See https://www.python.org/dev/peps/pep-0487/#implementation-details
+            super(_TypedDictMeta, cls).__init__(name, bases, ns)
+
         def __new__(cls, name, bases, ns, total=True):
             # Create new typed dict class object.
             # This method is called directly when TypedDict is subclassed,

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -1618,9 +1618,11 @@ elif HAVE_PROTOCOLS:
             pass
 
 
-if sys.version_info[:2] >= (3, 9):
+if sys.version_info >= (3, 9, 2):
     # The standard library TypedDict in Python 3.8 does not store runtime information
     # about which (if any) keys are optional.  See https://bugs.python.org/issue38834
+    # The standard library TypedDict in Python 3.9.0/1 does not honour the "total"
+    # keyword with old-style TypedDict().  See https://bugs.python.org/issue42059
     TypedDict = typing.TypedDict
 else:
     def _check_fails(cls, other):

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -1677,14 +1677,14 @@ else:
             raise TypeError("TypedDict takes either a dict or keyword arguments,"
                             " but not both")
 
-        ns = {'__annotations__': dict(fields), '__total__': total}
+        ns = {'__annotations__': dict(fields)}
         try:
             # Setting correct module is necessary to make typed dict classes pickleable.
             ns['__module__'] = sys._getframe(1).f_globals.get('__name__', '__main__')
         except (AttributeError, ValueError):
             pass
 
-        return _TypedDictMeta(typename, (), ns)
+        return _TypedDictMeta(typename, (), ns, total=total)
 
     _typeddict_new.__text_signature__ = ('($cls, _typename, _fields=None,'
                                          ' /, *, total=True, **kwargs)')


### PR DESCRIPTION
Fixes #761 

Copied from https://github.com/python/cpython/pull/22736

Co-authored-by: Alex Grönholm <alex.gronholm@nextday.fi>