### PR TITLE
Rework README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,40 @@
 [![Chat at https://gitter.im/python/typing](https://badges.gitter.im/python/typing.svg)](https://gitter.im/python/typing?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-PEP 484: Type Hints
-===================
+Static Typing for Python
+========================
 
-This GitHub repo is used for three separate things:
+Documentation and Support
+-------------------------
 
-- The issue tracker is used to discuss PEP-level type system issues.
-  However,
-  [typing-sig](https://mail.python.org/mailman3/lists/typing-sig.python.org/)
-  is more appropriate these days.
+The documentation for Python's static typing can be found at
+[typing.readthedocs.io](https://typing.readthedocs.io/). You can get
+help either in our [support forum](/python/typing/discussions) or
+chat with us on (Gitter)[https://gitter.im/python/typing].
+
+Improvements to the type system should be discussed on the
+[typing-sig](https://mail.python.org/mailman3/lists/typing-sig.python.org/)
+mailing list, although the [issues](/python/typing/issues) in this
+repository contain some historic discussions.
+
+Repository Content
+------------------
+
+This GitHub repo is used for several things:
 
 - A backport of the `typing` module for older Python versions (2.7 and
-  3.4) is maintained here.  Note that the canonical source lives
+  3.4) is maintained in the [src directory](./src).
+  Note that the canonical source lives
   [upstream](https://github.com/python/cpython/blob/master/Lib/typing.py)
   in the CPython repo.
 
-- The `typing_extensions` module lives here.
+- The `typing_extensions` module lives in the
+  [typing\_extensions](./typing_extensions) directory.
+
+- The documentation at [typing.readthedocs.io](https://typing.readthedocs.io/)
+  is maintained in the [docs directory](./docs).
+
+- A [discussion forum](/python/typing/discussions) for typing-related user
+  help is hosted here.
 
 Workflow
 --------


### PR DESCRIPTION
* Rename to "Static Typing for Python".
* Add "Documentation and Support" section.
* Update what the repository is used for.