### PR TITLE
Add a missing comma to `__all__`

### DIFF
--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -2191,6 +2191,10 @@ class AllTests(BaseTestCase):
             self.assertIn('Protocol', a)
             self.assertIn('runtime', a)
 
+        # Check that all objects in `__all__` are present in the module
+        for name in a:
+            self.assertTrue(hasattr(typing_extensions, name))
+
     def test_typing_extensions_defers_when_possible(self):
         exclude = {
             'overload',

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -136,7 +136,7 @@ __all__ = [
     'Counter',
     'Deque',
     'DefaultDict',
-    'OrderedDict'
+    'OrderedDict',
     'TypedDict',
 
     # Structural checks, a.k.a. protocols.


### PR DESCRIPTION
A comma is currently missing between `"DefaultDict"` and `"OrderedDict"`, 
thus concatenating both names into the non-existent `"DefaultDictOrderedDict"`.