### PR TITLE
Implement TypeGuard (PEP 649)

### DIFF
--- a/typing_extensions/README.rst
+++ b/typing_extensions/README.rst
@@ -46,7 +46,7 @@ All Python versions:
 - ``overload`` (note that older versions of ``typing`` only let you use ``overload`` in stubs)
 - ``OrderedDict``
 - ``Protocol`` (except on Python 3.5.0)
-- ``runtime`` (except on Python 3.5.0)
+- ``runtime_checkable`` (except on Python 3.5.0)
 - ``Text``
 - ``Type``
 - ``TypedDict``
@@ -61,6 +61,7 @@ Python 3.4+ only:
 - ``Concatenate``
 - ``ParamSpecArgs``
 - ``ParamSpecKwargs``
+- ``TypeGuard``
 
 Python 3.5+ only:
 -----------------

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -13,7 +13,7 @@ from typing import Tuple, List, Dict, Iterator, Callable
 from typing import Generic
 from typing import no_type_check
 from typing_extensions import NoReturn, ClassVar, Final, IntVar, Literal, Type, NewType, TypedDict
-from typing_extensions import TypeAlias, ParamSpec, Concatenate, ParamSpecArgs, ParamSpecKwargs
+from typing_extensions import TypeAlias, ParamSpec, Concatenate, ParamSpecArgs, ParamSpecKwargs, TypeGuard
 
 try:
     from typing_extensions import Protocol, runtime, runtime_checkable
@@ -2106,6 +2106,45 @@ class ConcatenateTests(BaseTestCase):
         self.assertEqual(C1, C2)
         self.assertEqual(hash(C1), hash(C2))
         self.assertNotEqual(C1, C3)
+
+
+class TypeGuardTests(BaseTestCase):
+    def test_basics(self):
+        TypeGuard[int]  # OK
+
+        def foo(arg) -> TypeGuard[int]: ...
+        self.assertEqual(gth(foo), {'return': TypeGuard[int]})
+
+    def test_repr(self):
+        self.assertEqual(repr(TypeGuard), 'typing.TypeGuard')
+        cv = TypeGuard[int]
+        self.assertEqual(repr(cv), 'typing.TypeGuard[int]')
+        cv = TypeGuard[Employee]
+        self.assertEqual(repr(cv), 'typing.TypeGuard[%s.Employee]' % __name__)
+        cv = TypeGuard[tuple[int]]
+        self.assertEqual(repr(cv), 'typing.TypeGuard[tuple[int]]')
+
+    def test_cannot_subclass(self):
+        with self.assertRaises(TypeError):
+            class C(type(TypeGuard)):
+                pass
+        with self.assertRaises(TypeError):
+            class C(type(TypeGuard[int])):
+                pass
+
+    def test_cannot_init(self):
+        with self.assertRaises(TypeError):
+            TypeGuard()
+        with self.assertRaises(TypeError):
+            type(TypeGuard)()
+        with self.assertRaises(TypeError):
+            type(TypeGuard[Optional[int]])()
+
+    def test_no_isinstance(self):
+        with self.assertRaises(TypeError):
+            isinstance(1, TypeGuard[int])
+        with self.assertRaises(TypeError):
+            issubclass(int, TypeGuard)
 
 
 class AllTests(BaseTestCase):

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -2124,6 +2124,7 @@ class TypeGuardTests(BaseTestCase):
         cv = TypeGuard[Tuple[int]]
         self.assertEqual(repr(cv), 'typing_extensions.TypeGuard[typing.Tuple[int]]')
 
+    @skipUnless(SUBCLASS_CHECK_FORBIDDEN, "Behavior added in typing 3.5.3")
     def test_cannot_subclass(self):
         with self.assertRaises(TypeError):
             class C(type(TypeGuard)):

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -2111,18 +2111,23 @@ class ConcatenateTests(BaseTestCase):
 class TypeGuardTests(BaseTestCase):
     def test_basics(self):
         TypeGuard[int]  # OK
+        self.assertEqual(TypeGuard[int], TypeGuard[int])
 
         def foo(arg) -> TypeGuard[int]: ...
         self.assertEqual(gth(foo), {'return': TypeGuard[int]})
 
     def test_repr(self):
-        self.assertEqual(repr(TypeGuard), 'typing_extensions.TypeGuard')
+        if hasattr(typing, 'TypeGuard'):
+            mod_name = 'typing'
+        else:
+            mod_name = 'typing_extensions'
+        self.assertEqual(repr(TypeGuard), '{}.TypeGuard'.format(mod_name))
         cv = TypeGuard[int]
-        self.assertEqual(repr(cv), 'typing_extensions.TypeGuard[int]')
+        self.assertEqual(repr(cv), '{}.TypeGuard[int]'.format(mod_name))
         cv = TypeGuard[Employee]
-        self.assertEqual(repr(cv), 'typing_extensions.TypeGuard[%s.Employee]' % __name__)
+        self.assertEqual(repr(cv), '{}.TypeGuard[{}.Employee]'.format(mod_name, __name__))
         cv = TypeGuard[Tuple[int]]
-        self.assertEqual(repr(cv), 'typing_extensions.TypeGuard[typing.Tuple[int]]')
+        self.assertEqual(repr(cv), '{}.TypeGuard[typing.Tuple[int]]'.format(mod_name))
 
     @skipUnless(SUBCLASS_CHECK_FORBIDDEN, "Behavior added in typing 3.5.3")
     def test_cannot_subclass(self):

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -2116,13 +2116,13 @@ class TypeGuardTests(BaseTestCase):
         self.assertEqual(gth(foo), {'return': TypeGuard[int]})
 
     def test_repr(self):
-        self.assertEqual(repr(TypeGuard), 'typing.TypeGuard')
+        self.assertEqual(repr(TypeGuard), 'typing_extensions.TypeGuard')
         cv = TypeGuard[int]
-        self.assertEqual(repr(cv), 'typing.TypeGuard[int]')
+        self.assertEqual(repr(cv), 'typing_extensions.TypeGuard[int]')
         cv = TypeGuard[Employee]
-        self.assertEqual(repr(cv), 'typing.TypeGuard[%s.Employee]' % __name__)
-        cv = TypeGuard[tuple[int]]
-        self.assertEqual(repr(cv), 'typing.TypeGuard[tuple[int]]')
+        self.assertEqual(repr(cv), 'typing_extensions.TypeGuard[%s.Employee]' % __name__)
+        cv = TypeGuard[Tuple[int]]
+        self.assertEqual(repr(cv), 'typing_extensions.TypeGuard[typing.Tuple[int]]')
 
     def test_cannot_subclass(self):
         with self.assertRaises(TypeError):

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -2146,6 +2146,7 @@ class TypeGuardTests(BaseTestCase):
         with self.assertRaises(TypeError):
             type(TypeGuard[Optional[int]])()
 
+    @skipUnless(SUBCLASS_CHECK_FORBIDDEN, "Behavior added in typing 3.5.3")
     def test_no_isinstance(self):
         with self.assertRaises(TypeError):
             isinstance(1, TypeGuard[int])

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -2146,7 +2146,6 @@ class TypeGuardTests(BaseTestCase):
         with self.assertRaises(TypeError):
             type(TypeGuard[Optional[int]])()
 
-    @skipUnless(SUBCLASS_CHECK_FORBIDDEN, "Behavior added in typing 3.5.3")
     def test_no_isinstance(self):
         with self.assertRaises(TypeError):
             isinstance(1, TypeGuard[int])

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -2753,7 +2753,7 @@ else:
             return hash((type(self).__name__, self.__type__))
 
         def __eq__(self, other):
-            if not isinstance(other, TypeGuard):
+            if type(other) is not TypeGuard:
                 return NotImplemented
             if self.__type__ is not None:
                 return self.__type__ == other.__type__

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -2717,12 +2717,6 @@ else:
                 self.__type__ = tp
             return self
 
-        def __instancecheck__(self, obj):
-            raise TypeError("TypeGuard cannot be used with isinstance().")
-
-        def __subclasscheck__(self, cls):
-            raise TypeError("TypeGuard cannot be used with issubclass().")
-
         def __getitem__(self, item):
             cls = type(self)
             if self.__type__ is not None:
@@ -2753,7 +2747,7 @@ else:
             return hash((type(self).__name__, self.__type__))
 
         def __eq__(self, other):
-            if type(other) is not TypeGuard:
+            if not isinstance(other, TypeGuard):
                 return NotImplemented
             if self.__type__ is not None:
                 return self.__type__ == other.__type__

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -2567,7 +2567,7 @@ elif sys.version_info[:2] >= (3, 9):
         ``TypeGuard`` also works with type variables.  For more information, see
         PEP 647 (User-Defined Type Guards).
         """
-        item = typing._type_check(parameters, f'{self} accepts only single type.')
+        item = typing._type_check(parameters, '{} accepts only single type.'.format(self))
         return _GenericAlias(self, (item,))
 
 elif sys.version_info[:2] >= (3, 7):

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -2518,6 +2518,58 @@ else:
 
 if hasattr(typing, 'TypeGuard'):
     TypeGuard = typing.TypeGuard
+elif sys.version_info[:2] >= (3, 9):
+    class _TypeGuardForm(typing._SpecialForm, _root=True):
+        def __repr__(self):
+            return 'typing_extensions.' + self._name
+
+    @_TypeGuardForm
+    def TypeGuard(self, parameters):
+        """Special typing form used to annotate the return type of a user-defined
+        type guard function.  ``TypeGuard`` only accepts a single type argument.
+        At runtime, functions marked this way should return a boolean.
+
+        ``TypeGuard`` aims to benefit *type narrowing* -- a technique used by static
+        type checkers to determine a more precise type of an expression within a
+        program's code flow.  Usually type narrowing is done by analyzing
+        conditional code flow and applying the narrowing to a block of code.  The
+        conditional expression here is sometimes referred to as a "type guard".
+
+        Sometimes it would be convenient to use a user-defined boolean function
+        as a type guard.  Such a function should use ``TypeGuard[...]`` as its
+        return type to alert static type checkers to this intention.
+
+        Using  ``-> TypeGuard`` tells the static type checker that for a given
+        function:
+
+        1. The return value is a boolean.
+        2. If the return value is ``True``, the type of its argument
+        is the type inside ``TypeGuard``.
+
+        For example::
+
+            def is_str(val: Union[str, float]):
+                # "isinstance" type guard
+                if isinstance(val, str):
+                    # Type of ``val`` is narrowed to ``str``
+                    ...
+                else:
+                    # Else, type of ``val`` is narrowed to ``float``.
+                    ...
+
+        Strict type narrowing is not enforced -- ``TypeB`` need not be a narrower
+        form of ``TypeA`` (it can even be a wider form) and this may lead to
+        type-unsafe results.  The main reason is to allow for things like
+        narrowing ``List[object]`` to ``List[str]`` even though the latter is not
+        a subtype of the former, since ``List`` is invariant.  The responsibility of
+        writing type-safe type guards is left to the user.
+
+        ``TypeGuard`` also works with type variables.  For more information, see
+        PEP 647 (User-Defined Type Guards).
+        """
+        item = typing._type_check(parameters, f'{self} accepts only single type.')
+        return _GenericAlias(self, (item,))
+
 elif sys.version_info[:2] >= (3, 7):
     class _TypeGuardForm(typing._SpecialForm, _root=True):
 
@@ -2529,11 +2581,93 @@ elif sys.version_info[:2] >= (3, 7):
                                       '{} accepts only a single type'.format(self._name))
             return _GenericAlias(self, (item,))
 
-    TypeGuard = _TypeGuardForm('TypeGuard',
-                       doc="""TODO.""")
+    TypeGuard = _TypeGuardForm(
+            'TypeGuard',
+            doc="""Special typing form used to annotate the return type of a user-defined
+        type guard function.  ``TypeGuard`` only accepts a single type argument.
+        At runtime, functions marked this way should return a boolean.
+
+        ``TypeGuard`` aims to benefit *type narrowing* -- a technique used by static
+        type checkers to determine a more precise type of an expression within a
+        program's code flow.  Usually type narrowing is done by analyzing
+        conditional code flow and applying the narrowing to a block of code.  The
+        conditional expression here is sometimes referred to as a "type guard".
+
+        Sometimes it would be convenient to use a user-defined boolean function
+        as a type guard.  Such a function should use ``TypeGuard[...]`` as its
+        return type to alert static type checkers to this intention.
+
+        Using  ``-> TypeGuard`` tells the static type checker that for a given
+        function:
+
+        1. The return value is a boolean.
+        2. If the return value is ``True``, the type of its argument
+        is the type inside ``TypeGuard``.
+
+        For example::
+
+            def is_str(val: Union[str, float]):
+                # "isinstance" type guard
+                if isinstance(val, str):
+                    # Type of ``val`` is narrowed to ``str``
+                    ...
+                else:
+                    # Else, type of ``val`` is narrowed to ``float``.
+                    ...
+
+        Strict type narrowing is not enforced -- ``TypeB`` need not be a narrower
+        form of ``TypeA`` (it can even be a wider form) and this may lead to
+        type-unsafe results.  The main reason is to allow for things like
+        narrowing ``List[object]`` to ``List[str]`` even though the latter is not
+        a subtype of the former, since ``List`` is invariant.  The responsibility of
+        writing type-safe type guards is left to the user.
+
+        ``TypeGuard`` also works with type variables.  For more information, see
+        PEP 647 (User-Defined Type Guards).
+        """)
 elif hasattr(typing, '_FinalTypingBase'):
     class _TypeGuard(typing._FinalTypingBase, _root=True):
-        """TODO
+        """Special typing form used to annotate the return type of a user-defined
+        type guard function.  ``TypeGuard`` only accepts a single type argument.
+        At runtime, functions marked this way should return a boolean.
+
+        ``TypeGuard`` aims to benefit *type narrowing* -- a technique used by static
+        type checkers to determine a more precise type of an expression within a
+        program's code flow.  Usually type narrowing is done by analyzing
+        conditional code flow and applying the narrowing to a block of code.  The
+        conditional expression here is sometimes referred to as a "type guard".
+
+        Sometimes it would be convenient to use a user-defined boolean function
+        as a type guard.  Such a function should use ``TypeGuard[...]`` as its
+        return type to alert static type checkers to this intention.
+
+        Using  ``-> TypeGuard`` tells the static type checker that for a given
+        function:
+
+        1. The return value is a boolean.
+        2. If the return value is ``True``, the type of its argument
+        is the type inside ``TypeGuard``.
+
+        For example::
+
+            def is_str(val: Union[str, float]):
+                # "isinstance" type guard
+                if isinstance(val, str):
+                    # Type of ``val`` is narrowed to ``str``
+                    ...
+                else:
+                    # Else, type of ``val`` is narrowed to ``float``.
+                    ...
+
+        Strict type narrowing is not enforced -- ``TypeB`` need not be a narrower
+        form of ``TypeA`` (it can even be a wider form) and this may lead to
+        type-unsafe results.  The main reason is to allow for things like
+        narrowing ``List[object]`` to ``List[str]`` even though the latter is not
+        a subtype of the former, since ``List`` is invariant.  The responsibility of
+        writing type-safe type guards is left to the user.
+
+        ``TypeGuard`` also works with type variables.  For more information, see
+        PEP 647 (User-Defined Type Guards).
         """
 
         __slots__ = ('__type__',)
@@ -2626,7 +2760,46 @@ else:
             return self is other
 
     class TypeGuard(typing.Final, metaclass=_TypeGuardMeta, _root=True):
-        """TODO
-        """
+        """Special typing form used to annotate the return type of a user-defined
+        type guard function.  ``TypeGuard`` only accepts a single type argument.
+        At runtime, functions marked this way should return a boolean.
 
+        ``TypeGuard`` aims to benefit *type narrowing* -- a technique used by static
+        type checkers to determine a more precise type of an expression within a
+        program's code flow.  Usually type narrowing is done by analyzing
+        conditional code flow and applying the narrowing to a block of code.  The
+        conditional expression here is sometimes referred to as a "type guard".
+
+        Sometimes it would be convenient to use a user-defined boolean function
+        as a type guard.  Such a function should use ``TypeGuard[...]`` as its
+        return type to alert static type checkers to this intention.
+
+        Using  ``-> TypeGuard`` tells the static type checker that for a given
+        function:
+
+        1. The return value is a boolean.
+        2. If the return value is ``True``, the type of its argument
+        is the type inside ``TypeGuard``.
+
+        For example::
+
+            def is_str(val: Union[str, float]):
+                # "isinstance" type guard
+                if isinstance(val, str):
+                    # Type of ``val`` is narrowed to ``str``
+                    ...
+                else:
+                    # Else, type of ``val`` is narrowed to ``float``.
+                    ...
+
+        Strict type narrowing is not enforced -- ``TypeB`` need not be a narrower
+        form of ``TypeA`` (it can even be a wider form) and this may lead to
+        type-unsafe results.  The main reason is to allow for things like
+        narrowing ``List[object]`` to ``List[str]`` even though the latter is not
+        a subtype of the former, since ``List`` is invariant.  The responsibility of
+        writing type-safe type guards is left to the user.
+
+        ``TypeGuard`` also works with type variables.  For more information, see
+        PEP 647 (User-Defined Type Guards).
+        """
         __type__ = None

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -2717,6 +2717,12 @@ else:
                 self.__type__ = tp
             return self
 
+        def __instancecheck__(self, obj):
+            raise TypeError("TypeGuard cannot be used with isinstance().")
+
+        def __subclasscheck__(self, cls):
+            raise TypeError("TypeGuard cannot be used with issubclass().")
+
         def __getitem__(self, item):
             cls = type(self)
             if self.__type__ is not None:
@@ -2747,7 +2753,7 @@ else:
             return hash((type(self).__name__, self.__type__))
 
         def __eq__(self, other):
-            if not isinstance(other, TypeGuard):
+            if not hasattr(other, "__type__"):
                 return NotImplemented
             if self.__type__ is not None:
                 return self.__type__ == other.__type__


### PR DESCRIPTION
This should be the last missing piece for a 3.10-compatible release.

The implementation was mostly inspired by that of `Final`, with an additional special case for 3.9.