### PR TITLE
Fix linting

### DIFF
--- a/.flake8-tests
+++ b/.flake8-tests
@@ -11,17 +11,25 @@ builtins = basestring, unicode
 max-line-length = 100
 ignore =
   # temporary ignores until we sort it out
+  B017,
+  E302,
+  E303,
   E306,
+  E501,
   E701,
   E704,
+  F722,
   F811,
+  F821,
+  F841,
+  W503,
   # irrelevant plugins
   B3,
-  DW12
+  DW12,
   # consistency with mypy
   W504
 exclude =
   # This config is NOT for the main module.
-  setup.py
+  setup.py,
   python2/typing.py,
   src/typing.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           pytest $PYTHONPATH
 
   linting:
-    name: Run linting
+    name: Lint
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r test-requirements.txt
 
-      - name: Run linting
-        run: |
-          flake8
-          flake8 --config=.flake8-tests src/test_typing.py python2/test_typing.py typing_extensions/src_py2/test_typing_extensions.py typing_extensions/src_py3/test_typing_extensions.py
+      - name: Lint implementation
+        run: flake8
+
+      - name: Lint tests
+        run: flake8 --config=.flake8-tests src/test_typing.py python2/test_typing.py typing_extensions/src_py2/test_typing_extensions.py typing_extensions/src_py3/test_typing_extensions.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Install dependencies
         run: |

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -2428,7 +2428,9 @@ if not hasattr(typing, 'Concatenate'):
 
         @property
         def __parameters__(self):
-            return tuple(tp for tp in self.__args__ if isinstance(tp, (TypeVar, ParamSpec)))
+            return tuple(
+                tp for tp in self.__args__ if isinstance(tp, (TypeVar, ParamSpec))
+            )
 
         if not PEP_560:
             # Only required in 3.6 and lower.


### PR DESCRIPTION
* Split linting against implementation and tests into two steps.
* Add more error codes for test linting.
* Lint with Python 3.9.
* Fix a linting problem.

Ideally, we'd have just one configuration for linting both the implementation and tests.