### PR TITLE
Fixes crash on Python3.10-beta.2 and typing_extensions@3.10.0.1

### DIFF
--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -2392,7 +2392,7 @@ class _ConcatenateGenericAlias(list):
 
     # Trick Generic into looking into this for __parameters__.
     if PEP_560:
-        __class__ = _GenericAlias
+        __class__ = typing._GenericAlias
     elif sys.version_info[:3] == (3, 5, 2):
         __class__ = typing.TypingMeta
     else:


### PR DESCRIPTION
I got hit by it today: https://github.com/dry-python/returns/pull/1041/checks?check_run_id=3462681678