### PR TITLE
Fix tests for 3.10rc1 and up

### DIFF
--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -53,6 +53,7 @@ TYPING_3_5_1 = TYPING_LATEST or sys.version_info[:3] >= (3, 5, 1)
 TYPING_3_5_3 = TYPING_LATEST or sys.version_info[:3] >= (3, 5, 3)
 TYPING_3_6_1 = TYPING_LATEST or sys.version_info[:3] >= (3, 6, 1)
 TYPING_3_10_0 = TYPING_LATEST or sys.version_info[:3] >= (3, 10, 0)
+TYPING_3_11_0 = TYPING_LATEST or sys.version_info[:3] >= (3, 11, 0)
 
 # For typing versions where issubclass(...) and
 # isinstance(...) checks are forbidden.
@@ -466,6 +467,10 @@ class GetTypeHintTests(BaseTestCase):
     @skipUnless(PY36, 'Python 3.6 required')
     def test_get_type_hints_modules(self):
         ann_module_type_hints = {1: 2, 'f': Tuple[int, int], 'x': int, 'y': str}
+        if (TYPING_3_11_0
+                or (TYPING_3_10_0 and sys.version_info.releaselevel in {'candidate', 'final'})):
+            # More tests were added in 3.10rc1.
+            ann_module_type_hints['u'] = int | float
         self.assertEqual(gth(ann_module), ann_module_type_hints)
         self.assertEqual(gth(ann_module2), {})
         self.assertEqual(gth(ann_module3), {})


### PR DESCRIPTION
Before:
```
======================================================================
FAIL: test_get_type_hints_modules (__main__.GetTypeHintTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "D:\Ken\Documents\GitHub\typing\typing_extensions\src_py3\test_typing_extensions.py", line 473, in test_get_type_hints_modules
    self.assertEqual(gth(ann_module), ann_module_type_hints)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: {1: 2, 'x': <class 'int'>, 'y': <class 'str'>, 'f[39 chars]loat} != {1: 2, 'f': typing.Tuple[int, int], 'x': <class '[21 chars]tr'>}
+ {1: 2, 'f': typing.Tuple[int, int], 'x': <class 'int'>, 'y': <class 'str'>}
- {1: 2,
-  'f': typing.Tuple[int, int],
-  'u': int | float,
-  'x': <class 'int'>,
-  'y': <class 'str'>}
```
Because `ann_module` added a new annotation for union tests in 3.10rc1.