### PR TITLE
Add docs/venv to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 MANIFEST
 build/
 dist/
+docs/venv/
 .tox/
 .vscode/
 .idea/


### PR DESCRIPTION
This directory is automatically created by "make -C docs venv".