### PR TITLE
Fix and clean up CI script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,29 @@ permissions:
   contents: read
 
 jobs:
+  tests-27:
+    name: Run tests (2.7)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 2.7
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r test-requirements.txt
+
+      - name: Run tests
+        run: |
+          pytest python2
+          pip install -U .
+          pytest typing_extensions/src_py2
+
   tests:
     name: Run tests
 
@@ -15,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         # Python 3.4 disabled, due to problems with GitHub Actions.
-        python-version: [3.10-dev, 3.9, 3.8, 3.7, 3.6, 3.5, 2.7]
+        python-version: [3.10-dev, 3.9, 3.8, 3.7, 3.6, 3.5]
 
     runs-on: ubuntu-latest
 
@@ -32,16 +55,12 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r test-requirements.txt
 
-      - name: Run tests
-        env:
-          PYTHON_VERSION: ${{ matrix.python-version }}
-        run: |
-          export PYTHONPATH=`python -c "import sys; print('python2' if sys.version.startswith('2') else 'src')"`
-          if [[ $PYTHON_VERSION < '3.7' ]]; then pytest $PYTHONPATH; fi
+      - name: Test typing
+        if: matrix.python-version < '3.7'
+        run: pytest src
 
-          if [[ $PYTHON_VERSION < '3.5' ]]; then pip install -U .; fi
-          export PYTHONPATH=`python -c "import sys; print('typing_extensions/src_py2' if sys.version.startswith('2') else 'typing_extensions/src_py3')"`
-          pytest $PYTHONPATH
+      - name: Test typing_extensions
+        run: pytest typing_extensions/src_py3
 
   linting:
     name: Run linting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,12 +57,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r test-requirements.txt
 
-      - name: Test typing
-        if: matrix.python-version >= '3.4' && matrix.python-version < '3.7'
-        env:
-          PYTHONPATH: src
-        run: pytest src
-
       - name: Test typing_extensions
         run: pytest typing_extensions/src_py3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,8 @@ jobs:
 
       - name: Test typing
         if: matrix.python-version < '3.7'
+        env:
+          PYTHONPATH=src
         run: pytest src
 
       - name: Test typing_extensions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Test typing_extensions
         run: |
-          pip install -U .
+          pip install typing
           pytest typing_extensions/src_py2
 
   tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Python 3.4 disabled, due to problems with GitHub Actions.
-        python-version: [3.10-dev, 3.9, 3.8, 3.7, 3.6, 3.5]
+        python-version: [3.10-dev, 3.9, 3.8, 3.7, 3.6]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
           pip install -r test-requirements.txt
 
       - name: Test typing
-        if: matrix.python-version < '3.7'
+        if: matrix.python-version >= '3.4' && matrix.python-version < '3.7'
         env:
           PYTHONPATH: src
         run: pytest src

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r test-requirements.txt
 
-      - name: Run tests
+      - name: Test typing
+        run: pytest python2
+
+      - name: Test typing_extensions
         run: |
-          pytest python2
           pip install -U .
           pytest typing_extensions/src_py2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Test typing
         if: matrix.python-version < '3.7'
         env:
-          PYTHONPATH=src
+          PYTHONPATH: src
         run: pytest src
 
       - name: Test typing_extensions

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,5 @@
 flake8; python_version >= '3.6'
 flake8-bugbear; python_version >= '3.6'
 flake8-pyi; python_version >= '3.6'
-pytest==4.6.11
-pytest-xdist>=1.18; python_version >= '3.4'
-pytest-cov>=2.4.0; python_version >= '3.4'
+pytest==4.6.11; python_version < '3.0'
+pytest; python_version >= '3.0'


### PR DESCRIPTION
* Split Python 2.7 tests from Python 3 tests as they use different paths and require installation of the typing module.
* Split typing backport and typing_extension tests for Python 2.
* Install typing from pypi instead of using the local version for Python 2.
* Remove support for Python 3.4 and 3.5.
* Don't run typing backport tests for Python 3.
* Unpin pytest version for Python 3.
* Don't install unnecessary pytest plugins pytest-xdist and pytest-cov.