### PR TITLE
Support most use cases for PEP 612 with Generic

### DIFF
--- a/typing_extensions/README.rst
+++ b/typing_extensions/README.rst
@@ -90,8 +90,8 @@ issues when mixing the differing implementations of modified classes.
 
 Certain types have incorrect runtime behavior due to limitations of older
 versions of the typing module.  For example, ``ParamSpec`` and ``Concatenate``
-will not work with ``get_args``, ``get_origin`` or user-defined ``Generic``\ s
-because they need to be lists to work with older versions of ``Callable``.
+will not work with ``get_args``, ``get_origin``. Certain PEP 612 special cases
+in user-defined ``Generic``\ s are also not available.
 These types are only guaranteed to work for static type checking.
 
 Running tests

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -2052,8 +2052,7 @@ class ParamSpecTests(BaseTestCase):
         P_2 = ParamSpec("P_2")
 
         class X(Generic[T, P]):
-            f: Callable[P, int]
-            x: T
+            pass
 
         G1 = X[int, P_2]
         self.assertEqual(G1.__args__, (int, P_2))
@@ -2072,7 +2071,7 @@ class ParamSpecTests(BaseTestCase):
         # G6 = Z[int, str, bool]
 
         class Z(Generic[P]):
-            f: Callable[P, int]
+            pass
 
     def test_pickle(self):
         global P, P_co, P_contra

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -2012,25 +2012,33 @@ class ParamSpecTests(BaseTestCase):
         P = ParamSpec('P')
         T = TypeVar('T')
         C1 = typing.Callable[P, int]
+        self.assertEqual(C1.__args__, (P, int))
+        self.assertEqual(C1.__parameters__, (P,))
         C2 = typing.Callable[P, T]
+        self.assertEqual(C2.__args__, (P, T))
+        self.assertEqual(C2.__parameters__, (P, T))
 
-        # Note: no tests for Callable.__args__ and Callable.__parameters__ here
-        # because pre-3.10 Callable sees ParamSpec as a plain list, not a
-        # TypeVar.
 
         # Test collections.abc.Callable too.
         if sys.version_info[:2] >= (3, 9):
+            # Note: no tests for Callable.__parameters__ here
+            # because types.GenericAlias Callable is hardcoded to search
+            # for tp_name "TypeVar" in C.  This was changed in 3.10.
             C3 = collections.abc.Callable[P, int]
+            self.assertEqual(C3.__args__, (P, int))
             C4 = collections.abc.Callable[P, T]
+            self.assertEqual(C4.__args__, (P, T))
 
         # ParamSpec instances should also have args and kwargs attributes.
-        self.assertIn('args', dir(P))
-        self.assertIn('kwargs', dir(P))
+        # Note: not in dir(P) because of __class__ hacks
+        self.assertTrue(hasattr(P, 'args'))
+        self.assertTrue(hasattr(P, 'kwargs'))
 
     def test_args_kwargs(self):
         P = ParamSpec('P')
-        self.assertIn('args', dir(P))
-        self.assertIn('kwargs', dir(P))
+        # Note: not in dir(P) because of __class__ hacks
+        self.assertTrue(hasattr(P, 'args'))
+        self.assertTrue(hasattr(P, 'kwargs'))
         self.assertIsInstance(P.args, ParamSpecArgs)
         self.assertIsInstance(P.kwargs, ParamSpecKwargs)
         self.assertIs(P.args.__origin__, P)
@@ -2038,8 +2046,33 @@ class ParamSpecTests(BaseTestCase):
         self.assertEqual(repr(P.args), "P.args")
         self.assertEqual(repr(P.kwargs), "P.kwargs")
 
-    # Note: ParamSpec doesn't work for pre-3.10 user-defined Generics due
-    # to type checks inside Generic.
+    def test_user_generics(self):
+        T = TypeVar("T")
+        P = ParamSpec("P")
+        P_2 = ParamSpec("P_2")
+
+        class X(Generic[T, P]):
+            f: Callable[P, int]
+            x: T
+
+        G1 = X[int, P_2]
+        self.assertEqual(G1.__args__, (int, P_2))
+        self.assertEqual(G1.__parameters__, (P_2,))
+
+        G2 = X[int, Concatenate[int, P_2]]
+        self.assertEqual(G2.__args__, (int, Concatenate[int, P_2]))
+        self.assertEqual(G2.__parameters__, (P_2,))
+
+        # The following are some valid uses cases in PEP 612 that don't work:
+        # These do not work in 3.9, _type_check blocks the list and ellipsis.
+        # G3 = X[int, [int, bool]]
+        # G4 = X[int, ...]
+        # G5 = Z[[int, str, bool]]
+        # Not working because this is special-cased in 3.10.
+        # G6 = Z[int, str, bool]
+
+        class Z(Generic[P]):
+            f: Callable[P, int]
 
     def test_pickle(self):
         global P, P_co, P_contra

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -2012,7 +2012,10 @@ class ParamSpecTests(BaseTestCase):
         P = ParamSpec('P')
         T = TypeVar('T')
         C1 = typing.Callable[P, int]
-        self.assertEqual(C1.__args__, (P, int))
+        # Callable in Python 3.5.2 might be bugged when collecting __args__.
+        # https://github.com/python/cpython/blob/91185fe0284a04162e0b3425b53be49bdbfad67d/Lib/typing.py#L1026
+        if not sys.version_info[:3] == (3, 5, 2):
+            self.assertEqual(C1.__args__, (P, int))
         self.assertEqual(C1.__parameters__, (P,))
         C2 = typing.Callable[P, T]
         self.assertEqual(C2.__args__, (P, T))

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -2014,12 +2014,14 @@ class ParamSpecTests(BaseTestCase):
         C1 = typing.Callable[P, int]
         # Callable in Python 3.5.2 might be bugged when collecting __args__.
         # https://github.com/python/cpython/blob/91185fe0284a04162e0b3425b53be49bdbfad67d/Lib/typing.py#L1026
-        if not sys.version_info[:3] == (3, 5, 2):
+        PY_3_5_2 = sys.version_info[:3] == (3, 5, 2)
+        if not PY_3_5_2:
             self.assertEqual(C1.__args__, (P, int))
-        self.assertEqual(C1.__parameters__, (P,))
+            self.assertEqual(C1.__parameters__, (P,))
         C2 = typing.Callable[P, T]
-        self.assertEqual(C2.__args__, (P, T))
-        self.assertEqual(C2.__parameters__, (P, T))
+        if not PY_3_5_2:
+            self.assertEqual(C2.__args__, (P, T))
+            self.assertEqual(C2.__parameters__, (P, T))
 
 
         # Test collections.abc.Callable too.

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -2393,12 +2393,12 @@ class _ConcatenateGenericAlias(list):
     if PEP_560:
         __class__ = _GenericAlias
     else:
-        __class__ = typing._TypingBase
+        __class__ = typing.TypingMeta
 
     # Flag in 3.8.
     _special = False
-    # Flag in 3.6
-    _gorg = Generic
+    # Attribute in 3.6
+    _gorg = GenericMeta
 
     def __init__(self, origin, args):
         super().__init__(args)

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -2392,13 +2392,18 @@ class _ConcatenateGenericAlias(list):
     # Trick Generic into looking into this for __parameters__.
     if PEP_560:
         __class__ = _GenericAlias
-    else:
+    elif sys.version_info[:3] == (3, 5, 2):
         __class__ = typing.TypingMeta
+    else:
+        __class__ = typing._TypingBase
 
     # Flag in 3.8.
     _special = False
-    # Attribute in 3.6
-    _gorg = GenericMeta
+    # Attribute in 3.6 and earlier.
+    if sys.version_info[:3] == (3, 5, 2):
+        _gorg = typing.GenericMeta
+    else:
+        _gorg = typing.Generic
 
     def __init__(self, origin, args):
         super().__init__(args)

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -2385,7 +2385,13 @@ else:
 class _ConcatenateGenericAlias(list):
 
     # Trick Generic into looking into this for __parameters__.
-    __class__ = _GenericAlias
+    if OLD_GENERICS:
+        __class__ = _GenericAlias
+    else:
+        __class__ = GenericMeta
+
+    # Flag in 3.8.
+    _special = False
 
     def __init__(self, origin, args):
         super().__init__(args)
@@ -2409,6 +2415,10 @@ class _ConcatenateGenericAlias(list):
     def __parameters__(self):
         return tuple(tp for tp in self.__args__ if isinstance(tp, (TypeVar, ParamSpec)))
 
+    # Only needed in 3.6 and lower.
+    def _get_type_vars(self, tvars):
+        if self not in tvars:
+            tvars.append(self)
 
 @_tp_cache
 def _concatenate_getitem(self, parameters):


### PR DESCRIPTION
Support PEP 612 and most user-defined generics use cases. This also brings the PEP 612 test suite to near parity with CPython. Note some limitations in valid use cases below simply because of runtime limitations.

Fixes #816.