### PR TITLE
Clean-up `typing_extensions` after support dropped for older Pythons

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,5 @@
 [flake8]
 
-# fake builtins for python2/*
-builtins = basestring, unicode
 max-line-length = 90
 ignore =
   # irrelevant plugins

--- a/.flake8-tests
+++ b/.flake8-tests
@@ -6,8 +6,6 @@
 # This will be possibly merged in the future.
 
 [flake8]
-# fake builtins for python2/*
-builtins = basestring, unicode
 max-line-length = 100
 ignore =
   # temporary ignores until we sort it out

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,8 +18,7 @@ standard library, so that users can experiment with them before they are added t
 standard library. Such features should ideally already be specified in a PEP or draft
 PEP.
 
-`typing_extensions` still supports all Python versions supported by `typing`, down to
-Python 2.7 and 3.4. However, it is OK to omit support for Python versions that have
+`typing_extensions` supports Python 3.6+. However, it is OK to omit support for Python versions that have
 reached end of life if doing so is too difficult or otherwise does not make sense. For
 example, `typing_extensions.AsyncGenerator` only exists on Python 3.6 and higher,
 because async generators were added to the language in 3.6.
@@ -41,12 +40,8 @@ new release that doesn't include any new standard library features would be call
 - Build the source and wheel distributions:
 
   - `pip3 install -U setuptools wheel`
-  - `pip2 install -U setuptools wheel`
   - `rm -rf dist/ build/`
   - `python3 setup.py sdist bdist_wheel`
-  - `rm -rf build/` (Works around
-    `a Wheel bug <https://bitbucket.org/pypa/wheel/issues/147/bdist_wheel-should-start-by-cleaning-up>`\_)
-  - `python2 setup.py bdist_wheel`
 
 - Install the built distributions locally and test (if you were using `tox`, you already
   tested the source distribution).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,8 +20,8 @@ PEP.
 
 `typing_extensions` supports Python 3.6+. However, it is OK to omit support for Python versions that have
 reached end of life if doing so is too difficult or otherwise does not make sense. For
-example, `typing_extensions.AsyncGenerator` only exists on Python 3.6 and higher,
-because async generators were added to the language in 3.6.
+example, `typing_extensions.AsyncGenerator` was only supported in Python 3.6 and newer, because async 
+generators were not part of the language before then.
 
 # Versioning scheme
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,4 @@
-flake8; python_version >= '3.6'
-flake8-bugbear; python_version >= '3.6'
-flake8-pyi; python_version >= '3.6'
-pytest==4.6.11; python_version < '3.0'
-pytest; python_version >= '3.0'
+flake8
+flake8-bugbear
+flake8-pyi
+pytest

--- a/typing_extensions/README.rst
+++ b/typing_extensions/README.rst
@@ -43,7 +43,7 @@ This module currently contains the following:
 - ``Literal``
 - ``NewType``
 - ``NoReturn``
-- ``overload`` (note that older versions of ``typing`` only let you use ``overload`` in stubs)
+- ``overload``
 - ``OrderedDict``
 - ``ParamSpec``
 - ``ParamSpecArgs``
@@ -56,6 +56,14 @@ This module currently contains the following:
 - ``TypeAlias``
 - ``TypeGuard``
 - ``TYPE_CHECKING``
+
+Python 3.7+
+-----------
+
+- ``get_origin``
+- ``get_args``
+- ``get_type_hints``
+
 
 Other Notes and Limitations
 ===========================

--- a/typing_extensions/setup.cfg
+++ b/typing_extensions/setup.cfg
@@ -1,5 +1,0 @@
-[metadata]
-license-file = LICENSE
-
-[options]
-python_version = >=3.6

--- a/typing_extensions/setup.py
+++ b/typing_extensions/setup.py
@@ -1,13 +1,10 @@
 #!/usr/bin/env python
-# coding: utf-8
 
 import sys
 from setuptools import setup
 
 if sys.version_info < (3, 6, 0):
-    sys.stderr.write('ERROR: You need Python 3.6+ '
-                     'to install typing_extensions.\n')
-    exit(1)
+    sys.exit('ERROR: You need Python 3.6+ to install typing_extensions.\n')
 
 version = '3.10.0.2'
 description = 'Backported and Experimental Type Hints for Python 3.6+'
@@ -47,9 +44,11 @@ setup(name='typing_extensions',
       author_email='levkivskyi@gmail.com',
       url='https://github.com/python/typing/blob/master/typing_extensions/README.rst',
       license='PSF',
+      license_files=["LICENSE"],
       keywords='typing function annotations type hints hinting checking '
                'checker typehints typehinting typechecking backport',
       package_dir={'': 'src_py3'},
       py_modules=['typing_extensions'],
+      python_requires=">=3.6",
       classifiers=classifiers,
       )

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -49,16 +49,16 @@ CAN_INSTANTIATE_COLLECTIONS = TYPING_3_6_1
 class BaseTestCase(TestCase):
     def assertIsSubclass(self, cls, class_or_tuple, msg=None):
         if not issubclass(cls, class_or_tuple):
-            message = '%r is not a subclass of %r' % (cls, class_or_tuple)
+            message = f'{repr(cls)} is not a subclass of {repr(class_or_tuple)}'
             if msg is not None:
-                message += ' : %s' % msg
+                message += f' : {msg}'
             raise self.failureException(message)
 
     def assertNotIsSubclass(self, cls, class_or_tuple, msg=None):
         if issubclass(cls, class_or_tuple):
-            message = '%r is a subclass of %r' % (cls, class_or_tuple)
+            message = f'{repr(cls)} is a subclass of {repr(class_or_tuple)}'
             if msg is not None:
-                message += ' : %s' % msg
+                message += f' : {msg}'
             raise self.failureException(message)
 
 
@@ -124,7 +124,7 @@ class ClassVarTests(BaseTestCase):
         cv = ClassVar[int]
         self.assertEqual(repr(cv), mod_name + '.ClassVar[int]')
         cv = ClassVar[Employee]
-        self.assertEqual(repr(cv), mod_name + '.ClassVar[%s.Employee]' % __name__)
+        self.assertEqual(repr(cv), mod_name + f'.ClassVar[{__name__}.Employee]')
 
     def test_cannot_subclass(self):
         with self.assertRaises(TypeError):
@@ -168,7 +168,7 @@ class FinalTests(BaseTestCase):
         cv = Final[int]
         self.assertEqual(repr(cv), mod_name + '.Final[int]')
         cv = Final[Employee]
-        self.assertEqual(repr(cv), mod_name + '.Final[%s.Employee]' % __name__)
+        self.assertEqual(repr(cv), mod_name + f'.Final[{__name__}.Employee]')
 
     def test_cannot_subclass(self):
         with self.assertRaises(TypeError):

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -52,9 +52,6 @@ TYPING_3_11_0 = sys.version_info[:3] >= (3, 11, 0)
 # See https://github.com/python/typing/issues/367
 CAN_INSTANTIATE_COLLECTIONS = TYPING_3_6_1
 
-# For Python versions supporting async/await and friends.
-ASYNCIO = sys.version_info[:2] >= (3, 5)
-
 # For checks reliant on Python 3.6 syntax changes (e.g. classvar)
 PY36 = sys.version_info[:2] >= (3, 6)
 
@@ -311,7 +308,6 @@ class OverloadTests(BaseTestCase):
         blah()
 
 
-ASYNCIO_TESTS = """
 from typing import Iterable
 from typing_extensions import Awaitable, AsyncIterator
 
@@ -346,17 +342,7 @@ class ACM:
         return 42
     async def __aexit__(self, etype, eval, tb):
         return None
-"""
 
-if ASYNCIO:
-    try:
-        exec(ASYNCIO_TESTS)
-    except ImportError:
-        ASYNCIO = False
-else:
-    # fake names for the sake of static analysis
-    asyncio = None
-    AwaitableWrapper = AsyncIteratorWrapper = ACM = object
 
 PY36_TESTS = """
 from test import ann_module, ann_module2, ann_module3
@@ -590,7 +576,6 @@ class CollectionsAbcTests(BaseTestCase):
         with self.assertRaises(TypeError):
             issubclass(collections.Counter, typing_extensions.Counter[str])
 
-    @skipUnless(ASYNCIO, 'Python 3.5 and multithreading required')
     def test_awaitable(self):
         ns = {}
         exec(
@@ -603,7 +588,6 @@ class CollectionsAbcTests(BaseTestCase):
         self.assertNotIsInstance(foo, typing_extensions.Awaitable)
         g.send(None)  # Run foo() till completion, to avoid warning.
 
-    @skipUnless(ASYNCIO, 'Python 3.5 and multithreading required')
     def test_coroutine(self):
         ns = {}
         exec(
@@ -621,7 +605,6 @@ class CollectionsAbcTests(BaseTestCase):
         except StopIteration:
             pass
 
-    @skipUnless(ASYNCIO, 'Python 3.5 and multithreading required')
     def test_async_iterable(self):
         base_it = range(10)  # type: Iterator[int]
         it = AsyncIteratorWrapper(base_it)
@@ -629,7 +612,6 @@ class CollectionsAbcTests(BaseTestCase):
         self.assertIsInstance(it, typing_extensions.AsyncIterable)
         self.assertNotIsInstance(42, typing_extensions.AsyncIterable)
 
-    @skipUnless(ASYNCIO, 'Python 3.5 and multithreading required')
     def test_async_iterator(self):
         base_it = range(10)  # type: Iterator[int]
         it = AsyncIteratorWrapper(base_it)
@@ -790,7 +772,6 @@ class OtherABCTests(BaseTestCase):
         self.assertIsInstance(cm, typing_extensions.ContextManager)
         self.assertNotIsInstance(42, typing_extensions.ContextManager)
 
-    @skipUnless(ASYNCIO, 'Python 3.5 required')
     def test_async_contextmanager(self):
         class NotACM:
             pass
@@ -2181,12 +2162,11 @@ class AllTests(BaseTestCase):
         if PEP_560:
             self.assertIn('get_type_hints', a)
 
-        if ASYNCIO:
-            self.assertIn('Awaitable', a)
-            self.assertIn('AsyncIterator', a)
-            self.assertIn('AsyncIterable', a)
-            self.assertIn('Coroutine', a)
-            self.assertIn('AsyncContextManager', a)
+        self.assertIn('Awaitable', a)
+        self.assertIn('AsyncIterator', a)
+        self.assertIn('AsyncIterable', a)
+        self.assertIn('Coroutine', a)
+        self.assertIn('AsyncContextManager', a)
 
         if PY36:
             self.assertIn('AsyncGenerator', a)

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -1970,7 +1970,7 @@ class ParamSpecTests(BaseTestCase):
         P_co = ParamSpec('P_co', covariant=True)
         P_contra = ParamSpec('P_contra', contravariant=True)
         for proto in range(pickle.HIGHEST_PROTOCOL):
-            with self.subTest('Pickle protocol {proto}'.format(proto=proto)):
+            with self.subTest(f'Pickle protocol {proto}'):
                 for paramspec in (P, P_co, P_contra):
                     z = pickle.loads(pickle.dumps(paramspec, proto))
                     self.assertEqual(z.__name__, paramspec.__name__)
@@ -2044,13 +2044,13 @@ class TypeGuardTests(BaseTestCase):
             mod_name = 'typing'
         else:
             mod_name = 'typing_extensions'
-        self.assertEqual(repr(TypeGuard), '{}.TypeGuard'.format(mod_name))
+        self.assertEqual(repr(TypeGuard), f'{mod_name}.TypeGuard')
         cv = TypeGuard[int]
-        self.assertEqual(repr(cv), '{}.TypeGuard[int]'.format(mod_name))
+        self.assertEqual(repr(cv), f'{mod_name}.TypeGuard[int]')
         cv = TypeGuard[Employee]
-        self.assertEqual(repr(cv), '{}.TypeGuard[{}.Employee]'.format(mod_name, __name__))
+        self.assertEqual(repr(cv), f'{mod_name}.TypeGuard[{__name__}.Employee]')
         cv = TypeGuard[Tuple[int]]
-        self.assertEqual(repr(cv), '{}.TypeGuard[typing.Tuple[int]]'.format(mod_name))
+        self.assertEqual(repr(cv), f'{mod_name}.TypeGuard[typing.Tuple[int]]')
 
     def test_cannot_subclass(self):
         with self.assertRaises(TypeError):
@@ -2134,8 +2134,7 @@ class AllTests(BaseTestCase):
         file_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                                  'typing_extensions.py')
         try:
-            subprocess.check_output('{} -OO {}'.format(sys.executable,
-                                                       file_path),
+            subprocess.check_output(f'{sys.executable} -OO {file_path}',
                                     stderr=subprocess.STDOUT,
                                     shell=True)
         except subprocess.CalledProcessError:

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -52,9 +52,6 @@ TYPING_3_11_0 = sys.version_info[:3] >= (3, 11, 0)
 # See https://github.com/python/typing/issues/367
 CAN_INSTANTIATE_COLLECTIONS = TYPING_3_6_1
 
-# Protocols are hard to backport to the original version of typing 3.5.0
-HAVE_PROTOCOLS = sys.version_info[:3] != (3, 5, 0)
-
 
 class BaseTestCase(TestCase):
     def assertIsSubclass(self, cls, class_or_tuple, msg=None):
@@ -872,583 +869,582 @@ class NT(NamedTuple):
     y: int
 
 
-if HAVE_PROTOCOLS:
-    class ProtocolTests(BaseTestCase):
+class ProtocolTests(BaseTestCase):
 
-        def test_basic_protocol(self):
-            @runtime
-            class P(Protocol):
-                def meth(self):
-                    pass
-            class C: pass
-            class D:
-                def meth(self):
-                    pass
-            def f():
+    def test_basic_protocol(self):
+        @runtime
+        class P(Protocol):
+            def meth(self):
                 pass
-            self.assertIsSubclass(D, P)
-            self.assertIsInstance(D(), P)
-            self.assertNotIsSubclass(C, P)
-            self.assertNotIsInstance(C(), P)
-            self.assertNotIsSubclass(types.FunctionType, P)
-            self.assertNotIsInstance(f, P)
-
-        def test_everything_implements_empty_protocol(self):
-            @runtime
-            class Empty(Protocol): pass
-            class C: pass
-            def f():
+        class C: pass
+        class D:
+            def meth(self):
                 pass
-            for thing in (object, type, tuple, C, types.FunctionType):
-                self.assertIsSubclass(thing, Empty)
-            for thing in (object(), 1, (), typing, f):
-                self.assertIsInstance(thing, Empty)
+        def f():
+            pass
+        self.assertIsSubclass(D, P)
+        self.assertIsInstance(D(), P)
+        self.assertNotIsSubclass(C, P)
+        self.assertNotIsInstance(C(), P)
+        self.assertNotIsSubclass(types.FunctionType, P)
+        self.assertNotIsInstance(f, P)
 
-        def test_function_implements_protocol(self):
-            def f():
+    def test_everything_implements_empty_protocol(self):
+        @runtime
+        class Empty(Protocol): pass
+        class C: pass
+        def f():
+            pass
+        for thing in (object, type, tuple, C, types.FunctionType):
+            self.assertIsSubclass(thing, Empty)
+        for thing in (object(), 1, (), typing, f):
+            self.assertIsInstance(thing, Empty)
+
+    def test_function_implements_protocol(self):
+        def f():
+            pass
+        self.assertIsInstance(f, HasCallProtocol)
+
+    def test_no_inheritance_from_nominal(self):
+        class C: pass
+        class BP(Protocol): pass
+        with self.assertRaises(TypeError):
+            class P(C, Protocol):
                 pass
-            self.assertIsInstance(f, HasCallProtocol)
-
-        def test_no_inheritance_from_nominal(self):
-            class C: pass
-            class BP(Protocol): pass
-            with self.assertRaises(TypeError):
-                class P(C, Protocol):
-                    pass
-            with self.assertRaises(TypeError):
-                class P(Protocol, C):
-                    pass
-            with self.assertRaises(TypeError):
-                class P(BP, C, Protocol):
-                    pass
-            class D(BP, C): pass
-            class E(C, BP): pass
-            self.assertNotIsInstance(D(), E)
-            self.assertNotIsInstance(E(), D)
-
-        def test_no_instantiation(self):
-            class P(Protocol): pass
-            with self.assertRaises(TypeError):
-                P()
-            class C(P): pass
-            self.assertIsInstance(C(), C)
-            T = TypeVar('T')
-            class PG(Protocol[T]): pass
-            with self.assertRaises(TypeError):
-                PG()
-            with self.assertRaises(TypeError):
-                PG[int]()
-            with self.assertRaises(TypeError):
-                PG[T]()
-            class CG(PG[T]): pass
-            self.assertIsInstance(CG[int](), CG)
-
-        def test_cannot_instantiate_abstract(self):
-            @runtime
-            class P(Protocol):
-                @abc.abstractmethod
-                def ameth(self) -> int:
-                    raise NotImplementedError
-            class B(P):
+        with self.assertRaises(TypeError):
+            class P(Protocol, C):
                 pass
-            class C(B):
-                def ameth(self) -> int:
-                    return 26
-            with self.assertRaises(TypeError):
-                B()
-            self.assertIsInstance(C(), P)
-
-        def test_subprotocols_extending(self):
-            class P1(Protocol):
-                def meth1(self):
-                    pass
-            @runtime
-            class P2(P1, Protocol):
-                def meth2(self):
-                    pass
-            class C:
-                def meth1(self):
-                    pass
-                def meth2(self):
-                    pass
-            class C1:
-                def meth1(self):
-                    pass
-            class C2:
-                def meth2(self):
-                    pass
-            self.assertNotIsInstance(C1(), P2)
-            self.assertNotIsInstance(C2(), P2)
-            self.assertNotIsSubclass(C1, P2)
-            self.assertNotIsSubclass(C2, P2)
-            self.assertIsInstance(C(), P2)
-            self.assertIsSubclass(C, P2)
-
-        def test_subprotocols_merging(self):
-            class P1(Protocol):
-                def meth1(self):
-                    pass
-            class P2(Protocol):
-                def meth2(self):
-                    pass
-            @runtime
-            class P(P1, P2, Protocol):
+        with self.assertRaises(TypeError):
+            class P(BP, C, Protocol):
                 pass
-            class C:
-                def meth1(self):
-                    pass
-                def meth2(self):
-                    pass
-            class C1:
-                def meth1(self):
-                    pass
-            class C2:
-                def meth2(self):
-                    pass
-            self.assertNotIsInstance(C1(), P)
-            self.assertNotIsInstance(C2(), P)
-            self.assertNotIsSubclass(C1, P)
-            self.assertNotIsSubclass(C2, P)
-            self.assertIsInstance(C(), P)
-            self.assertIsSubclass(C, P)
+        class D(BP, C): pass
+        class E(C, BP): pass
+        self.assertNotIsInstance(D(), E)
+        self.assertNotIsInstance(E(), D)
 
-        def test_protocols_issubclass(self):
-            T = TypeVar('T')
-            @runtime
-            class P(Protocol):
-                def x(self): ...
-            @runtime
-            class PG(Protocol[T]):
-                def x(self): ...
-            class BadP(Protocol):
-                def x(self): ...
-            class BadPG(Protocol[T]):
-                def x(self): ...
-            class C:
-                def x(self): ...
-            self.assertIsSubclass(C, P)
-            self.assertIsSubclass(C, PG)
-            self.assertIsSubclass(BadP, PG)
-            if not PEP_560:
-                self.assertIsSubclass(PG[int], PG)
-                self.assertIsSubclass(BadPG[int], P)
-                self.assertIsSubclass(BadPG[T], PG)
-            with self.assertRaises(TypeError):
-                issubclass(C, PG[T])
-            with self.assertRaises(TypeError):
-                issubclass(C, PG[C])
-            with self.assertRaises(TypeError):
-                issubclass(C, BadP)
-            with self.assertRaises(TypeError):
-                issubclass(C, BadPG)
-            with self.assertRaises(TypeError):
-                issubclass(P, PG[T])
-            with self.assertRaises(TypeError):
-                issubclass(PG, PG[int])
+    def test_no_instantiation(self):
+        class P(Protocol): pass
+        with self.assertRaises(TypeError):
+            P()
+        class C(P): pass
+        self.assertIsInstance(C(), C)
+        T = TypeVar('T')
+        class PG(Protocol[T]): pass
+        with self.assertRaises(TypeError):
+            PG()
+        with self.assertRaises(TypeError):
+            PG[int]()
+        with self.assertRaises(TypeError):
+            PG[T]()
+        class CG(PG[T]): pass
+        self.assertIsInstance(CG[int](), CG)
 
-        def test_protocols_issubclass_non_callable(self):
-            class C:
-                x = 1
-            @runtime
-            class PNonCall(Protocol):
-                x = 1
-            with self.assertRaises(TypeError):
-                issubclass(C, PNonCall)
-            self.assertIsInstance(C(), PNonCall)
-            PNonCall.register(C)
-            with self.assertRaises(TypeError):
-                issubclass(C, PNonCall)
-            self.assertIsInstance(C(), PNonCall)
-            # check that non-protocol subclasses are not affected
-            class D(PNonCall): ...
-            self.assertNotIsSubclass(C, D)
-            self.assertNotIsInstance(C(), D)
-            D.register(C)
-            self.assertIsSubclass(C, D)
-            self.assertIsInstance(C(), D)
-            with self.assertRaises(TypeError):
-                issubclass(D, PNonCall)
+    def test_cannot_instantiate_abstract(self):
+        @runtime
+        class P(Protocol):
+            @abc.abstractmethod
+            def ameth(self) -> int:
+                raise NotImplementedError
+        class B(P):
+            pass
+        class C(B):
+            def ameth(self) -> int:
+                return 26
+        with self.assertRaises(TypeError):
+            B()
+        self.assertIsInstance(C(), P)
 
-        def test_protocols_isinstance(self):
-            T = TypeVar('T')
-            @runtime
-            class P(Protocol):
-                def meth(x): ...
-            @runtime
-            class PG(Protocol[T]):
-                def meth(x): ...
-            class BadP(Protocol):
-                def meth(x): ...
-            class BadPG(Protocol[T]):
-                def meth(x): ...
-            class C:
-                def meth(x): ...
-            self.assertIsInstance(C(), P)
-            self.assertIsInstance(C(), PG)
+    def test_subprotocols_extending(self):
+        class P1(Protocol):
+            def meth1(self):
+                pass
+        @runtime
+        class P2(P1, Protocol):
+            def meth2(self):
+                pass
+        class C:
+            def meth1(self):
+                pass
+            def meth2(self):
+                pass
+        class C1:
+            def meth1(self):
+                pass
+        class C2:
+            def meth2(self):
+                pass
+        self.assertNotIsInstance(C1(), P2)
+        self.assertNotIsInstance(C2(), P2)
+        self.assertNotIsSubclass(C1, P2)
+        self.assertNotIsSubclass(C2, P2)
+        self.assertIsInstance(C(), P2)
+        self.assertIsSubclass(C, P2)
+
+    def test_subprotocols_merging(self):
+        class P1(Protocol):
+            def meth1(self):
+                pass
+        class P2(Protocol):
+            def meth2(self):
+                pass
+        @runtime
+        class P(P1, P2, Protocol):
+            pass
+        class C:
+            def meth1(self):
+                pass
+            def meth2(self):
+                pass
+        class C1:
+            def meth1(self):
+                pass
+        class C2:
+            def meth2(self):
+                pass
+        self.assertNotIsInstance(C1(), P)
+        self.assertNotIsInstance(C2(), P)
+        self.assertNotIsSubclass(C1, P)
+        self.assertNotIsSubclass(C2, P)
+        self.assertIsInstance(C(), P)
+        self.assertIsSubclass(C, P)
+
+    def test_protocols_issubclass(self):
+        T = TypeVar('T')
+        @runtime
+        class P(Protocol):
+            def x(self): ...
+        @runtime
+        class PG(Protocol[T]):
+            def x(self): ...
+        class BadP(Protocol):
+            def x(self): ...
+        class BadPG(Protocol[T]):
+            def x(self): ...
+        class C:
+            def x(self): ...
+        self.assertIsSubclass(C, P)
+        self.assertIsSubclass(C, PG)
+        self.assertIsSubclass(BadP, PG)
+        if not PEP_560:
+            self.assertIsSubclass(PG[int], PG)
+            self.assertIsSubclass(BadPG[int], P)
+            self.assertIsSubclass(BadPG[T], PG)
+        with self.assertRaises(TypeError):
+            issubclass(C, PG[T])
+        with self.assertRaises(TypeError):
+            issubclass(C, PG[C])
+        with self.assertRaises(TypeError):
+            issubclass(C, BadP)
+        with self.assertRaises(TypeError):
+            issubclass(C, BadPG)
+        with self.assertRaises(TypeError):
+            issubclass(P, PG[T])
+        with self.assertRaises(TypeError):
+            issubclass(PG, PG[int])
+
+    def test_protocols_issubclass_non_callable(self):
+        class C:
+            x = 1
+        @runtime
+        class PNonCall(Protocol):
+            x = 1
+        with self.assertRaises(TypeError):
+            issubclass(C, PNonCall)
+        self.assertIsInstance(C(), PNonCall)
+        PNonCall.register(C)
+        with self.assertRaises(TypeError):
+            issubclass(C, PNonCall)
+        self.assertIsInstance(C(), PNonCall)
+        # check that non-protocol subclasses are not affected
+        class D(PNonCall): ...
+        self.assertNotIsSubclass(C, D)
+        self.assertNotIsInstance(C(), D)
+        D.register(C)
+        self.assertIsSubclass(C, D)
+        self.assertIsInstance(C(), D)
+        with self.assertRaises(TypeError):
+            issubclass(D, PNonCall)
+
+    def test_protocols_isinstance(self):
+        T = TypeVar('T')
+        @runtime
+        class P(Protocol):
+            def meth(x): ...
+        @runtime
+        class PG(Protocol[T]):
+            def meth(x): ...
+        class BadP(Protocol):
+            def meth(x): ...
+        class BadPG(Protocol[T]):
+            def meth(x): ...
+        class C:
+            def meth(x): ...
+        self.assertIsInstance(C(), P)
+        self.assertIsInstance(C(), PG)
+        with self.assertRaises(TypeError):
+            isinstance(C(), PG[T])
+        with self.assertRaises(TypeError):
+            isinstance(C(), PG[C])
+        with self.assertRaises(TypeError):
+            isinstance(C(), BadP)
+        with self.assertRaises(TypeError):
+            isinstance(C(), BadPG)
+
+    def test_protocols_isinstance_py36(self):
+        class APoint:
+            def __init__(self, x, y, label):
+                self.x = x
+                self.y = y
+                self.label = label
+        class BPoint:
+            label = 'B'
+            def __init__(self, x, y):
+                self.x = x
+                self.y = y
+        class C:
+            def __init__(self, attr):
+                self.attr = attr
+            def meth(self, arg):
+                return 0
+        class Bad: pass
+        self.assertIsInstance(APoint(1, 2, 'A'), Point)
+        self.assertIsInstance(BPoint(1, 2), Point)
+        self.assertNotIsInstance(MyPoint(), Point)
+        self.assertIsInstance(BPoint(1, 2), Position)
+        self.assertIsInstance(Other(), Proto)
+        self.assertIsInstance(Concrete(), Proto)
+        self.assertIsInstance(C(42), Proto)
+        self.assertNotIsInstance(Bad(), Proto)
+        self.assertNotIsInstance(Bad(), Point)
+        self.assertNotIsInstance(Bad(), Position)
+        self.assertNotIsInstance(Bad(), Concrete)
+        self.assertNotIsInstance(Other(), Concrete)
+        self.assertIsInstance(NT(1, 2), Position)
+
+    def test_protocols_isinstance_init(self):
+        T = TypeVar('T')
+        @runtime
+        class P(Protocol):
+            x = 1
+        @runtime
+        class PG(Protocol[T]):
+            x = 1
+        class C:
+            def __init__(self, x):
+                self.x = x
+        self.assertIsInstance(C(1), P)
+        self.assertIsInstance(C(1), PG)
+
+    def test_protocols_support_register(self):
+        @runtime
+        class P(Protocol):
+            x = 1
+        class PM(Protocol):
+            def meth(self): pass
+        class D(PM): pass
+        class C: pass
+        D.register(C)
+        P.register(C)
+        self.assertIsInstance(C(), P)
+        self.assertIsInstance(C(), D)
+
+    def test_none_on_non_callable_doesnt_block_implementation(self):
+        @runtime
+        class P(Protocol):
+            x = 1
+        class A:
+            x = 1
+        class B(A):
+            x = None
+        class C:
+            def __init__(self):
+                self.x = None
+        self.assertIsInstance(B(), P)
+        self.assertIsInstance(C(), P)
+
+    def test_none_on_callable_blocks_implementation(self):
+        @runtime
+        class P(Protocol):
+            def x(self): ...
+        class A:
+            def x(self): ...
+        class B(A):
+            x = None
+        class C:
+            def __init__(self):
+                self.x = None
+        self.assertNotIsInstance(B(), P)
+        self.assertNotIsInstance(C(), P)
+
+    def test_non_protocol_subclasses(self):
+        class P(Protocol):
+            x = 1
+        @runtime
+        class PR(Protocol):
+            def meth(self): pass
+        class NonP(P):
+            x = 1
+        class NonPR(PR): pass
+        class C:
+            x = 1
+        class D:
+            def meth(self): pass
+        self.assertNotIsInstance(C(), NonP)
+        self.assertNotIsInstance(D(), NonPR)
+        self.assertNotIsSubclass(C, NonP)
+        self.assertNotIsSubclass(D, NonPR)
+        self.assertIsInstance(NonPR(), PR)
+        self.assertIsSubclass(NonPR, PR)
+
+    def test_custom_subclasshook(self):
+        class P(Protocol):
+            x = 1
+        class OKClass: pass
+        class BadClass:
+            x = 1
+        class C(P):
+            @classmethod
+            def __subclasshook__(cls, other):
+                return other.__name__.startswith("OK")
+        self.assertIsInstance(OKClass(), C)
+        self.assertNotIsInstance(BadClass(), C)
+        self.assertIsSubclass(OKClass, C)
+        self.assertNotIsSubclass(BadClass, C)
+
+    def test_issubclass_fails_correctly(self):
+        @runtime
+        class P(Protocol):
+            x = 1
+        class C: pass
+        with self.assertRaises(TypeError):
+            issubclass(C(), P)
+
+    @skipUnless(not OLD_GENERICS, "New style generics required")
+    def test_defining_generic_protocols(self):
+        T = TypeVar('T')
+        S = TypeVar('S')
+        @runtime
+        class PR(Protocol[T, S]):
+            def meth(self): pass
+        class P(PR[int, T], Protocol[T]):
+            y = 1
+        self.assertIsSubclass(PR[int, T], PR)
+        self.assertIsSubclass(P[str], PR)
+        with self.assertRaises(TypeError):
+            PR[int]
+        with self.assertRaises(TypeError):
+            P[int, str]
+        with self.assertRaises(TypeError):
+            PR[int, 1]
+        with self.assertRaises(TypeError):
+            PR[int, ClassVar]
+        class C(PR[int, T]): pass
+        self.assertIsInstance(C[str](), C)
+
+    def test_defining_generic_protocols_old_style(self):
+        T = TypeVar('T')
+        S = TypeVar('S')
+        @runtime
+        class PR(Protocol, Generic[T, S]):
+            def meth(self): pass
+        class P(PR[int, str], Protocol):
+            y = 1
+        if not PEP_560:
+            self.assertIsSubclass(PR[int, str], PR)
+        else:
             with self.assertRaises(TypeError):
-                isinstance(C(), PG[T])
-            with self.assertRaises(TypeError):
-                isinstance(C(), PG[C])
-            with self.assertRaises(TypeError):
-                isinstance(C(), BadP)
-            with self.assertRaises(TypeError):
-                isinstance(C(), BadPG)
-
-        def test_protocols_isinstance_py36(self):
-            class APoint:
-                def __init__(self, x, y, label):
-                    self.x = x
-                    self.y = y
-                    self.label = label
-            class BPoint:
-                label = 'B'
-                def __init__(self, x, y):
-                    self.x = x
-                    self.y = y
-            class C:
-                def __init__(self, attr):
-                    self.attr = attr
-                def meth(self, arg):
-                    return 0
-            class Bad: pass
-            self.assertIsInstance(APoint(1, 2, 'A'), Point)
-            self.assertIsInstance(BPoint(1, 2), Point)
-            self.assertNotIsInstance(MyPoint(), Point)
-            self.assertIsInstance(BPoint(1, 2), Position)
-            self.assertIsInstance(Other(), Proto)
-            self.assertIsInstance(Concrete(), Proto)
-            self.assertIsInstance(C(42), Proto)
-            self.assertNotIsInstance(Bad(), Proto)
-            self.assertNotIsInstance(Bad(), Point)
-            self.assertNotIsInstance(Bad(), Position)
-            self.assertNotIsInstance(Bad(), Concrete)
-            self.assertNotIsInstance(Other(), Concrete)
-            self.assertIsInstance(NT(1, 2), Position)
-
-        def test_protocols_isinstance_init(self):
-            T = TypeVar('T')
-            @runtime
-            class P(Protocol):
-                x = 1
-            @runtime
-            class PG(Protocol[T]):
-                x = 1
-            class C:
-                def __init__(self, x):
-                    self.x = x
-            self.assertIsInstance(C(1), P)
-            self.assertIsInstance(C(1), PG)
-
-        def test_protocols_support_register(self):
-            @runtime
-            class P(Protocol):
-                x = 1
-            class PM(Protocol):
-                def meth(self): pass
-            class D(PM): pass
-            class C: pass
-            D.register(C)
-            P.register(C)
-            self.assertIsInstance(C(), P)
-            self.assertIsInstance(C(), D)
-
-        def test_none_on_non_callable_doesnt_block_implementation(self):
-            @runtime
-            class P(Protocol):
-                x = 1
-            class A:
-                x = 1
-            class B(A):
-                x = None
-            class C:
-                def __init__(self):
-                    self.x = None
-            self.assertIsInstance(B(), P)
-            self.assertIsInstance(C(), P)
-
-        def test_none_on_callable_blocks_implementation(self):
-            @runtime
-            class P(Protocol):
-                def x(self): ...
-            class A:
-                def x(self): ...
-            class B(A):
-                x = None
-            class C:
-                def __init__(self):
-                    self.x = None
-            self.assertNotIsInstance(B(), P)
-            self.assertNotIsInstance(C(), P)
-
-        def test_non_protocol_subclasses(self):
-            class P(Protocol):
-                x = 1
-            @runtime
-            class PR(Protocol):
-                def meth(self): pass
-            class NonP(P):
-                x = 1
-            class NonPR(PR): pass
-            class C:
-                x = 1
-            class D:
-                def meth(self): pass
-            self.assertNotIsInstance(C(), NonP)
-            self.assertNotIsInstance(D(), NonPR)
-            self.assertNotIsSubclass(C, NonP)
-            self.assertNotIsSubclass(D, NonPR)
-            self.assertIsInstance(NonPR(), PR)
-            self.assertIsSubclass(NonPR, PR)
-
-        def test_custom_subclasshook(self):
-            class P(Protocol):
-                x = 1
-            class OKClass: pass
-            class BadClass:
-                x = 1
-            class C(P):
-                @classmethod
-                def __subclasshook__(cls, other):
-                    return other.__name__.startswith("OK")
-            self.assertIsInstance(OKClass(), C)
-            self.assertNotIsInstance(BadClass(), C)
-            self.assertIsSubclass(OKClass, C)
-            self.assertNotIsSubclass(BadClass, C)
-
-        def test_issubclass_fails_correctly(self):
-            @runtime
-            class P(Protocol):
-                x = 1
-            class C: pass
-            with self.assertRaises(TypeError):
-                issubclass(C(), P)
-
-        @skipUnless(not OLD_GENERICS, "New style generics required")
-        def test_defining_generic_protocols(self):
-            T = TypeVar('T')
-            S = TypeVar('S')
-            @runtime
-            class PR(Protocol[T, S]):
-                def meth(self): pass
-            class P(PR[int, T], Protocol[T]):
-                y = 1
-            self.assertIsSubclass(PR[int, T], PR)
-            self.assertIsSubclass(P[str], PR)
-            with self.assertRaises(TypeError):
-                PR[int]
-            with self.assertRaises(TypeError):
-                P[int, str]
+                self.assertIsSubclass(PR[int, str], PR)
+        self.assertIsSubclass(P, PR)
+        with self.assertRaises(TypeError):
+            PR[int]
+        if not TYPING_3_10_0:
             with self.assertRaises(TypeError):
                 PR[int, 1]
+        class P1(Protocol, Generic[T]):
+            def bar(self, x: T) -> str: ...
+        class P2(Generic[T], Protocol):
+            def bar(self, x: T) -> str: ...
+        @runtime
+        class PSub(P1[str], Protocol):
+            x = 1
+        class Test:
+            x = 1
+            def bar(self, x: str) -> str:
+                return x
+        self.assertIsInstance(Test(), PSub)
+        if not TYPING_3_10_0:
             with self.assertRaises(TypeError):
                 PR[int, ClassVar]
-            class C(PR[int, T]): pass
-            self.assertIsInstance(C[str](), C)
 
-        def test_defining_generic_protocols_old_style(self):
-            T = TypeVar('T')
-            S = TypeVar('S')
-            @runtime
-            class PR(Protocol, Generic[T, S]):
-                def meth(self): pass
-            class P(PR[int, str], Protocol):
-                y = 1
-            if not PEP_560:
-                self.assertIsSubclass(PR[int, str], PR)
-            else:
-                with self.assertRaises(TypeError):
-                    self.assertIsSubclass(PR[int, str], PR)
-            self.assertIsSubclass(P, PR)
-            with self.assertRaises(TypeError):
-                PR[int]
-            if not TYPING_3_10_0:
-                with self.assertRaises(TypeError):
-                    PR[int, 1]
-            class P1(Protocol, Generic[T]):
-                def bar(self, x: T) -> str: ...
-            class P2(Generic[T], Protocol):
-                def bar(self, x: T) -> str: ...
-            @runtime
-            class PSub(P1[str], Protocol):
-                x = 1
-            class Test:
-                x = 1
-                def bar(self, x: str) -> str:
-                    return x
-            self.assertIsInstance(Test(), PSub)
-            if not TYPING_3_10_0:
-                with self.assertRaises(TypeError):
-                    PR[int, ClassVar]
+    def test_init_called(self):
+        T = TypeVar('T')
+        class P(Protocol[T]): pass
+        class C(P[T]):
+            def __init__(self):
+                self.test = 'OK'
+        self.assertEqual(C[int]().test, 'OK')
 
-        def test_init_called(self):
-            T = TypeVar('T')
-            class P(Protocol[T]): pass
-            class C(P[T]):
-                def __init__(self):
-                    self.test = 'OK'
-            self.assertEqual(C[int]().test, 'OK')
+    @skipUnless(not OLD_GENERICS, "New style generics required")
+    def test_protocols_bad_subscripts(self):
+        T = TypeVar('T')
+        S = TypeVar('S')
+        with self.assertRaises(TypeError):
+            class P(Protocol[T, T]): pass
+        with self.assertRaises(TypeError):
+            class P(Protocol[int]): pass
+        with self.assertRaises(TypeError):
+            class P(Protocol[T], Protocol[S]): pass
+        with self.assertRaises(TypeError):
+            class P(typing.Mapping[T, S], Protocol[T]): pass
 
-        @skipUnless(not OLD_GENERICS, "New style generics required")
-        def test_protocols_bad_subscripts(self):
-            T = TypeVar('T')
-            S = TypeVar('S')
-            with self.assertRaises(TypeError):
-                class P(Protocol[T, T]): pass
-            with self.assertRaises(TypeError):
-                class P(Protocol[int]): pass
-            with self.assertRaises(TypeError):
-                class P(Protocol[T], Protocol[S]): pass
-            with self.assertRaises(TypeError):
-                class P(typing.Mapping[T, S], Protocol[T]): pass
+    def test_generic_protocols_repr(self):
+        T = TypeVar('T')
+        S = TypeVar('S')
+        class P(Protocol[T, S]): pass
+        # After PEP 560 unsubscripted generics have a standard repr.
+        if not PEP_560:
+            self.assertTrue(repr(P).endswith('P'))
+        self.assertTrue(repr(P[T, S]).endswith('P[~T, ~S]'))
+        self.assertTrue(repr(P[int, str]).endswith('P[int, str]'))
 
-        def test_generic_protocols_repr(self):
-            T = TypeVar('T')
-            S = TypeVar('S')
-            class P(Protocol[T, S]): pass
-            # After PEP 560 unsubscripted generics have a standard repr.
-            if not PEP_560:
-                self.assertTrue(repr(P).endswith('P'))
-            self.assertTrue(repr(P[T, S]).endswith('P[~T, ~S]'))
-            self.assertTrue(repr(P[int, str]).endswith('P[int, str]'))
+    def test_generic_protocols_eq(self):
+        T = TypeVar('T')
+        S = TypeVar('S')
+        class P(Protocol[T, S]): pass
+        self.assertEqual(P, P)
+        self.assertEqual(P[int, T], P[int, T])
+        self.assertEqual(P[T, T][Tuple[T, S]][int, str],
+                         P[Tuple[int, str], Tuple[int, str]])
 
-        def test_generic_protocols_eq(self):
-            T = TypeVar('T')
-            S = TypeVar('S')
-            class P(Protocol[T, S]): pass
-            self.assertEqual(P, P)
-            self.assertEqual(P[int, T], P[int, T])
-            self.assertEqual(P[T, T][Tuple[T, S]][int, str],
-                             P[Tuple[int, str], Tuple[int, str]])
+    @skipUnless(not OLD_GENERICS, "New style generics required")
+    def test_generic_protocols_special_from_generic(self):
+        T = TypeVar('T')
+        class P(Protocol[T]): pass
+        self.assertEqual(P.__parameters__, (T,))
+        self.assertIs(P.__args__, None)
+        self.assertIs(P.__origin__, None)
+        self.assertEqual(P[int].__parameters__, ())
+        self.assertEqual(P[int].__args__, (int,))
+        self.assertIs(P[int].__origin__, P)
 
-        @skipUnless(not OLD_GENERICS, "New style generics required")
-        def test_generic_protocols_special_from_generic(self):
-            T = TypeVar('T')
-            class P(Protocol[T]): pass
-            self.assertEqual(P.__parameters__, (T,))
-            self.assertIs(P.__args__, None)
-            self.assertIs(P.__origin__, None)
-            self.assertEqual(P[int].__parameters__, ())
-            self.assertEqual(P[int].__args__, (int,))
-            self.assertIs(P[int].__origin__, P)
-
-        def test_generic_protocols_special_from_protocol(self):
-            @runtime
-            class PR(Protocol):
-                x = 1
-            class P(Protocol):
-                def meth(self):
-                    pass
-            T = TypeVar('T')
-            class PG(Protocol[T]):
-                x = 1
-                def meth(self):
-                    pass
-            self.assertTrue(P._is_protocol)
-            self.assertTrue(PR._is_protocol)
-            self.assertTrue(PG._is_protocol)
-            if hasattr(typing, 'Protocol'):
+    def test_generic_protocols_special_from_protocol(self):
+        @runtime
+        class PR(Protocol):
+            x = 1
+        class P(Protocol):
+            def meth(self):
+                pass
+        T = TypeVar('T')
+        class PG(Protocol[T]):
+            x = 1
+            def meth(self):
+                pass
+        self.assertTrue(P._is_protocol)
+        self.assertTrue(PR._is_protocol)
+        self.assertTrue(PG._is_protocol)
+        if hasattr(typing, 'Protocol'):
+            self.assertFalse(P._is_runtime_protocol)
+        else:
+            with self.assertRaises(AttributeError):
                 self.assertFalse(P._is_runtime_protocol)
-            else:
-                with self.assertRaises(AttributeError):
-                    self.assertFalse(P._is_runtime_protocol)
-            self.assertTrue(PR._is_runtime_protocol)
-            self.assertTrue(PG[int]._is_protocol)
-            self.assertEqual(typing_extensions._get_protocol_attrs(P), {'meth'})
-            self.assertEqual(typing_extensions._get_protocol_attrs(PR), {'x'})
-            self.assertEqual(frozenset(typing_extensions._get_protocol_attrs(PG)),
+        self.assertTrue(PR._is_runtime_protocol)
+        self.assertTrue(PG[int]._is_protocol)
+        self.assertEqual(typing_extensions._get_protocol_attrs(P), {'meth'})
+        self.assertEqual(typing_extensions._get_protocol_attrs(PR), {'x'})
+        self.assertEqual(frozenset(typing_extensions._get_protocol_attrs(PG)),
+                         frozenset({'x', 'meth'}))
+        if not PEP_560:
+            self.assertEqual(frozenset(typing_extensions._get_protocol_attrs(PG[int])),
                              frozenset({'x', 'meth'}))
-            if not PEP_560:
-                self.assertEqual(frozenset(typing_extensions._get_protocol_attrs(PG[int])),
-                                 frozenset({'x', 'meth'}))
 
-        def test_no_runtime_deco_on_nominal(self):
-            with self.assertRaises(TypeError):
-                @runtime
-                class C: pass
-            class Proto(Protocol):
-                x = 1
-            with self.assertRaises(TypeError):
-                @runtime
-                class Concrete(Proto):
-                    pass
-
-        def test_none_treated_correctly(self):
+    def test_no_runtime_deco_on_nominal(self):
+        with self.assertRaises(TypeError):
             @runtime
-            class P(Protocol):
-                x = None  # type: int
-            class B(object): pass
-            self.assertNotIsInstance(B(), P)
-            class C:
-                x = 1
-            class D:
-                x = None
-            self.assertIsInstance(C(), P)
-            self.assertIsInstance(D(), P)
-            class CI:
-                def __init__(self):
-                    self.x = 1
-            class DI:
-                def __init__(self):
-                    self.x = None
-            self.assertIsInstance(C(), P)
-            self.assertIsInstance(D(), P)
-
-        def test_protocols_in_unions(self):
-            class P(Protocol):
-                x = None  # type: int
-            Alias = typing.Union[typing.Iterable, P]
-            Alias2 = typing.Union[P, typing.Iterable]
-            self.assertEqual(Alias, Alias2)
-
-        def test_protocols_pickleable(self):
-            global P, CP  # pickle wants to reference the class by name
-            T = TypeVar('T')
-
+            class C: pass
+        class Proto(Protocol):
+            x = 1
+        with self.assertRaises(TypeError):
             @runtime
-            class P(Protocol[T]):
+            class Concrete(Proto):
+                pass
+
+    def test_none_treated_correctly(self):
+        @runtime
+        class P(Protocol):
+            x = None  # type: int
+        class B(object): pass
+        self.assertNotIsInstance(B(), P)
+        class C:
+            x = 1
+        class D:
+            x = None
+        self.assertIsInstance(C(), P)
+        self.assertIsInstance(D(), P)
+        class CI:
+            def __init__(self):
+                self.x = 1
+        class DI:
+            def __init__(self):
+                self.x = None
+        self.assertIsInstance(C(), P)
+        self.assertIsInstance(D(), P)
+
+    def test_protocols_in_unions(self):
+        class P(Protocol):
+            x = None  # type: int
+        Alias = typing.Union[typing.Iterable, P]
+        Alias2 = typing.Union[P, typing.Iterable]
+        self.assertEqual(Alias, Alias2)
+
+    def test_protocols_pickleable(self):
+        global P, CP  # pickle wants to reference the class by name
+        T = TypeVar('T')
+
+        @runtime
+        class P(Protocol[T]):
+            x = 1
+        class CP(P[int]):
+            pass
+
+        c = CP()
+        c.foo = 42
+        c.bar = 'abc'
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            z = pickle.dumps(c, proto)
+            x = pickle.loads(z)
+            self.assertEqual(x.foo, 42)
+            self.assertEqual(x.bar, 'abc')
+            self.assertEqual(x.x, 1)
+            self.assertEqual(x.__dict__, {'foo': 42, 'bar': 'abc'})
+            s = pickle.dumps(P)
+            D = pickle.loads(s)
+            class E:
                 x = 1
-            class CP(P[int]):
-                pass
+            self.assertIsInstance(E(), D)
 
-            c = CP()
-            c.foo = 42
-            c.bar = 'abc'
-            for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-                z = pickle.dumps(c, proto)
-                x = pickle.loads(z)
-                self.assertEqual(x.foo, 42)
-                self.assertEqual(x.bar, 'abc')
-                self.assertEqual(x.x, 1)
-                self.assertEqual(x.__dict__, {'foo': 42, 'bar': 'abc'})
-                s = pickle.dumps(P)
-                D = pickle.loads(s)
-                class E:
-                    x = 1
-                self.assertIsInstance(E(), D)
+    def test_collections_protocols_allowed(self):
+        @runtime_checkable
+        class Custom(collections.abc.Iterable, Protocol):
+            def close(self): pass
 
-        def test_collections_protocols_allowed(self):
-            @runtime_checkable
-            class Custom(collections.abc.Iterable, Protocol):
-                def close(self): pass
+        class A: ...
+        class B:
+            def __iter__(self):
+                return []
+            def close(self):
+                return 0
 
-            class A: ...
-            class B:
-                def __iter__(self):
-                    return []
-                def close(self):
-                    return 0
+        self.assertIsSubclass(B, Custom)
+        self.assertNotIsSubclass(A, Custom)
 
-            self.assertIsSubclass(B, Custom)
-            self.assertNotIsSubclass(A, Custom)
+    def test_no_init_same_for_different_protocol_implementations(self):
+        class CustomProtocolWithoutInitA(Protocol):
+            pass
 
-        def test_no_init_same_for_different_protocol_implementations(self):
-            class CustomProtocolWithoutInitA(Protocol):
-                pass
+        class CustomProtocolWithoutInitB(Protocol):
+            pass
 
-            class CustomProtocolWithoutInitB(Protocol):
-                pass
-
-            self.assertEqual(CustomProtocolWithoutInitA.__init__, CustomProtocolWithoutInitB.__init__)
+        self.assertEqual(CustomProtocolWithoutInitA.__init__, CustomProtocolWithoutInitB.__init__)
 
 
 class TypedDictTests(BaseTestCase):

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -3,36 +3,27 @@ import os
 import abc
 import contextlib
 import collections
+import collections.abc
 import pickle
 import subprocess
 import types
 from unittest import TestCase, main, skipUnless, skipIf
 from test import ann_module, ann_module2, ann_module3
+import typing
 from typing import TypeVar, Optional, Union
 from typing import T, KT, VT  # Not in __all__.
 from typing import Tuple, List, Dict, Iterable, Iterator, Callable
 from typing import Generic, NamedTuple
 from typing import no_type_check
+import typing_extensions
 from typing_extensions import NoReturn, ClassVar, Final, IntVar, Literal, Type, NewType, TypedDict
 from typing_extensions import TypeAlias, ParamSpec, Concatenate, ParamSpecArgs, ParamSpecKwargs, TypeGuard
 from typing_extensions import Awaitable, AsyncIterator, AsyncContextManager
-
-try:
-    from typing_extensions import Protocol, runtime, runtime_checkable
-except ImportError:
-    pass
-try:
-    from typing_extensions import Annotated
-except ImportError:
-    pass
+from typing_extensions import Protocol, runtime, runtime_checkable, Annotated, overload
 try:
     from typing_extensions import get_type_hints
 except ImportError:
     from typing import get_type_hints
-
-import typing
-import typing_extensions
-import collections.abc as collections_abc
 
 PEP_560 = sys.version_info[:3] >= (3, 7, 0)
 
@@ -281,8 +272,6 @@ class LiteralTests(BaseTestCase):
 class OverloadTests(BaseTestCase):
 
     def test_overload_fails(self):
-        from typing_extensions import overload
-
         with self.assertRaises(RuntimeError):
 
             @overload
@@ -292,8 +281,6 @@ class OverloadTests(BaseTestCase):
             blah()
 
     def test_overload_succeeds(self):
-        from typing_extensions import overload
-
         @overload
         def blah():
             pass
@@ -545,10 +532,10 @@ class GetUtilitiesTestCase(TestCase):
 class CollectionsAbcTests(BaseTestCase):
 
     def test_isinstance_collections(self):
-        self.assertNotIsInstance(1, collections_abc.Mapping)
-        self.assertNotIsInstance(1, collections_abc.Iterable)
-        self.assertNotIsInstance(1, collections_abc.Container)
-        self.assertNotIsInstance(1, collections_abc.Sized)
+        self.assertNotIsInstance(1, collections.abc.Mapping)
+        self.assertNotIsInstance(1, collections.abc.Iterable)
+        self.assertNotIsInstance(1, collections.abc.Container)
+        self.assertNotIsInstance(1, collections.abc.Sized)
         with self.assertRaises(TypeError):
             isinstance(collections.deque(), typing_extensions.Deque[int])
         with self.assertRaises(TypeError):
@@ -723,15 +710,15 @@ class CollectionsAbcTests(BaseTestCase):
         g = ns['g']
         self.assertIsSubclass(G, typing_extensions.AsyncGenerator)
         self.assertIsSubclass(G, typing_extensions.AsyncIterable)
-        self.assertIsSubclass(G, collections_abc.AsyncGenerator)
-        self.assertIsSubclass(G, collections_abc.AsyncIterable)
+        self.assertIsSubclass(G, collections.abc.AsyncGenerator)
+        self.assertIsSubclass(G, collections.abc.AsyncIterable)
         self.assertNotIsSubclass(type(g), G)
 
         instance = G()
         self.assertIsInstance(instance, typing_extensions.AsyncGenerator)
         self.assertIsInstance(instance, typing_extensions.AsyncIterable)
-        self.assertIsInstance(instance, collections_abc.AsyncGenerator)
-        self.assertIsInstance(instance, collections_abc.AsyncIterable)
+        self.assertIsInstance(instance, collections.abc.AsyncGenerator)
+        self.assertIsInstance(instance, collections.abc.AsyncIterable)
         self.assertNotIsInstance(type(g), G)
         self.assertNotIsInstance(g, G)
 

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -40,27 +40,18 @@ try:
 except ImportError:
     OLD_GENERICS = True
 
-# We assume Python versions *below* 3.5.0 will have the most
-# up-to-date version of the typing module installed. Since
-# the typing module isn't a part of the standard library in older
-# versions of Python, those users are likely to have a reasonably
-# modern version of `typing` installed from PyPi.
-TYPING_LATEST = sys.version_info[:3] < (3, 5, 0)
-
 # Flags used to mark tests that only apply after a specific
 # version of the typing module.
-TYPING_3_5_1 = TYPING_LATEST or sys.version_info[:3] >= (3, 5, 1)
-TYPING_3_5_3 = TYPING_LATEST or sys.version_info[:3] >= (3, 5, 3)
-TYPING_3_6_1 = TYPING_LATEST or sys.version_info[:3] >= (3, 6, 1)
-TYPING_3_10_0 = TYPING_LATEST or sys.version_info[:3] >= (3, 10, 0)
-TYPING_3_11_0 = TYPING_LATEST or sys.version_info[:3] >= (3, 11, 0)
+TYPING_3_6_1 = sys.version_info[:3] >= (3, 6, 1)
+TYPING_3_10_0 = sys.version_info[:3] >= (3, 10, 0)
+TYPING_3_11_0 = sys.version_info[:3] >= (3, 11, 0)
 
 # For typing versions where issubclass(...) and
 # isinstance(...) checks are forbidden.
 #
 # See https://github.com/python/typing/issues/136
 # and https://github.com/python/typing/pull/283
-SUBCLASS_CHECK_FORBIDDEN = TYPING_3_5_3
+SUBCLASS_CHECK_FORBIDDEN = True
 
 # For typing versions where instantiating collection
 # types are allowed.
@@ -654,8 +645,7 @@ class CollectionsAbcTests(BaseTestCase):
     def test_async_iterator(self):
         base_it = range(10)  # type: Iterator[int]
         it = AsyncIteratorWrapper(base_it)
-        if TYPING_3_5_1:
-            self.assertIsInstance(it, typing_extensions.AsyncIterator)
+        self.assertIsInstance(it, typing_extensions.AsyncIterator)
         self.assertNotIsInstance(42, typing_extensions.AsyncIterator)
 
     def test_deque(self):
@@ -687,8 +677,7 @@ class CollectionsAbcTests(BaseTestCase):
         self.assertIsInstance(dd, MyDefDict)
 
         self.assertIsSubclass(MyDefDict, collections.defaultdict)
-        if TYPING_3_5_3:
-            self.assertNotIsSubclass(collections.defaultdict, MyDefDict)
+        self.assertNotIsSubclass(collections.defaultdict, MyDefDict)
 
     @skipUnless(CAN_INSTANTIATE_COLLECTIONS, "Behavior added in typing 3.6.1")
     def test_ordereddict_instantiation(self):
@@ -711,16 +700,14 @@ class CollectionsAbcTests(BaseTestCase):
         self.assertIsInstance(od, MyOrdDict)
 
         self.assertIsSubclass(MyOrdDict, collections.OrderedDict)
-        if TYPING_3_5_3:
-            self.assertNotIsSubclass(collections.OrderedDict, MyOrdDict)
+        self.assertNotIsSubclass(collections.OrderedDict, MyOrdDict)
 
     def test_chainmap_instantiation(self):
         self.assertIs(type(typing_extensions.ChainMap()), collections.ChainMap)
         self.assertIs(type(typing_extensions.ChainMap[KT, VT]()), collections.ChainMap)
         self.assertIs(type(typing_extensions.ChainMap[str, int]()), collections.ChainMap)
         class CM(typing_extensions.ChainMap[KT, VT]): ...
-        if TYPING_3_5_3:
-            self.assertIs(type(CM[int, str]()), CM)
+        self.assertIs(type(CM[int, str]()), CM)
 
     def test_chainmap_subclass(self):
 
@@ -731,28 +718,25 @@ class CollectionsAbcTests(BaseTestCase):
         self.assertIsInstance(cm, MyChainMap)
 
         self.assertIsSubclass(MyChainMap, collections.ChainMap)
-        if TYPING_3_5_3:
-            self.assertNotIsSubclass(collections.ChainMap, MyChainMap)
+        self.assertNotIsSubclass(collections.ChainMap, MyChainMap)
 
     def test_deque_instantiation(self):
         self.assertIs(type(typing_extensions.Deque()), collections.deque)
         self.assertIs(type(typing_extensions.Deque[T]()), collections.deque)
         self.assertIs(type(typing_extensions.Deque[int]()), collections.deque)
         class D(typing_extensions.Deque[T]): ...
-        if TYPING_3_5_3:
-            self.assertIs(type(D[int]()), D)
+        self.assertIs(type(D[int]()), D)
 
     def test_counter_instantiation(self):
         self.assertIs(type(typing_extensions.Counter()), collections.Counter)
         self.assertIs(type(typing_extensions.Counter[T]()), collections.Counter)
         self.assertIs(type(typing_extensions.Counter[int]()), collections.Counter)
         class C(typing_extensions.Counter[T]): ...
-        if TYPING_3_5_3:
-            self.assertIs(type(C[int]()), C)
-            if not PEP_560:
-                self.assertEqual(C.__bases__, (typing_extensions.Counter,))
-            else:
-                self.assertEqual(C.__bases__, (collections.Counter, typing.Generic))
+        self.assertIs(type(C[int]()), C)
+        if not PEP_560:
+            self.assertEqual(C.__bases__, (typing_extensions.Counter,))
+        else:
+            self.assertEqual(C.__bases__, (collections.Counter, typing.Generic))
 
     def test_counter_subclass_instantiation(self):
 
@@ -762,8 +746,7 @@ class CollectionsAbcTests(BaseTestCase):
         d = MyCounter()
         self.assertIsInstance(d, MyCounter)
         self.assertIsInstance(d, collections.Counter)
-        if TYPING_3_5_1:
-            self.assertIsInstance(d, typing_extensions.Counter)
+        self.assertIsInstance(d, typing_extensions.Counter)
 
     @skipUnless(PY36, 'Python 3.6 required')
     def test_async_generator(self):
@@ -831,8 +814,7 @@ class OtherABCTests(BaseTestCase):
 
         cm = manager()
         self.assertNotIsInstance(cm, typing_extensions.AsyncContextManager)
-        if TYPING_3_5_3:
-            self.assertEqual(typing_extensions.AsyncContextManager[int].__args__, (int,))
+        self.assertEqual(typing_extensions.AsyncContextManager[int].__args__, (int,))
         if TYPING_3_6_1:
             with self.assertRaises(TypeError):
                 isinstance(42, typing_extensions.AsyncContextManager[int])
@@ -1323,9 +1305,8 @@ if HAVE_PROTOCOLS:
                 P[int, str]
             with self.assertRaises(TypeError):
                 PR[int, 1]
-            if TYPING_3_5_3:
-                with self.assertRaises(TypeError):
-                    PR[int, ClassVar]
+            with self.assertRaises(TypeError):
+                PR[int, ClassVar]
             class C(PR[int, T]): pass
             self.assertIsInstance(C[str](), C)
 
@@ -1360,7 +1341,7 @@ if HAVE_PROTOCOLS:
                 def bar(self, x: str) -> str:
                     return x
             self.assertIsInstance(Test(), PSub)
-            if TYPING_3_5_3 and not TYPING_3_10_0:
+            if not TYPING_3_10_0:
                 with self.assertRaises(TypeError):
                     PR[int, ClassVar]
 
@@ -1385,7 +1366,6 @@ if HAVE_PROTOCOLS:
             with self.assertRaises(TypeError):
                 class P(typing.Mapping[T, S], Protocol[T]): pass
 
-        @skipUnless(TYPING_3_5_3, 'New style __repr__ and __eq__ only')
         def test_generic_protocols_repr(self):
             T = TypeVar('T')
             S = TypeVar('S')
@@ -1396,7 +1376,6 @@ if HAVE_PROTOCOLS:
             self.assertTrue(repr(P[T, S]).endswith('P[~T, ~S]'))
             self.assertTrue(repr(P[int, str]).endswith('P[int, str]'))
 
-        @skipUnless(TYPING_3_5_3, 'New style __repr__ and __eq__ only')
         def test_generic_protocols_eq(self):
             T = TypeVar('T')
             S = TypeVar('S')
@@ -1704,7 +1683,6 @@ class TypedDictTests(BaseTestCase):
         }
 
 
-@skipUnless(TYPING_3_5_3, "Python >= 3.5.3 required")
 class AnnotatedTests(BaseTestCase):
 
     def test_repr(self):
@@ -2214,8 +2192,7 @@ class AllTests(BaseTestCase):
         self.assertIn('ParamSpec', a)
         self.assertIn("Concatenate", a)
 
-        if TYPING_3_5_3:
-            self.assertIn('Annotated', a)
+        self.assertIn('Annotated', a)
         if PEP_560:
             self.assertIn('get_type_hints', a)
 
@@ -2229,9 +2206,8 @@ class AllTests(BaseTestCase):
         if PY36:
             self.assertIn('AsyncGenerator', a)
 
-        if TYPING_3_5_3:
-            self.assertIn('Protocol', a)
-            self.assertIn('runtime', a)
+        self.assertIn('Protocol', a)
+        self.assertIn('runtime', a)
 
         # Check that all objects in `__all__` are present in the module
         for name in a:

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -49,14 +49,14 @@ CAN_INSTANTIATE_COLLECTIONS = TYPING_3_6_1
 class BaseTestCase(TestCase):
     def assertIsSubclass(self, cls, class_or_tuple, msg=None):
         if not issubclass(cls, class_or_tuple):
-            message = f'{repr(cls)} is not a subclass of {repr(class_or_tuple)}'
+            message = f'{cls!r} is not a subclass of {repr(class_or_tuple)}'
             if msg is not None:
                 message += f' : {msg}'
             raise self.failureException(message)
 
     def assertNotIsSubclass(self, cls, class_or_tuple, msg=None):
         if issubclass(cls, class_or_tuple):
-            message = f'{repr(cls)} is a subclass of {repr(class_or_tuple)}'
+            message = f'{cls!r} is a subclass of {repr(class_or_tuple)}'
             if msg is not None:
                 message += f' : {msg}'
             raise self.failureException(message)

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -7,13 +7,15 @@ import pickle
 import subprocess
 import types
 from unittest import TestCase, main, skipUnless, skipIf
+from test import ann_module, ann_module2, ann_module3
 from typing import TypeVar, Optional, Union
 from typing import T, KT, VT  # Not in __all__.
-from typing import Tuple, List, Dict, Iterator, Callable
-from typing import Generic
+from typing import Tuple, List, Dict, Iterable, Iterator, Callable
+from typing import Generic, NamedTuple
 from typing import no_type_check
 from typing_extensions import NoReturn, ClassVar, Final, IntVar, Literal, Type, NewType, TypedDict
 from typing_extensions import TypeAlias, ParamSpec, Concatenate, ParamSpecArgs, ParamSpecKwargs, TypeGuard
+from typing_extensions import Awaitable, AsyncIterator, AsyncContextManager
 
 try:
     from typing_extensions import Protocol, runtime, runtime_checkable
@@ -302,8 +304,6 @@ class OverloadTests(BaseTestCase):
         blah()
 
 
-from typing import Iterable
-from typing_extensions import Awaitable, AsyncIterator
 
 T_a = TypeVar('T_a')
 
@@ -334,13 +334,11 @@ class AsyncIteratorWrapper(AsyncIterator[T_a]):
 class ACM:
     async def __aenter__(self) -> int:
         return 42
+
     async def __aexit__(self, etype, eval, tb):
         return None
 
 
-from test import ann_module, ann_module2, ann_module3
-from typing_extensions import AsyncContextManager
-from typing import NamedTuple
 
 class A:
     y: float
@@ -363,8 +361,10 @@ class NoneAndForward:
 class XRepr(NamedTuple):
     x: int
     y: int = 1
+
     def __str__(self):
         return f'{self.x} -> {self.y}'
+
     def __add__(self, other):
         return 0
 
@@ -407,6 +407,7 @@ class Animal(BaseAnimal, total=False):
 
 class Cat(Animal):
     fur_color: str
+
 
 gth = get_type_hints
 
@@ -849,6 +850,7 @@ class Position(XAxis, YAxis, Protocol):
 @runtime
 class Proto(Protocol):
     attr: int
+
     def meth(self, arg: str) -> int:
         ...
 
@@ -857,6 +859,7 @@ class Concrete(Proto):
 
 class Other:
     attr: int = 1
+
     def meth(self, arg: str) -> int:
         if arg == 'this':
             return 1

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -46,13 +46,6 @@ TYPING_3_6_1 = sys.version_info[:3] >= (3, 6, 1)
 TYPING_3_10_0 = sys.version_info[:3] >= (3, 10, 0)
 TYPING_3_11_0 = sys.version_info[:3] >= (3, 11, 0)
 
-# For typing versions where issubclass(...) and
-# isinstance(...) checks are forbidden.
-#
-# See https://github.com/python/typing/issues/136
-# and https://github.com/python/typing/pull/283
-SUBCLASS_CHECK_FORBIDDEN = True
-
 # For typing versions where instantiating collection
 # types are allowed.
 #
@@ -99,7 +92,6 @@ class NoReturnTests(BaseTestCase):
         with self.assertRaises(TypeError):
             issubclass(Employee, NoReturn)
 
-    @skipUnless(SUBCLASS_CHECK_FORBIDDEN, "Behavior added in typing 3.5.3")
     def test_noreturn_subclass_type_error_2(self):
         with self.assertRaises(TypeError):
             issubclass(NoReturn, Employee)
@@ -118,10 +110,9 @@ class NoReturnTests(BaseTestCase):
         with self.assertRaises(TypeError):
             class A(NoReturn):
                 pass
-        if SUBCLASS_CHECK_FORBIDDEN:
-            with self.assertRaises(TypeError):
-                class A(type(NoReturn)):
-                    pass
+        with self.assertRaises(TypeError):
+            class A(type(NoReturn)):
+                pass
 
     def test_cannot_instantiate(self):
         with self.assertRaises(TypeError):
@@ -151,7 +142,6 @@ class ClassVarTests(BaseTestCase):
         cv = ClassVar[Employee]
         self.assertEqual(repr(cv), mod_name + '.ClassVar[%s.Employee]' % __name__)
 
-    @skipUnless(SUBCLASS_CHECK_FORBIDDEN, "Behavior added in typing 3.5.3")
     def test_cannot_subclass(self):
         with self.assertRaises(TypeError):
             class C(type(ClassVar)):
@@ -196,7 +186,6 @@ class FinalTests(BaseTestCase):
         cv = Final[Employee]
         self.assertEqual(repr(cv), mod_name + '.Final[%s.Employee]' % __name__)
 
-    @skipUnless(SUBCLASS_CHECK_FORBIDDEN, "Behavior added in typing 3.5.3")
     def test_cannot_subclass(self):
         with self.assertRaises(TypeError):
             class C(type(Final)):
@@ -596,11 +585,10 @@ class CollectionsAbcTests(BaseTestCase):
         self.assertNotIsInstance(1, collections_abc.Iterable)
         self.assertNotIsInstance(1, collections_abc.Container)
         self.assertNotIsInstance(1, collections_abc.Sized)
-        if SUBCLASS_CHECK_FORBIDDEN:
-            with self.assertRaises(TypeError):
-                isinstance(collections.deque(), typing_extensions.Deque[int])
-            with self.assertRaises(TypeError):
-                issubclass(collections.Counter, typing_extensions.Counter[str])
+        with self.assertRaises(TypeError):
+            isinstance(collections.deque(), typing_extensions.Deque[int])
+        with self.assertRaises(TypeError):
+            issubclass(collections.Counter, typing_extensions.Counter[str])
 
     @skipUnless(ASYNCIO, 'Python 3.5 and multithreading required')
     def test_awaitable(self):
@@ -1945,19 +1933,17 @@ class TypeAliasTests(BaseTestCase):
         with self.assertRaises(TypeError):
             issubclass(Employee, TypeAlias)
 
-        if SUBCLASS_CHECK_FORBIDDEN:
-            with self.assertRaises(TypeError):
-                issubclass(TypeAlias, Employee)
+        with self.assertRaises(TypeError):
+            issubclass(TypeAlias, Employee)
 
     def test_cannot_subclass(self):
         with self.assertRaises(TypeError):
             class C(TypeAlias):
                 pass
 
-        if SUBCLASS_CHECK_FORBIDDEN:
-            with self.assertRaises(TypeError):
-                class C(type(TypeAlias)):
-                    pass
+        with self.assertRaises(TypeError):
+            class C(type(TypeAlias)):
+                pass
 
     def test_repr(self):
         if hasattr(typing, 'TypeAlias'):
@@ -2149,7 +2135,6 @@ class TypeGuardTests(BaseTestCase):
         cv = TypeGuard[Tuple[int]]
         self.assertEqual(repr(cv), '{}.TypeGuard[typing.Tuple[int]]'.format(mod_name))
 
-    @skipUnless(SUBCLASS_CHECK_FORBIDDEN, "Behavior added in typing 3.5.3")
     def test_cannot_subclass(self):
         with self.assertRaises(TypeError):
             class C(type(TypeGuard)):

--- a/typing_extensions/src_py3/test_typing_extensions.py
+++ b/typing_extensions/src_py3/test_typing_extensions.py
@@ -791,8 +791,6 @@ class TypeTests(BaseTestCase):
 
         new_user(BasicUser)
 
-    @skipUnless(sys.version_info[:3] != (3, 5, 2),
-                'Python 3.5.2 has a somewhat buggy Type impl')
     def test_type_optional(self):
         A = Optional[Type[BaseException]]
 
@@ -1453,9 +1451,7 @@ class TypedDictTests(BaseTestCase):
         Emp = TypedDict('Emp', {'name': str, 'id': int})
         self.assertIsSubclass(Emp, dict)
         self.assertIsSubclass(Emp, typing.MutableMapping)
-        if sys.version_info[0] >= 3:
-            import collections.abc
-            self.assertNotIsSubclass(Emp, collections.abc.Sequence)
+        self.assertNotIsSubclass(Emp, collections.abc.Sequence)
         jim = Emp(name='Jim', id=1)
         self.assertIs(type(jim), dict)
         self.assertEqual(jim['name'], 'Jim')
@@ -1470,9 +1466,7 @@ class TypedDictTests(BaseTestCase):
         Emp = TypedDict('Emp', name=str, id=int)
         self.assertIsSubclass(Emp, dict)
         self.assertIsSubclass(Emp, typing.MutableMapping)
-        if sys.version_info[0] >= 3:
-            import collections.abc
-            self.assertNotIsSubclass(Emp, collections.abc.Sequence)
+        self.assertNotIsSubclass(Emp, collections.abc.Sequence)
         jim = Emp(name='Jim', id=1)
         self.assertIs(type(jim), dict)
         self.assertEqual(jim['name'], 'Jim')
@@ -1919,16 +1913,11 @@ class ParamSpecTests(BaseTestCase):
         P = ParamSpec('P')
         T = TypeVar('T')
         C1 = typing.Callable[P, int]
-        # Callable in Python 3.5.2 might be bugged when collecting __args__.
-        # https://github.com/python/cpython/blob/91185fe0284a04162e0b3425b53be49bdbfad67d/Lib/typing.py#L1026
-        PY_3_5_2 = sys.version_info[:3] == (3, 5, 2)
-        if not PY_3_5_2:
-            self.assertEqual(C1.__args__, (P, int))
-            self.assertEqual(C1.__parameters__, (P,))
+        self.assertEqual(C1.__args__, (P, int))
+        self.assertEqual(C1.__parameters__, (P,))
         C2 = typing.Callable[P, T]
-        if not PY_3_5_2:
-            self.assertEqual(C2.__args__, (P, T))
-            self.assertEqual(C2.__parameters__, (P, T))
+        self.assertEqual(C2.__args__, (P, T))
+        self.assertEqual(C2.__parameters__, (P, T))
 
 
         # Test collections.abc.Callable too.

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -6,7 +6,7 @@ import typing
 
 # After PEP 560, internal typing API was substantially reworked.
 # This is especially important for Protocol class which uses internal APIs
-# quite extensivelly.
+# quite extensively.
 PEP_560 = sys.version_info[:3] >= (3, 7, 0)
 
 if PEP_560:

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -508,8 +508,192 @@ def _is_callable_members_only(cls):
 # 3.8+
 if hasattr(typing, 'Protocol'):
     Protocol = typing.Protocol
+# 3.7
+elif PEP_560:
+    from typing import _collect_type_vars  # noqa
+
+    def _no_init(self, *args, **kwargs):
+        if type(self)._is_protocol:
+            raise TypeError('Protocols cannot be instantiated')
+
+    class _ProtocolMeta(abc.ABCMeta):
+        # This metaclass is a bit unfortunate and exists only because of the lack
+        # of __instancehook__.
+        def __instancecheck__(cls, instance):
+            # We need this method for situations where attributes are
+            # assigned in __init__.
+            if ((not getattr(cls, '_is_protocol', False) or
+                 _is_callable_members_only(cls)) and
+                    issubclass(instance.__class__, cls)):
+                return True
+            if cls._is_protocol:
+                if all(hasattr(instance, attr) and
+                       (not callable(getattr(cls, attr, None)) or
+                        getattr(instance, attr) is not None)
+                       for attr in _get_protocol_attrs(cls)):
+                    return True
+            return super().__instancecheck__(instance)
+
+    class Protocol(metaclass=_ProtocolMeta):
+        # There is quite a lot of overlapping code with typing.Generic.
+        # Unfortunately it is hard to avoid this while these live in two different
+        # modules. The duplicated code will be removed when Protocol is moved to typing.
+        """Base class for protocol classes. Protocol classes are defined as::
+
+            class Proto(Protocol):
+                def meth(self) -> int:
+                    ...
+
+        Such classes are primarily used with static type checkers that recognize
+        structural subtyping (static duck-typing), for example::
+
+            class C:
+                def meth(self) -> int:
+                    return 0
+
+            def func(x: Proto) -> int:
+                return x.meth()
+
+            func(C())  # Passes static type check
+
+        See PEP 544 for details. Protocol classes decorated with
+        @typing_extensions.runtime act as simple-minded runtime protocol that checks
+        only the presence of given attributes, ignoring their type signatures.
+
+        Protocol classes can be generic, they are defined as::
+
+            class GenProto(Protocol[T]):
+                def meth(self) -> T:
+                    ...
+        """
+        __slots__ = ()
+        _is_protocol = True
+
+        def __new__(cls, *args, **kwds):
+            if cls is Protocol:
+                raise TypeError("Type Protocol cannot be instantiated; "
+                                "it can only be used as a base class")
+            return super().__new__(cls)
+
+        @_tp_cache
+        def __class_getitem__(cls, params):
+            if not isinstance(params, tuple):
+                params = (params,)
+            if not params and cls is not typing.Tuple:
+                raise TypeError(
+                    f"Parameter list to {cls.__qualname__}[...] cannot be empty")
+            msg = "Parameters to generic types must be types."
+            params = tuple(typing._type_check(p, msg) for p in params)  # noqa
+            if cls is Protocol:
+                # Generic can only be subscripted with unique type variables.
+                if not all(isinstance(p, typing.TypeVar) for p in params):
+                    i = 0
+                    while isinstance(params[i], typing.TypeVar):
+                        i += 1
+                    raise TypeError(
+                        "Parameters to Protocol[...] must all be type variables."
+                        f" Parameter {i + 1} is {params[i]}")
+                if len(set(params)) != len(params):
+                    raise TypeError(
+                        "Parameters to Protocol[...] must all be unique")
+            else:
+                # Subscripting a regular Generic subclass.
+                _check_generic(cls, params)
+            return _GenericAlias(cls, params)
+
+        def __init_subclass__(cls, *args, **kwargs):
+            tvars = []
+            if '__orig_bases__' in cls.__dict__:
+                error = typing.Generic in cls.__orig_bases__
+            else:
+                error = typing.Generic in cls.__bases__
+            if error:
+                raise TypeError("Cannot inherit from plain Generic")
+            if '__orig_bases__' in cls.__dict__:
+                tvars = _collect_type_vars(cls.__orig_bases__)
+                # Look for Generic[T1, ..., Tn] or Protocol[T1, ..., Tn].
+                # If found, tvars must be a subset of it.
+                # If not found, tvars is it.
+                # Also check for and reject plain Generic,
+                # and reject multiple Generic[...] and/or Protocol[...].
+                gvars = None
+                for base in cls.__orig_bases__:
+                    if (isinstance(base, _GenericAlias) and
+                            base.__origin__ in (typing.Generic, Protocol)):
+                        # for error messages
+                        the_base = base.__origin__.__name__
+                        if gvars is not None:
+                            raise TypeError(
+                                "Cannot inherit from Generic[...]"
+                                " and/or Protocol[...] multiple types.")
+                        gvars = base.__parameters__
+                if gvars is None:
+                    gvars = tvars
+                else:
+                    tvarset = set(tvars)
+                    gvarset = set(gvars)
+                    if not tvarset <= gvarset:
+                        s_vars = ', '.join(str(t) for t in tvars if t not in gvarset)
+                        s_args = ', '.join(str(g) for g in gvars)
+                        raise TypeError(f"Some type variables ({s_vars}) are"
+                                        f" not listed in {the_base}[{s_args}]")
+                    tvars = gvars
+            cls.__parameters__ = tuple(tvars)
+
+            # Determine if this is a protocol or a concrete subclass.
+            if not cls.__dict__.get('_is_protocol', None):
+                cls._is_protocol = any(b is Protocol for b in cls.__bases__)
+
+            # Set (or override) the protocol subclass hook.
+            def _proto_hook(other):
+                if not cls.__dict__.get('_is_protocol', None):
+                    return NotImplemented
+                if not getattr(cls, '_is_runtime_protocol', False):
+                    if sys._getframe(2).f_globals['__name__'] in ['abc', 'functools']:
+                        return NotImplemented
+                    raise TypeError("Instance and class checks can only be used with"
+                                    " @runtime protocols")
+                if not _is_callable_members_only(cls):
+                    if sys._getframe(2).f_globals['__name__'] in ['abc', 'functools']:
+                        return NotImplemented
+                    raise TypeError("Protocols with non-method members"
+                                    " don't support issubclass()")
+                if not isinstance(other, type):
+                    # Same error as for issubclass(1, int)
+                    raise TypeError('issubclass() arg 1 must be a class')
+                for attr in _get_protocol_attrs(cls):
+                    for base in other.__mro__:
+                        if attr in base.__dict__:
+                            if base.__dict__[attr] is None:
+                                return NotImplemented
+                            break
+                        annotations = getattr(base, '__annotations__', {})
+                        if (isinstance(annotations, typing.Mapping) and
+                                attr in annotations and
+                                isinstance(other, _ProtocolMeta) and
+                                other._is_protocol):
+                            break
+                    else:
+                        return NotImplemented
+                return True
+            if '__subclasshook__' not in cls.__dict__:
+                cls.__subclasshook__ = _proto_hook
+
+            # We have nothing more to do for non-protocols.
+            if not cls._is_protocol:
+                return
+
+            # Check consistency of bases.
+            for base in cls.__bases__:
+                if not (base in (object, typing.Generic) or
+                        base.__module__ == 'collections.abc' and
+                        base.__name__ in _PROTO_WHITELIST or
+                        isinstance(base, _ProtocolMeta) and base._is_protocol):
+                    raise TypeError('Protocols can only inherit from other'
+                                    f' protocols, got {repr(base)}')
+            cls.__init__ = _no_init
 # 3.6
-elif not PEP_560:
+else:
     from typing import _next_in_mro, _type_check  # noqa
 
     def _no_init(self, *args, **kwargs):
@@ -746,190 +930,6 @@ elif not PEP_560:
                 raise TypeError("Type Protocol cannot be instantiated; "
                                 "it can be used only as a base class")
             return typing._generic_new(cls.__next_in_mro__, cls, *args, **kwds)
-# 3.7
-else:
-    from typing import _collect_type_vars  # noqa
-
-    def _no_init(self, *args, **kwargs):
-        if type(self)._is_protocol:
-            raise TypeError('Protocols cannot be instantiated')
-
-    class _ProtocolMeta(abc.ABCMeta):
-        # This metaclass is a bit unfortunate and exists only because of the lack
-        # of __instancehook__.
-        def __instancecheck__(cls, instance):
-            # We need this method for situations where attributes are
-            # assigned in __init__.
-            if ((not getattr(cls, '_is_protocol', False) or
-                    _is_callable_members_only(cls)) and
-                    issubclass(instance.__class__, cls)):
-                return True
-            if cls._is_protocol:
-                if all(hasattr(instance, attr) and
-                        (not callable(getattr(cls, attr, None)) or
-                         getattr(instance, attr) is not None)
-                        for attr in _get_protocol_attrs(cls)):
-                    return True
-            return super().__instancecheck__(instance)
-
-    class Protocol(metaclass=_ProtocolMeta):
-        # There is quite a lot of overlapping code with typing.Generic.
-        # Unfortunately it is hard to avoid this while these live in two different
-        # modules. The duplicated code will be removed when Protocol is moved to typing.
-        """Base class for protocol classes. Protocol classes are defined as::
-
-            class Proto(Protocol):
-                def meth(self) -> int:
-                    ...
-
-        Such classes are primarily used with static type checkers that recognize
-        structural subtyping (static duck-typing), for example::
-
-            class C:
-                def meth(self) -> int:
-                    return 0
-
-            def func(x: Proto) -> int:
-                return x.meth()
-
-            func(C())  # Passes static type check
-
-        See PEP 544 for details. Protocol classes decorated with
-        @typing_extensions.runtime act as simple-minded runtime protocol that checks
-        only the presence of given attributes, ignoring their type signatures.
-
-        Protocol classes can be generic, they are defined as::
-
-            class GenProto(Protocol[T]):
-                def meth(self) -> T:
-                    ...
-        """
-        __slots__ = ()
-        _is_protocol = True
-
-        def __new__(cls, *args, **kwds):
-            if cls is Protocol:
-                raise TypeError("Type Protocol cannot be instantiated; "
-                                "it can only be used as a base class")
-            return super().__new__(cls)
-
-        @_tp_cache
-        def __class_getitem__(cls, params):
-            if not isinstance(params, tuple):
-                params = (params,)
-            if not params and cls is not typing.Tuple:
-                raise TypeError(
-                    f"Parameter list to {cls.__qualname__}[...] cannot be empty")
-            msg = "Parameters to generic types must be types."
-            params = tuple(typing._type_check(p, msg) for p in params)  # noqa
-            if cls is Protocol:
-                # Generic can only be subscripted with unique type variables.
-                if not all(isinstance(p, typing.TypeVar) for p in params):
-                    i = 0
-                    while isinstance(params[i], typing.TypeVar):
-                        i += 1
-                    raise TypeError(
-                        "Parameters to Protocol[...] must all be type variables."
-                        f" Parameter {i + 1} is {params[i]}")
-                if len(set(params)) != len(params):
-                    raise TypeError(
-                        "Parameters to Protocol[...] must all be unique")
-            else:
-                # Subscripting a regular Generic subclass.
-                _check_generic(cls, params)
-            return _GenericAlias(cls, params)
-
-        def __init_subclass__(cls, *args, **kwargs):
-            tvars = []
-            if '__orig_bases__' in cls.__dict__:
-                error = typing.Generic in cls.__orig_bases__
-            else:
-                error = typing.Generic in cls.__bases__
-            if error:
-                raise TypeError("Cannot inherit from plain Generic")
-            if '__orig_bases__' in cls.__dict__:
-                tvars = _collect_type_vars(cls.__orig_bases__)
-                # Look for Generic[T1, ..., Tn] or Protocol[T1, ..., Tn].
-                # If found, tvars must be a subset of it.
-                # If not found, tvars is it.
-                # Also check for and reject plain Generic,
-                # and reject multiple Generic[...] and/or Protocol[...].
-                gvars = None
-                for base in cls.__orig_bases__:
-                    if (isinstance(base, _GenericAlias) and
-                            base.__origin__ in (typing.Generic, Protocol)):
-                        # for error messages
-                        the_base = base.__origin__.__name__
-                        if gvars is not None:
-                            raise TypeError(
-                                "Cannot inherit from Generic[...]"
-                                " and/or Protocol[...] multiple types.")
-                        gvars = base.__parameters__
-                if gvars is None:
-                    gvars = tvars
-                else:
-                    tvarset = set(tvars)
-                    gvarset = set(gvars)
-                    if not tvarset <= gvarset:
-                        s_vars = ', '.join(str(t) for t in tvars if t not in gvarset)
-                        s_args = ', '.join(str(g) for g in gvars)
-                        raise TypeError(f"Some type variables ({s_vars}) are"
-                                        f" not listed in {the_base}[{s_args}]")
-                    tvars = gvars
-            cls.__parameters__ = tuple(tvars)
-
-            # Determine if this is a protocol or a concrete subclass.
-            if not cls.__dict__.get('_is_protocol', None):
-                cls._is_protocol = any(b is Protocol for b in cls.__bases__)
-
-            # Set (or override) the protocol subclass hook.
-            def _proto_hook(other):
-                if not cls.__dict__.get('_is_protocol', None):
-                    return NotImplemented
-                if not getattr(cls, '_is_runtime_protocol', False):
-                    if sys._getframe(2).f_globals['__name__'] in ['abc', 'functools']:
-                        return NotImplemented
-                    raise TypeError("Instance and class checks can only be used with"
-                                    " @runtime protocols")
-                if not _is_callable_members_only(cls):
-                    if sys._getframe(2).f_globals['__name__'] in ['abc', 'functools']:
-                        return NotImplemented
-                    raise TypeError("Protocols with non-method members"
-                                    " don't support issubclass()")
-                if not isinstance(other, type):
-                    # Same error as for issubclass(1, int)
-                    raise TypeError('issubclass() arg 1 must be a class')
-                for attr in _get_protocol_attrs(cls):
-                    for base in other.__mro__:
-                        if attr in base.__dict__:
-                            if base.__dict__[attr] is None:
-                                return NotImplemented
-                            break
-                        annotations = getattr(base, '__annotations__', {})
-                        if (isinstance(annotations, typing.Mapping) and
-                                attr in annotations and
-                                isinstance(other, _ProtocolMeta) and
-                                other._is_protocol):
-                            break
-                    else:
-                        return NotImplemented
-                return True
-            if '__subclasshook__' not in cls.__dict__:
-                cls.__subclasshook__ = _proto_hook
-
-            # We have nothing more to do for non-protocols.
-            if not cls._is_protocol:
-                return
-
-            # Check consistency of bases.
-            for base in cls.__bases__:
-                if not (base in (object, typing.Generic) or
-                        base.__module__ == 'collections.abc' and
-                        base.__name__ in _PROTO_WHITELIST or
-                        isinstance(base, _ProtocolMeta) and base._is_protocol):
-                    raise TypeError('Protocols can only inherit from other'
-                                    f' protocols, got {repr(base)}')
-            cls.__init__ = _no_init
 
 
 # 3.8+

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -4,7 +4,6 @@ import collections
 import collections.abc
 import sys
 import typing
-from typing import _tp_cache, _TypingEllipsis, _TypingEmpty  # noqa
 import operator
 
 # After PEP 560, internal typing API was substantially reworked.
@@ -575,7 +574,7 @@ elif PEP_560:
                                 "it can only be used as a base class")
             return super().__new__(cls)
 
-        @_tp_cache
+        @typing._tp_cache
         def __class_getitem__(cls, params):
             if not isinstance(params, tuple):
                 params = (params,)
@@ -756,8 +755,8 @@ else:
                                                  self if not origin else
                                                  _gorg(origin))
             self.__parameters__ = tvars
-            self.__args__ = tuple(... if a is _TypingEllipsis else
-                                  () if a is _TypingEmpty else
+            self.__args__ = tuple(... if a is typing._TypingEllipsis else
+                                  () if a is typing._TypingEmpty else
                                   a for a in args) if args else None
             self.__next_in_mro__ = _next_in_mro(self)
             if orig_bases is None:
@@ -853,7 +852,7 @@ else:
                                 " don't support issubclass()")
             return super(GenericMeta, self).__subclasscheck__(cls)
 
-        @_tp_cache
+        @typing._tp_cache
         def __getitem__(self, params):
             # We also need to copy this from GenericMeta.__getitem__ to get
             # special treatment of "Protocol". (Comments removed for brevity.)
@@ -1209,7 +1208,7 @@ elif PEP_560:
         def __new__(cls, *args, **kwargs):
             raise TypeError("Type Annotated cannot be instantiated.")
 
-        @_tp_cache
+        @typing._tp_cache
         def __class_getitem__(cls, params):
             if not isinstance(params, tuple) or len(params) < 2:
                 raise TypeError("Annotated[...] should be used "
@@ -1330,7 +1329,7 @@ else:
             else:
                 return tree
 
-        @_tp_cache
+        @typing._tp_cache
         def __getitem__(self, params):
             if not isinstance(params, tuple):
                 params = (params,)
@@ -1764,7 +1763,7 @@ if not hasattr(typing, 'Concatenate'):
 
 
 # 3.6-3.9
-@_tp_cache
+@typing._tp_cache
 def _concatenate_getitem(self, parameters):
     if parameters == ():
         raise TypeError("Cannot take a Concatenate of no types.")

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -47,25 +47,6 @@ def _check_generic(cls, parameters):
                         f" actual {alen}, expected {elen}")
 
 
-if hasattr(typing, '_generic_new'):
-    _generic_new = typing._generic_new
-else:
-    # Note: The '_generic_new(...)' function is used as a part of the
-    # process of creating a generic type and was added to the typing module
-    # as of Python 3.5.3.
-    #
-    # We've defined '_generic_new(...)' below to exactly match the behavior
-    # implemented in older versions of 'typing' bundled with Python 3.5.0 to
-    # 3.5.2. This helps eliminate redundancy when defining collection types
-    # like 'Deque' later.
-    #
-    # See https://github.com/python/typing/pull/308 for more details -- in
-    # particular, compare and contrast the definition of types like
-    # 'typing.List' before and after the merge.
-
-    def _generic_new(base_cls, cls, *args, **kwargs):
-        return base_cls.__new__(cls, *args, **kwargs)
-
 # Please keep __all__ alphabetized within each category.
 __all__ = [
     # Super-special typing primitives.
@@ -404,7 +385,7 @@ else:
         def __new__(cls, *args, **kwds):
             if cls._gorg is Deque:
                 return collections.deque(*args, **kwds)
-            return _generic_new(collections.deque, cls, *args, **kwds)
+            return typing._generic_new(collections.deque, cls, *args, **kwds)
 
 ContextManager = typing.ContextManager
 # 3.6.2+
@@ -447,7 +428,7 @@ else:
         def __new__(cls, *args, **kwds):
             if cls._gorg is OrderedDict:
                 return collections.OrderedDict(*args, **kwds)
-            return _generic_new(collections.OrderedDict, cls, *args, **kwds)
+            return typing._generic_new(collections.OrderedDict, cls, *args, **kwds)
 
 # 3.6.2+
 if hasattr(typing, 'Counter'):
@@ -463,7 +444,7 @@ else:
         def __new__(cls, *args, **kwds):
             if cls._gorg is Counter:
                 return collections.Counter(*args, **kwds)
-            return _generic_new(collections.Counter, cls, *args, **kwds)
+            return typing._generic_new(collections.Counter, cls, *args, **kwds)
 
 # 3.6.1+
 if hasattr(typing, 'ChainMap'):
@@ -478,7 +459,7 @@ elif hasattr(collections, 'ChainMap'):
         def __new__(cls, *args, **kwds):
             if cls._gorg is ChainMap:
                 return collections.ChainMap(*args, **kwds)
-            return _generic_new(collections.ChainMap, cls, *args, **kwds)
+            return typing._generic_new(collections.ChainMap, cls, *args, **kwds)
 
 # 3.6.1+
 if hasattr(typing, 'AsyncGenerator'):
@@ -773,7 +754,7 @@ elif not PEP_560:
             if _gorg(cls) is Protocol:
                 raise TypeError("Type Protocol cannot be instantiated; "
                                 "it can be used only as a base class")
-            return _generic_new(cls.__next_in_mro__, cls, *args, **kwds)
+            return typing._generic_new(cls.__next_in_mro__, cls, *args, **kwds)
     if Protocol.__doc__ is not None:
         Protocol.__doc__ = Protocol.__doc__.format(bases="Protocol[T]")
 # 3.7

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -363,24 +363,6 @@ Type = typing.Type
 # Various ABCs mimicking those in collections.abc.
 # A few are simply re-exported for completeness.
 
-def _define_guard(type_name):
-    """
-    Returns True if the given type isn't defined in typing but
-    is defined in collections_abc.
-
-    Adds the type to __all__ if the collection is found in either
-    typing or collection_abc.
-    """
-    if hasattr(typing, type_name):
-        __all__.append(type_name)
-        globals()[type_name] = getattr(typing, type_name)
-        return False
-    elif hasattr(collections_abc, type_name):
-        __all__.append(type_name)
-        return True
-    else:
-        return False
-
 
 class _ExtensionsGenericMeta(GenericMeta):
     def __subclasscheck__(self, subclass):

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -121,8 +121,6 @@ T = typing.TypeVar('T')  # Any type.
 KT = typing.TypeVar('KT')  # Key type.
 VT = typing.TypeVar('VT')  # Value type.
 T_co = typing.TypeVar('T_co', covariant=True)  # Any type covariant containers.
-V_co = typing.TypeVar('V_co', covariant=True)  # Any type covariant containers.
-VT_co = typing.TypeVar('VT_co', covariant=True)  # Value type covariant containers.
 T_contra = typing.TypeVar('T_contra', contravariant=True)  # Ditto contravariant.
 
 ClassVar = typing.ClassVar

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -1,3 +1,4 @@
+from _collections_abc import _check_methods as _check_methods_in_mro
 import abc
 import collections
 import contextlib
@@ -94,23 +95,6 @@ if hasattr(typing, '_geqv'):
 else:
     _geqv = None
     _geqv_defined = False
-
-if sys.version_info[:2] >= (3, 6):
-    import _collections_abc
-    _check_methods_in_mro = _collections_abc._check_methods
-else:
-    def _check_methods_in_mro(C, *methods):
-        mro = C.__mro__
-        for method in methods:
-            for B in mro:
-                if method in B.__dict__:
-                    if B.__dict__[method] is None:
-                        return NotImplemented
-                    break
-            else:
-                return NotImplemented
-        return True
-
 
 # Please keep __all__ alphabetized within each category.
 __all__ = [

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -72,14 +72,6 @@ else:
     def _generic_new(base_cls, cls, *args, **kwargs):
         return base_cls.__new__(cls, *args, **kwargs)
 
-# See https://github.com/python/typing/pull/439
-if hasattr(typing, '_geqv'):
-    from typing import _geqv
-    _geqv_defined = True
-else:
-    _geqv = None
-    _geqv_defined = False
-
 # Please keep __all__ alphabetized within each category.
 __all__ = [
     # Super-special typing primitives.
@@ -788,16 +780,6 @@ if _define_guard('AsyncIterator'):
 
 if hasattr(typing, 'Deque'):
     Deque = typing.Deque
-elif _geqv_defined:
-    class Deque(collections.deque, typing.MutableSequence[T],
-                metaclass=_ExtensionsGenericMeta,
-                extra=collections.deque):
-        __slots__ = ()
-
-        def __new__(cls, *args, **kwds):
-            if _geqv(cls, Deque):
-                return collections.deque(*args, **kwds)
-            return _generic_new(collections.deque, cls, *args, **kwds)
 else:
     class Deque(collections.deque, typing.MutableSequence[T],
                 metaclass=_ExtensionsGenericMeta,
@@ -874,17 +856,6 @@ else:
 
 if hasattr(typing, 'DefaultDict'):
     DefaultDict = typing.DefaultDict
-elif _geqv_defined:
-    class DefaultDict(collections.defaultdict, typing.MutableMapping[KT, VT],
-                      metaclass=_ExtensionsGenericMeta,
-                      extra=collections.defaultdict):
-
-        __slots__ = ()
-
-        def __new__(cls, *args, **kwds):
-            if _geqv(cls, DefaultDict):
-                return collections.defaultdict(*args, **kwds)
-            return _generic_new(collections.defaultdict, cls, *args, **kwds)
 else:
     class DefaultDict(collections.defaultdict, typing.MutableMapping[KT, VT],
                       metaclass=_ExtensionsGenericMeta,
@@ -902,17 +873,6 @@ if hasattr(typing, 'OrderedDict'):
     OrderedDict = typing.OrderedDict
 elif (3, 7, 0) <= sys.version_info[:3] < (3, 7, 2):
     OrderedDict = typing._alias(collections.OrderedDict, (KT, VT))
-elif _geqv_defined:
-    class OrderedDict(collections.OrderedDict, typing.MutableMapping[KT, VT],
-                      metaclass=_ExtensionsGenericMeta,
-                      extra=collections.OrderedDict):
-
-        __slots__ = ()
-
-        def __new__(cls, *args, **kwds):
-            if _geqv(cls, OrderedDict):
-                return collections.OrderedDict(*args, **kwds)
-            return _generic_new(collections.OrderedDict, cls, *args, **kwds)
 else:
     class OrderedDict(collections.OrderedDict, typing.MutableMapping[KT, VT],
                       metaclass=_ExtensionsGenericMeta,
@@ -928,19 +888,6 @@ else:
 
 if hasattr(typing, 'Counter'):
     Counter = typing.Counter
-
-elif _geqv_defined:
-    class Counter(collections.Counter,
-                  typing.Dict[T, int],
-                  metaclass=_ExtensionsGenericMeta, extra=collections.Counter):
-
-        __slots__ = ()
-
-        def __new__(cls, *args, **kwds):
-            if _geqv(cls, Counter):
-                return collections.Counter(*args, **kwds)
-            return _generic_new(collections.Counter, cls, *args, **kwds)
-
 else:
     class Counter(collections.Counter,
                   typing.Dict[T, int],
@@ -959,28 +906,16 @@ if hasattr(typing, 'ChainMap'):
     __all__.append('ChainMap')
 elif hasattr(collections, 'ChainMap'):
     # ChainMap only exists in 3.3+
-    if _geqv_defined:
-        class ChainMap(collections.ChainMap, typing.MutableMapping[KT, VT],
-                       metaclass=_ExtensionsGenericMeta,
-                       extra=collections.ChainMap):
+    class ChainMap(collections.ChainMap, typing.MutableMapping[KT, VT],
+                   metaclass=_ExtensionsGenericMeta,
+                   extra=collections.ChainMap):
 
-            __slots__ = ()
+        __slots__ = ()
 
-            def __new__(cls, *args, **kwds):
-                if _geqv(cls, ChainMap):
-                    return collections.ChainMap(*args, **kwds)
-                return _generic_new(collections.ChainMap, cls, *args, **kwds)
-    else:
-        class ChainMap(collections.ChainMap, typing.MutableMapping[KT, VT],
-                       metaclass=_ExtensionsGenericMeta,
-                       extra=collections.ChainMap):
-
-            __slots__ = ()
-
-            def __new__(cls, *args, **kwds):
-                if cls._gorg is ChainMap:
-                    return collections.ChainMap(*args, **kwds)
-                return _generic_new(collections.ChainMap, cls, *args, **kwds)
+        def __new__(cls, *args, **kwds):
+            if cls._gorg is ChainMap:
+                return collections.ChainMap(*args, **kwds)
+            return _generic_new(collections.ChainMap, cls, *args, **kwds)
 
     __all__.append('ChainMap')
 

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -18,7 +18,7 @@ if PEP_560:
 else:
     from typing import GenericMeta, TypingMeta
 if sys.version_info[:2] == (3, 6):
-    from typing import _type_vars, _next_in_mro, _type_check, _subs_tree  # noqa
+    from typing import _type_vars  # noqa
 
 # The two functions below are copies of typing internal helpers.
 # They are needed by _ProtocolMeta
@@ -513,6 +513,7 @@ if hasattr(typing, 'Protocol'):
     Protocol = typing.Protocol
 # 3.6
 elif not PEP_560:
+    from typing import _next_in_mro, _type_check  # noqa
 
     def _no_init(self, *args, **kwargs):
         if type(self)._is_protocol:

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -978,7 +978,7 @@ else:
         """
         if not isinstance(cls, _ProtocolMeta) or not cls._is_protocol:
             raise TypeError('@runtime_checkable can be only applied to protocol classes,'
-                            f' got {repr(cls)}')
+                            f' got {cls!r}')
         cls._is_runtime_protocol = True
         return cls
 

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -1,9 +1,10 @@
-from _collections_abc import _check_methods as _check_methods_in_mro
+from _collections_abc import _check_methods as _check_methods_in_mro  # noqa
 import abc
 import collections
 import contextlib
 import sys
 import typing
+from typing import _tp_cache, _TypingEllipsis, _TypingEmpty  # noqa
 import collections.abc as collections_abc
 import operator
 
@@ -27,25 +28,8 @@ try:
     from typing import _type_vars, _next_in_mro, _type_check
 except ImportError:
     OLD_GENERICS = True
-try:
+if sys.version_info[:2] == (3, 6):
     from typing import _subs_tree  # noqa
-    SUBS_TREE = True
-except ImportError:
-    SUBS_TREE = False
-try:
-    from typing import _tp_cache
-except ImportError:
-    def _tp_cache(x):
-        return x
-try:
-    from typing import _TypingEllipsis, _TypingEmpty
-except ImportError:
-    class _TypingEllipsis:
-        pass
-
-    class _TypingEmpty:
-        pass
-
 
 # The two functions below are copies of typing internal helpers.
 # They are needed by _ProtocolMeta
@@ -139,17 +123,10 @@ __all__ = [
     'TYPE_CHECKING',
 ]
 
-# Annotated relies on substitution trees of pep 560. It will not work for
-# versions of typing older than 3.5.3
-HAVE_ANNOTATED = PEP_560 or SUBS_TREE
-
 if PEP_560:
     __all__.extend(["get_args", "get_origin", "get_type_hints"])
 
-if HAVE_ANNOTATED:
-    __all__.append("Annotated")
-
-__all__.extend(['Protocol', 'runtime', 'runtime_checkable'])
+__all__.extend(['Annotated', 'Protocol', 'runtime', 'runtime_checkable'])
 
 
 # TODO
@@ -1882,7 +1859,7 @@ elif PEP_560:
             return hint
         return {k: _strip_annotations(t) for k, t in hint.items()}
 
-elif HAVE_ANNOTATED:
+else:
 
     def _is_dunder(name):
         """Returns True if name is a __dunder_variable_name__."""

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -11,7 +11,6 @@ PEP_560 = sys.version_info[:3] >= (3, 7, 0)
 
 if PEP_560:
     GenericMeta = type
-    from typing import _GenericAlias
 else:
     # 3.6
     from typing import GenericMeta, _type_vars  # noqa
@@ -135,7 +134,7 @@ elif sys.version_info[:2] >= (3, 7):
         def __getitem__(self, parameters):
             item = typing._type_check(parameters,
                                       f'{self._name} accepts only single type')
-            return _GenericAlias(self, (item,))
+            return typing._GenericAlias(self, (item,))
 
     Final = _FinalForm('Final',
                        doc="""A special typing construct to indicate that a name
@@ -250,7 +249,7 @@ elif sys.version_info[:2] >= (3, 7):
             return 'typing_extensions.' + self._name
 
         def __getitem__(self, parameters):
-            return _GenericAlias(self, parameters)
+            return typing._GenericAlias(self, parameters)
 
     Literal = _LiteralForm('Literal',
                            doc="""A type that can be used to indicate to type checkers
@@ -598,7 +597,7 @@ elif PEP_560:
             else:
                 # Subscripting a regular Generic subclass.
                 _check_generic(cls, params)
-            return _GenericAlias(cls, params)
+            return typing._GenericAlias(cls, params)
 
         def __init_subclass__(cls, *args, **kwargs):
             tvars = []
@@ -617,7 +616,7 @@ elif PEP_560:
                 # and reject multiple Generic[...] and/or Protocol[...].
                 gvars = None
                 for base in cls.__orig_bases__:
-                    if (isinstance(base, _GenericAlias) and
+                    if (isinstance(base, typing._GenericAlias) and
                             base.__origin__ in (typing.Generic, Protocol)):
                         # for error messages
                         the_base = base.__origin__.__name__
@@ -1428,12 +1427,12 @@ elif PEP_560:
         # 3.9+
         from typing import _BaseGenericAlias
     except ImportError:
-        _BaseGenericAlias = _GenericAlias
+        _BaseGenericAlias = typing._GenericAlias
     try:
         # 3.9+
         from typing import GenericAlias
     except ImportError:
-        GenericAlias = _GenericAlias
+        GenericAlias = typing._GenericAlias
 
     def get_origin(tp):
         """Get the unsubscripted version of a type.
@@ -1452,7 +1451,7 @@ elif PEP_560:
         """
         if isinstance(tp, _AnnotatedAlias):
             return Annotated
-        if isinstance(tp, (_GenericAlias, GenericAlias, _BaseGenericAlias,
+        if isinstance(tp, (typing._GenericAlias, GenericAlias, _BaseGenericAlias,
                            ParamSpecArgs, ParamSpecKwargs)):
             return tp.__origin__
         if tp is typing.Generic:
@@ -1472,7 +1471,7 @@ elif PEP_560:
         """
         if isinstance(tp, _AnnotatedAlias):
             return (tp.__origin__,) + tp.__metadata__
-        if isinstance(tp, (_GenericAlias, GenericAlias)):
+        if isinstance(tp, (typing._GenericAlias, GenericAlias)):
             if getattr(tp, "_special", False):
                 return ()
             res = tp.__args__
@@ -1910,7 +1909,7 @@ elif sys.version_info[:2] >= (3, 9):
         PEP 647 (User-Defined Type Guards).
         """
         item = typing._type_check(parameters, f'{self} accepts only single type.')
-        return _GenericAlias(self, (item,))
+        return typing._GenericAlias(self, (item,))
 # 3.7-3.8
 elif sys.version_info[:2] >= (3, 7):
     class _TypeGuardForm(typing._SpecialForm, _root=True):
@@ -1921,7 +1920,7 @@ elif sys.version_info[:2] >= (3, 7):
         def __getitem__(self, parameters):
             item = typing._type_check(parameters,
                                       f'{self._name} accepts only a single type')
-            return _GenericAlias(self, (item,))
+            return typing._GenericAlias(self, (item,))
 
     TypeGuard = _TypeGuardForm(
         'TypeGuard',

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -1079,7 +1079,7 @@ else:
             # In Python 3.4 and 3.5 the __init__ method also needs to support the
             # keyword arguments.
             # See https://www.python.org/dev/peps/pep-0487/#implementation-details
-            super(_TypedDictMeta, cls).__init__(name, bases, ns)
+            super().__init__(name, bases, ns)
 
         def __new__(cls, name, bases, ns, total=True):
             # Create new typed dict class object.
@@ -1089,7 +1089,7 @@ else:
             # Subclasses and instances of TypedDict return actual dictionaries
             # via _dict_new.
             ns['__new__'] = _typeddict_new if name == 'TypedDict' else _dict_new
-            tp_dict = super(_TypedDictMeta, cls).__new__(cls, name, (dict,), ns)
+            tp_dict = super().__new__(cls, name, (dict,), ns)
 
             annotations = {}
             own_annotations = ns.get('__annotations__', {})

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -1,10 +1,8 @@
-from _collections_abc import _check_methods as _check_methods_in_mro  # noqa
 import abc
 import collections
 import collections.abc
 import sys
 import typing
-import operator
 
 # After PEP 560, internal typing API was substantially reworked.
 # This is especially important for Protocol class which uses internal APIs
@@ -382,6 +380,8 @@ if hasattr(typing, 'AsyncContextManager'):
     AsyncContextManager = typing.AsyncContextManager
 # 3.6.0-3.6.1
 else:
+    from _collections_abc import _check_methods as _check_methods_in_mro  # noqa
+
     class AsyncContextManager(typing.Generic[T_co]):
         __slots__ = ()
 
@@ -1131,6 +1131,8 @@ if hasattr(typing, 'Annotated'):
     _AnnotatedAlias = typing._AnnotatedAlias
 # 3.7-3.8
 elif PEP_560:
+    import operator
+
     class _AnnotatedAlias(typing._GenericAlias, _root=True):
         """Runtime representation of an annotated type.
 

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -184,8 +184,7 @@ else:
                 return cls(typing._type_check(item,
                            f'{cls.__name__[1:]} accepts only single type.'),
                            _root=True)
-            raise TypeError('{} cannot be further subscripted'
-                            .format(cls.__name__[1:]))
+            raise TypeError(f'{cls.__name__[1:]} cannot be further subscripted')
 
         def _eval_type(self, globalns, localns):
             new_tp = typing._eval_type(self.__type__, globalns, localns)
@@ -297,8 +296,7 @@ else:
                 if not isinstance(values, tuple):
                     values = (values,)
                 return cls(values, _root=True)
-            raise TypeError('{} cannot be further subscripted'
-                            .format(cls.__name__[1:]))
+            raise TypeError(f'{cls.__name__[1:]} cannot be further subscripted')
 
         def _eval_type(self, globalns, localns):
             return self
@@ -306,7 +304,7 @@ else:
         def __repr__(self):
             r = super().__repr__()
             if self.__values__ is not None:
-                r += '[{}]'.format(', '.join(map(typing._type_repr, self.__values__)))
+                r += f'[{", ".join(map(typing._type_repr, self.__values__))}]'
             return r
 
         def __hash__(self):
@@ -737,7 +735,7 @@ elif not PEP_560:
 
         Protocol classes can be generic, they are defined as::
 
-          class GenProto({bases}):
+          class GenProto(Protocol[T]):
               def meth(self) -> T:
                   ...
         """
@@ -749,8 +747,6 @@ elif not PEP_560:
                 raise TypeError("Type Protocol cannot be instantiated; "
                                 "it can be used only as a base class")
             return typing._generic_new(cls.__next_in_mro__, cls, *args, **kwds)
-    if Protocol.__doc__ is not None:
-        Protocol.__doc__ = Protocol.__doc__.format(bases="Protocol[T]")
 # 3.7
 else:
     from typing import _collect_type_vars  # noqa
@@ -835,7 +831,7 @@ else:
                         i += 1
                     raise TypeError(
                         "Parameters to Protocol[...] must all be type variables."
-                        " Parameter {} is {}".format(i + 1, params[i]))
+                        f" Parameter {i + 1} is {params[i]}")
                 if len(set(params)) != len(params):
                     raise TypeError(
                         "Parameters to Protocol[...] must all be unique")
@@ -864,7 +860,7 @@ else:
                     if (isinstance(base, _GenericAlias) and
                             base.__origin__ in (typing.Generic, Protocol)):
                         # for error messages
-                        the_base = 'Generic' if base.__origin__ is typing.Generic else 'Protocol'
+                        the_base = base.__origin__.__name__
                         if gvars is not None:
                             raise TypeError(
                                 "Cannot inherit from Generic[...]"
@@ -878,9 +874,8 @@ else:
                     if not tvarset <= gvarset:
                         s_vars = ', '.join(str(t) for t in tvars if t not in gvarset)
                         s_args = ', '.join(str(g) for g in gvars)
-                        raise TypeError("Some type variables ({}) are"
-                                        " not listed in {}[{}]".format(s_vars,
-                                                                       the_base, s_args))
+                        raise TypeError(f"Some type variables ({s_vars}) are"
+                                        f" not listed in {the_base}[{s_args}]")
                     tvars = gvars
             cls.__parameters__ = tuple(tvars)
 
@@ -1021,8 +1016,8 @@ else:
                 fields, = args  # allow the "_fields" keyword be passed
             except ValueError:
                 raise TypeError('TypedDict.__new__() takes from 2 to 3 '
-                                'positional arguments but {} '
-                                'were given'.format(len(args) + 2))
+                                f'positional arguments but {len(args) + 2} '
+                                'were given')
         elif '_fields' in kwargs and len(kwargs) == 1:
             fields = kwargs.pop('_fields')
             import warnings
@@ -1159,10 +1154,8 @@ elif PEP_560:
             return _AnnotatedAlias(new_type, self.__metadata__)
 
         def __repr__(self):
-            return "typing_extensions.Annotated[{}, {}]".format(
-                typing._type_repr(self.__origin__),
-                ", ".join(repr(a) for a in self.__metadata__)
-            )
+            return (f"typing_extensions.Annotated[{typing._type_repr(self.__origin__)}, "
+                    f"{', '.join(repr(a) for a in self.__metadata__)}]")
 
         def __reduce__(self):
             return operator.getitem, (
@@ -1748,9 +1741,8 @@ if not hasattr(typing, 'Concatenate'):
 
         def __repr__(self):
             _type_repr = typing._type_repr
-            return '{origin}[{args}]' \
-                   .format(origin=_type_repr(self.__origin__),
-                           args=', '.join(_type_repr(arg) for arg in self.__args__))
+            return (f'{_type_repr(self.__origin__)}'
+                    f'[{", ".join(_type_repr(arg) for arg in self.__args__)}]')
 
         def __hash__(self):
             return hash((self.__origin__, self.__args__))
@@ -2032,8 +2024,7 @@ else:
                 return cls(typing._type_check(item,
                            f'{cls.__name__[1:]} accepts only a single type.'),
                            _root=True)
-            raise TypeError('{} cannot be further subscripted'
-                            .format(cls.__name__[1:]))
+            raise TypeError(f'{cls.__name__[1:]} cannot be further subscripted')
 
         def _eval_type(self, globalns, localns):
             new_tp = typing._eval_type(self.__type__, globalns, localns)

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -13,12 +13,11 @@ import operator
 PEP_560 = sys.version_info[:3] >= (3, 7, 0)
 
 if PEP_560:
-    GenericMeta = TypingMeta = type
+    GenericMeta = type
     from typing import _GenericAlias
 else:
-    from typing import GenericMeta, TypingMeta
-if sys.version_info[:2] == (3, 6):
-    from typing import _type_vars  # noqa
+    # 3.6
+    from typing import GenericMeta, _type_vars  # noqa
 
 # The two functions below are copies of typing internal helpers.
 # They are needed by _ProtocolMeta
@@ -599,7 +598,7 @@ elif not PEP_560:
                     if not (base in (object, typing.Generic) or
                             base.__module__ == 'collections.abc' and
                             base.__name__ in _PROTO_WHITELIST or
-                            isinstance(base, TypingMeta) and base._is_protocol or
+                            isinstance(base, typing.TypingMeta) and base._is_protocol or
                             isinstance(base, GenericMeta) and
                             base.__origin__ is typing.Generic):
                         raise TypeError(f'Protocols can only inherit from other'

--- a/typing_extensions/src_py3/typing_extensions.py
+++ b/typing_extensions/src_py3/typing_extensions.py
@@ -149,11 +149,7 @@ if PEP_560:
 if HAVE_ANNOTATED:
     __all__.append("Annotated")
 
-# Protocols are hard to backport to the original version of typing 3.5.0
-HAVE_PROTOCOLS = sys.version_info[:3] != (3, 5, 0)
-
-if HAVE_PROTOCOLS:
-    __all__.extend(['Protocol', 'runtime', 'runtime_checkable'])
+__all__.extend(['Protocol', 'runtime', 'runtime_checkable'])
 
 
 # TODO
@@ -1136,7 +1132,7 @@ def _is_callable_members_only(cls):
 
 if hasattr(typing, 'Protocol'):
     Protocol = typing.Protocol
-elif HAVE_PROTOCOLS and not PEP_560:
+elif not PEP_560:
 
     def _no_init(self, *args, **kwargs):
         if type(self)._is_protocol:
@@ -1571,7 +1567,7 @@ elif PEP_560:
 
 if hasattr(typing, 'runtime_checkable'):
     runtime_checkable = typing.runtime_checkable
-elif HAVE_PROTOCOLS:
+else:
     def runtime_checkable(cls):
         """Mark a protocol class as a runtime protocol, so that it
         can be used with isinstance() and issubclass(). Raise TypeError
@@ -1587,14 +1583,13 @@ elif HAVE_PROTOCOLS:
         return cls
 
 
-if HAVE_PROTOCOLS:
-    # Exists for backwards compatibility.
-    runtime = runtime_checkable
+# Exists for backwards compatibility.
+runtime = runtime_checkable
 
 
 if hasattr(typing, 'SupportsIndex'):
     SupportsIndex = typing.SupportsIndex
-elif HAVE_PROTOCOLS:
+else:
     @runtime_checkable
     class SupportsIndex(Protocol):
         __slots__ = ()


### PR DESCRIPTION
@hauntsaninja noted that a PR would likely be welcome, so opening here.

xref #867, https://github.com/python/typing/issues/867#issuecomment-920446047

A