### PR TITLE
backport ParamSpecArgs/Kwargs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Workflow
 Workflow for PyPI releases
 --------------------------
 
-* Run tests under all supported versions. As of May 2019 this includes
-  2.7, 3.4, 3.5, 3.6, 3.7.
+* Run tests under all supported versions. As of April 2021 this includes
+  2.7, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9.
 
 * On macOS, you can use `pyenv <https://github.com/pyenv/pyenv>`_ to
   manage multiple Python installations. Long story short:

--- a/typing_extensions/README.rst
+++ b/typing_extensions/README.rst
@@ -57,6 +57,10 @@ Python 3.4+ only:
 -----------------
 
 - ``ChainMap``
+- ``ParamSpec``
+- ``Concatenate``
+- ``ParamSpecArgs``
+- ``ParamSpecKwargs``
 
 Python 3.5+ only:
 -----------------

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -576,13 +576,14 @@ class GetUtilitiesTestCase(TestCase):
         if sys.version_info >= (3, 9):
             self.assertEqual(get_args(list[int]), (int,))
         self.assertEqual(get_args(list), ())
-        # Support Python versions with and without the fix for
-        # https://bugs.python.org/issue42195
-        self.assertIn(get_args(collections.abc.Callable[[int], str]),
-                      (([int], str), ([[int]], str)))
-        self.assertEqual(get_args(collections.abc.Callable[..., str]), (..., str))
-        self.assertIn(get_args(collections.abc.Callable[[], str]),
-                      (([], str), ([[]], str)))
+        if sys.version_info >= (3, 9):
+            # Support Python versions with and without the fix for
+            # https://bugs.python.org/issue42195
+            self.assertIn(get_args(collections.abc.Callable[[int], str]),
+                          (([int], str), ([[int]], str)))
+            self.assertEqual(get_args(collections.abc.Callable[..., str]), (..., str))
+            self.assertIn(get_args(collections.abc.Callable[[], str]),
+                          (([], str), ([[]], str)))
         P = ParamSpec('P')
         self.assertIn(get_args(Callable[P, int]), [(P, int), ([P], int)])
         self.assertEqual(get_args(Callable[Concatenate[int, P], int]),

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -541,7 +541,8 @@ class GetUtilitiesTestCase(TestCase):
         self.assertIs(get_origin(List), list)
         self.assertIs(get_origin(Tuple), tuple)
         self.assertIs(get_origin(Callable), collections.abc.Callable)
-        self.assertIs(get_origin(list[int]), list)
+        if sys.version_info >= (3, 9):
+            self.assertIs(get_origin(list[int]), list)
         self.assertIs(get_origin(list), None)
         self.assertIs(get_origin(P.args), P)
         self.assertIs(get_origin(P.kwargs), P)
@@ -572,7 +573,8 @@ class GetUtilitiesTestCase(TestCase):
         self.assertEqual(get_args(List), ())
         self.assertEqual(get_args(Tuple), ())
         self.assertEqual(get_args(Callable), ())
-        self.assertEqual(get_args(list[int]), (int,))
+        if sys.version_info >= (3, 9):
+            self.assertEqual(get_args(list[int]), (int,))
         self.assertEqual(get_args(list), ())
         # Support Python versions with and without the fix for
         # https://bugs.python.org/issue42195

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -14,7 +14,6 @@ from typing import Generic
 from typing import no_type_check
 from typing_extensions import NoReturn, ClassVar, Final, IntVar, Literal, Type, NewType, TypedDict
 from typing_extensions import TypeAlias, ParamSpec, Concatenate, ParamSpecArgs, ParamSpecKwargs
-from typing_extensions import get_origin, get_args
 
 try:
     from typing_extensions import Protocol, runtime, runtime_checkable
@@ -523,6 +522,8 @@ class GetTypeHintTests(BaseTestCase):
 @skipUnless(PEP_560, "Python 3.7+ required")
 class GetUtilitiesTestCase(TestCase):
     def test_get_origin(self):
+        from typing_extensions import get_origin
+
         T = TypeVar('T')
         P = ParamSpec('P')
         class C(Generic[T]): pass
@@ -546,6 +547,8 @@ class GetUtilitiesTestCase(TestCase):
         self.assertIs(get_origin(P.kwargs), P)
 
     def test_get_args(self):
+        from typing_extensions import get_args
+
         T = TypeVar('T')
         class C(Generic[T]): pass
         self.assertEqual(get_args(C[int]), (int,))
@@ -574,10 +577,10 @@ class GetUtilitiesTestCase(TestCase):
         # Support Python versions with and without the fix for
         # https://bugs.python.org/issue42195
         self.assertIn(get_args(collections.abc.Callable[[int], str]),
-                      (([int], str), (int, str)))
+                      (([int], str), ([[int]], str)))
         self.assertEqual(get_args(collections.abc.Callable[..., str]), (..., str))
         self.assertIn(get_args(collections.abc.Callable[[], str]),
-                      (([], str), (str,)))
+                      (([], str), ([[]], str)))
         P = ParamSpec('P')
         self.assertIn(get_args(Callable[P, int]), [(P, int), ([P], int)])
         self.assertEqual(get_args(Callable[Concatenate[int, P], int]),

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -571,11 +571,13 @@ class GetUtilitiesTestCase(TestCase):
         self.assertEqual(get_args(Callable), ())
         self.assertEqual(get_args(list[int]), (int,))
         self.assertEqual(get_args(list), ())
-        self.assertEqual(get_args(collections.abc.Callable[[int], str]), ([int], str))
+        # Support Python versions with and without the fix for
+        # https://bugs.python.org/issue42195
+        self.assertIn(get_args(collections.abc.Callable[[int], str]),
+                      (([int], str), (int, str)))
         self.assertEqual(get_args(collections.abc.Callable[..., str]), (..., str))
-        self.assertEqual(get_args(collections.abc.Callable[[], str]), ([], str))
-        self.assertEqual(get_args(collections.abc.Callable[[int], str]),
-                         get_args(Callable[[int], str]))
+        self.assertIn(get_args(collections.abc.Callable[[], str]),
+                      (([], str), (str,)))
         P = ParamSpec('P')
         self.assertIn(get_args(Callable[P, int]), [(P, int), ([P], int)])
         self.assertEqual(get_args(Callable[Concatenate[int, P], int]),

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -7,13 +7,14 @@ import pickle
 import subprocess
 import types
 from unittest import TestCase, main, skipUnless, skipIf
-from typing import TypeVar, Optional
+from typing import TypeVar, Optional, Union
 from typing import T, KT, VT  # Not in __all__.
-from typing import Tuple, List, Dict, Iterator
+from typing import Tuple, List, Dict, Iterator, Callable
 from typing import Generic
 from typing import no_type_check
 from typing_extensions import NoReturn, ClassVar, Final, IntVar, Literal, Type, NewType, TypedDict
-from typing_extensions import TypeAlias, ParamSpec, Concatenate
+from typing_extensions import TypeAlias, ParamSpec, Concatenate, ParamSpecArgs, ParamSpecKwargs
+from typing_extensions import get_origin, get_args
 
 try:
     from typing_extensions import Protocol, runtime, runtime_checkable
@@ -517,6 +518,68 @@ class GetTypeHintTests(BaseTestCase):
         self.assertEqual(gth(Loop, globals())['attr'], Final[Loop])
         self.assertNotEqual(gth(Loop, globals())['attr'], Final[int])
         self.assertNotEqual(gth(Loop, globals())['attr'], Final)
+
+
+@skipUnless(PEP_560, "Python 3.7+ required")
+class GetUtilitiesTestCase(TestCase):
+    def test_get_origin(self):
+        T = TypeVar('T')
+        P = ParamSpec('P')
+        class C(Generic[T]): pass
+        self.assertIs(get_origin(C[int]), C)
+        self.assertIs(get_origin(C[T]), C)
+        self.assertIs(get_origin(int), None)
+        self.assertIs(get_origin(ClassVar[int]), ClassVar)
+        self.assertIs(get_origin(Union[int, str]), Union)
+        self.assertIs(get_origin(Literal[42, 43]), Literal)
+        self.assertIs(get_origin(Final[List[int]]), Final)
+        self.assertIs(get_origin(Generic), Generic)
+        self.assertIs(get_origin(Generic[T]), Generic)
+        self.assertIs(get_origin(List[Tuple[T, T]][int]), list)
+        self.assertIs(get_origin(Annotated[T, 'thing']), Annotated)
+        self.assertIs(get_origin(List), list)
+        self.assertIs(get_origin(Tuple), tuple)
+        self.assertIs(get_origin(Callable), collections.abc.Callable)
+        self.assertIs(get_origin(list[int]), list)
+        self.assertIs(get_origin(list), None)
+        self.assertIs(get_origin(P.args), P)
+        self.assertIs(get_origin(P.kwargs), P)
+
+    def test_get_args(self):
+        T = TypeVar('T')
+        class C(Generic[T]): pass
+        self.assertEqual(get_args(C[int]), (int,))
+        self.assertEqual(get_args(C[T]), (T,))
+        self.assertEqual(get_args(int), ())
+        self.assertEqual(get_args(ClassVar[int]), (int,))
+        self.assertEqual(get_args(Union[int, str]), (int, str))
+        self.assertEqual(get_args(Literal[42, 43]), (42, 43))
+        self.assertEqual(get_args(Final[List[int]]), (List[int],))
+        self.assertEqual(get_args(Union[int, Tuple[T, int]][str]),
+                         (int, Tuple[str, int]))
+        self.assertEqual(get_args(typing.Dict[int, Tuple[T, T]][Optional[int]]),
+                         (int, Tuple[Optional[int], Optional[int]]))
+        self.assertEqual(get_args(Callable[[], T][int]), ([], int))
+        self.assertEqual(get_args(Callable[..., int]), (..., int))
+        self.assertEqual(get_args(Union[int, Callable[[Tuple[T, ...]], str]]),
+                         (int, Callable[[Tuple[T, ...]], str]))
+        self.assertEqual(get_args(Tuple[int, ...]), (int, ...))
+        self.assertEqual(get_args(Tuple[()]), ((),))
+        self.assertEqual(get_args(Annotated[T, 'one', 2, ['three']]), (T, 'one', 2, ['three']))
+        self.assertEqual(get_args(List), ())
+        self.assertEqual(get_args(Tuple), ())
+        self.assertEqual(get_args(Callable), ())
+        self.assertEqual(get_args(list[int]), (int,))
+        self.assertEqual(get_args(list), ())
+        self.assertEqual(get_args(collections.abc.Callable[[int], str]), ([int], str))
+        self.assertEqual(get_args(collections.abc.Callable[..., str]), (..., str))
+        self.assertEqual(get_args(collections.abc.Callable[[], str]), ([], str))
+        self.assertEqual(get_args(collections.abc.Callable[[int], str]),
+                         get_args(Callable[[int], str]))
+        P = ParamSpec('P')
+        self.assertIn(get_args(Callable[P, int]), [(P, int), ([P], int)])
+        self.assertEqual(get_args(Callable[Concatenate[int, P], int]),
+                         (Concatenate[int, P], int))
 
 
 class CollectionsAbcTests(BaseTestCase):
@@ -1948,8 +2011,17 @@ class ParamSpecTests(BaseTestCase):
         # ParamSpec instances should also have args and kwargs attributes.
         self.assertIn('args', dir(P))
         self.assertIn('kwargs', dir(P))
-        P.args
-        P.kwargs
+
+    def test_args_kwargs(self):
+        P = ParamSpec('P')
+        self.assertIn('args', dir(P))
+        self.assertIn('kwargs', dir(P))
+        self.assertIsInstance(P.args, ParamSpecArgs)
+        self.assertIsInstance(P.kwargs, ParamSpecKwargs)
+        self.assertIs(P.args.__origin__, P)
+        self.assertIs(P.kwargs.__origin__, P)
+        self.assertEqual(repr(P.args), "P.args")
+        self.assertEqual(repr(P.kwargs), "P.kwargs")
 
     # Note: ParamSpec doesn't work for pre-3.10 user-defined Generics due
     # to type checks inside Generic.
@@ -2068,7 +2140,7 @@ class AllTests(BaseTestCase):
             'Final',
             'get_type_hints'
         }
-        if sys.version_info[:2] == (3, 8):
+        if sys.version_info < (3, 10):
             exclude |= {'get_args', 'get_origin'}
         for item in typing_extensions.__all__:
             if item not in exclude and hasattr(typing, item):

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -579,12 +579,15 @@ class GetUtilitiesTestCase(TestCase):
         if sys.version_info >= (3, 9):
             # Support Python versions with and without the fix for
             # https://bugs.python.org/issue42195
+            # The first variant is for 3.9.2+, the second for 3.9.0 and 1
             self.assertIn(get_args(collections.abc.Callable[[int], str]),
                           (([int], str), ([[int]], str)))
-            self.assertEqual(get_args(collections.abc.Callable[..., str]), (..., str))
             self.assertIn(get_args(collections.abc.Callable[[], str]),
                           (([], str), ([[]], str)))
+            self.assertEqual(get_args(collections.abc.Callable[..., str]), (..., str))
         P = ParamSpec('P')
+        # In 3.9 and lower we use typing_extensions's hacky implementation
+        # of ParamSpec, which gets incorrectly wrapped in a list
         self.assertIn(get_args(Callable[P, int]), [(P, int), ([P], int)])
         self.assertEqual(get_args(Callable[Concatenate[int, P], int]),
                          (Concatenate[int, P], int))

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -2064,12 +2064,17 @@ if sys.version_info[:2] >= (3, 10):
     get_origin = typing.get_origin
     get_args = typing.get_args
 elif PEP_560:
+    from typing import _GenericAlias
     try:
         # 3.9+
         from typing import _BaseGenericAlias
     except ImportError:
-        _BaseGenericAlias = None
-    from typing import _GenericAlias, GenericAlias
+        _BaseGenericAlias = _GenericAlias
+    try:
+        # 3.9+
+        from typing import GenericAlias
+    except ImportError:
+        GenericAlias = _GenericAlias
 
     def get_origin(tp):
         """Get the unsubscripted version of a type.
@@ -2088,10 +2093,8 @@ elif PEP_560:
         """
         if isinstance(tp, _AnnotatedAlias):
             return Annotated
-        if isinstance(tp, (_GenericAlias, GenericAlias,
+        if isinstance(tp, (_GenericAlias, GenericAlias, _BaseGenericAlias
                            ParamSpecArgs, ParamSpecKwargs)):
-            return tp.__origin__
-        if _BaseGenericAlias is not None and isinstance(tp, _BaseGenericAlias):
             return tp.__origin__
         if tp is Generic:
             return Generic
@@ -2253,7 +2256,7 @@ else:
             self.__origin__ = origin
 
         def __repr__(self):
-            return f"{self.__origin__.__name__}.args"
+            return "{}.args".format(self.__origin__.__name__)
 
     class ParamSpecKwargs(_Final, _Immutable, _root=True):
         """The kwargs for a ParamSpec object.
@@ -2271,7 +2274,7 @@ else:
             self.__origin__ = origin
 
         def __repr__(self):
-            return f"{self.__origin__.__name__}.kwargs"
+            return "{}.kwargs".format(self.__origin__.__name__)
 
 if hasattr(typing, 'ParamSpec'):
     ParamSpec = typing.ParamSpec

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -2114,6 +2114,8 @@ elif PEP_560:
         if isinstance(tp, _AnnotatedAlias):
             return (tp.__origin__,) + tp.__metadata__
         if isinstance(tp, (_GenericAlias, GenericAlias)):
+            if getattr(tp, "_special", False):
+                return ()
             res = tp.__args__
             if get_origin(tp) is collections.abc.Callable and res[0] is not Ellipsis:
                 res = (list(res[:-1]), res[-1])
@@ -2221,15 +2223,6 @@ if hasattr(typing, 'ParamSpecArgs'):
     ParamSpecArgs = typing.ParamSpecArgs
     ParamSpecKwargs = typing.ParamSpecKwargs
 else:
-    class _Final:
-        """Mixin to prohibit subclassing"""
-
-        __slots__ = ('__weakref__',)
-
-        def __init_subclass__(self, *args, **kwds):
-            if '_root' not in kwds:
-                raise TypeError("Cannot subclass special typing classes")
-
     class _Immutable:
         """Mixin to indicate that object should not be copied."""
         __slots__ = ()
@@ -2240,7 +2233,7 @@ else:
         def __deepcopy__(self, memo):
             return self
 
-    class ParamSpecArgs(_Final, _Immutable, _root=True):
+    class ParamSpecArgs(_Immutable):
         """The args for a ParamSpec object.
 
         Given a ParamSpec object P, P.args is an instance of ParamSpecArgs.
@@ -2258,7 +2251,7 @@ else:
         def __repr__(self):
             return "{}.args".format(self.__origin__.__name__)
 
-    class ParamSpecKwargs(_Final, _Immutable, _root=True):
+    class ParamSpecKwargs(_Immutable):
         """The kwargs for a ParamSpec object.
 
         Given a ParamSpec object P, P.kwargs is an instance of ParamSpecKwargs.

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -2093,7 +2093,7 @@ elif PEP_560:
         """
         if isinstance(tp, _AnnotatedAlias):
             return Annotated
-        if isinstance(tp, (_GenericAlias, GenericAlias, _BaseGenericAlias
+        if isinstance(tp, (_GenericAlias, GenericAlias, _BaseGenericAlias,
                            ParamSpecArgs, ParamSpecKwargs)):
             return tp.__origin__
         if tp is Generic:


### PR DESCRIPTION
From python/cpython#25298. I also added more tests for get_args/get_origin,
which previously didn't exist in in typing_extensions.