### PR TITLE
Fix protocol’s __init__ behaviour to be same like in python >= 3.8

### DIFF
--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -1423,6 +1423,15 @@ if HAVE_PROTOCOLS:
             self.assertIsSubclass(B, Custom)
             self.assertNotIsSubclass(A, Custom)
 
+        def test_no_init_same_for_different_protocol_implementations(self):
+            class CustomProtocolWithoutInitA(Protocol):
+                pass
+
+            class CustomProtocolWithoutInitB(Protocol):
+                pass
+
+            self.assertEqual(CustomProtocolWithoutInitA.__init__, CustomProtocolWithoutInitB.__init__)
+
 
 class TypedDictTests(BaseTestCase):
 

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -1119,6 +1119,11 @@ def _is_callable_members_only(cls):
 if hasattr(typing, 'Protocol'):
     Protocol = typing.Protocol
 elif HAVE_PROTOCOLS and not PEP_560:
+
+    def _no_init(self, *args, **kwargs):
+        if type(self)._is_protocol:
+            raise TypeError('Protocols cannot be instantiated')
+
     class _ProtocolMeta(GenericMeta):
         """Internal metaclass for Protocol.
 
@@ -1209,9 +1214,6 @@ elif HAVE_PROTOCOLS and not PEP_560:
                         raise TypeError('Protocols can only inherit from other'
                                         ' protocols, got %r' % base)
 
-                def _no_init(self, *args, **kwargs):
-                    if type(self)._is_protocol:
-                        raise TypeError('Protocols cannot be instantiated')
                 cls.__init__ = _no_init
 
             def _proto_hook(other):
@@ -1365,6 +1367,10 @@ elif HAVE_PROTOCOLS and not PEP_560:
 
 elif PEP_560:
     from typing import _type_check, _GenericAlias, _collect_type_vars  # noqa
+
+    def _no_init(self, *args, **kwargs):
+        if type(self)._is_protocol:
+            raise TypeError('Protocols cannot be instantiated')
 
     class _ProtocolMeta(abc.ABCMeta):
         # This metaclass is a bit unfortunate and exists only because of the lack
@@ -1542,10 +1548,6 @@ elif PEP_560:
                         isinstance(base, _ProtocolMeta) and base._is_protocol):
                     raise TypeError('Protocols can only inherit from other'
                                     ' protocols, got %r' % base)
-
-            def _no_init(self, *args, **kwargs):
-                if type(self)._is_protocol:
-                    raise TypeError('Protocols cannot be instantiated')
             cls.__init__ = _no_init
 
 


### PR DESCRIPTION
Hello everyone, I am author of a dependency injection container for python: https://pypi.org/project/kink/. Lately we run into some issues with older versions of python were we do use `typing_extensions` as a pollyfill for missing functionalities.

In python >= 3.8 `_no_init` function which is responsible for disabling Protocol's initialisation is defined in the global scope of a module, which allows us to do checks like here: https://github.com/kodemore/kink/blob/master/kink/inject.py#L75. Sadly in `typing_extensions` this function is defined as a local function so when doing the check memory address does not match and comparison fails. This is inconsistent with python >= 3.8 implementation and this PR fixes this inconsistency.

I have also prepared test to cover the use-case.