### PR TITLE
Ignore venv and README when building docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,4 +49,4 @@ html_theme = 'python_docs_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,7 +36,7 @@ templates_path = ['_templates']
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'venv', 'README.rst']
 
 
 # -- Options for HTML output -------------------------------------------------


### PR DESCRIPTION
This suppresses warnings during the docs build if the venv directory
exists.