### PR TITLE
Add OrderedDict to typing_extensions

### DIFF
--- a/typing_extensions/README.rst
+++ b/typing_extensions/README.rst
@@ -44,6 +44,7 @@ All Python versions:
 - ``NewType``
 - ``NoReturn``
 - ``overload`` (note that older versions of ``typing`` only let you use ``overload`` in stubs)
+- ``OrderedDict``
 - ``Protocol`` (except on Python 3.5.0)
 - ``runtime`` (except on Python 3.5.0)
 - ``Text``

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -610,6 +610,30 @@ class CollectionsAbcTests(BaseTestCase):
         if TYPING_3_5_3:
             self.assertNotIsSubclass(collections.defaultdict, MyDefDict)
 
+    @skipUnless(CAN_INSTANTIATE_COLLECTIONS, "Behavior added in typing 3.6.1")
+    def test_ordereddict_instantiation(self):
+        self.assertIs(
+            type(typing_extensions.OrderedDict()),
+            collections.OrderedDict)
+        self.assertIs(
+            type(typing_extensions.OrderedDict[KT, VT]()),
+            collections.OrderedDict)
+        self.assertIs(
+            type(typing_extensions.OrderedDict[str, int]()),
+            collections.OrderedDict)
+
+    def test_ordereddict_subclass(self):
+
+        class MyOrdDict(typing_extensions.OrderedDict[str, int]):
+            pass
+
+        od = MyOrdDict()
+        self.assertIsInstance(od, MyOrdDict)
+
+        self.assertIsSubclass(MyOrdDict, collections.OrderedDict)
+        if TYPING_3_5_3:
+            self.assertNotIsSubclass(collections.OrderedDict, MyOrdDict)
+
     def test_chainmap_instantiation(self):
         self.assertIs(type(typing_extensions.ChainMap()), collections.ChainMap)
         self.assertIs(type(typing_extensions.ChainMap[KT, VT]()), collections.ChainMap)

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -134,6 +134,7 @@ __all__ = [
     'Counter',
     'Deque',
     'DefaultDict',
+    'OrderedDict'
     'TypedDict',
 
     # Structural checks, a.k.a. protocols.
@@ -936,6 +937,32 @@ else:
             if cls._gorg is DefaultDict:
                 return collections.defaultdict(*args, **kwds)
             return _generic_new(collections.defaultdict, cls, *args, **kwds)
+
+
+if hasattr(typing, 'OrderedDict'):
+    OrderedDict = typing.OrderedDict
+elif _geqv_defined:
+    class OrderedDict(collections.OrderedDict, typing.MutableMapping[KT, VT],
+                      metaclass=_ExtensionsGenericMeta,
+                      extra=collections.OrderedDict):
+
+        __slots__ = ()
+
+        def __new__(cls, *args, **kwds):
+            if _geqv(cls, OrderedDict):
+                return collections.OrderedDict(*args, **kwds)
+            return _generic_new(collections.OrderedDict, cls, *args, **kwds)
+else:
+    class OrderedDict(collections.OrderedDict, typing.MutableMapping[KT, VT],
+                      metaclass=_ExtensionsGenericMeta,
+                      extra=collections.OrderedDict):
+
+        __slots__ = ()
+
+        def __new__(cls, *args, **kwds):
+            if cls._gorg is OrderedDict:
+                return collections.OrderedDict(*args, **kwds)
+            return _generic_new(collections.OrderedDict, cls, *args, **kwds)
 
 
 if hasattr(typing, 'Counter'):

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -941,6 +941,8 @@ else:
 
 if hasattr(typing, 'OrderedDict'):
     OrderedDict = typing.OrderedDict
+elif (3, 7, 0) <= sys.version_info[:3] < (3, 7, 2):
+    OrderedDict = typing._alias(collections.OrderedDict, (KT, VT))
 elif _geqv_defined:
     class OrderedDict(collections.OrderedDict, typing.MutableMapping[KT, VT],
                       metaclass=_ExtensionsGenericMeta,


### PR DESCRIPTION
This PR adds OrderedDict to the typing_extensions module for Python 3 since it is not available in Python < 3.7.2