### PR TITLE
Use Semantic Versioning for typing_extensions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 Code in this repository should follow CPython's style guidelines and
 contributors need to sign the PSF Contributor Agreement.
 
-# typing_extensions
+# typing\_extensions
 
 The `typing_extensions` module provides a way to access new features from the standard
 library `typing` module in older versions of Python. For example, Python 3.10 adds
@@ -18,19 +18,13 @@ standard library, so that users can experiment with them before they are added t
 standard library. Such features should ideally already be specified in a PEP or draft
 PEP.
 
-`typing_extensions` still supports all Python versions supported by `typing`, down to
-Python 2.7 and 3.4. However, it is OK to omit support for Python versions that have
-reached end of life if doing so is too difficult or otherwise does not make sense. For
-example, `typing_extensions.AsyncGenerator` only exists on Python 3.6 and higher,
-because async generators were added to the language in 3.6.
+`typing_extensions` supports Python versions 3.6 an up.
 
 # Versioning scheme
 
-The version number of `typing_extensions` indicates the version of the standard library `typing`
-module that is reflected in the backport. For example, `typing_extensions` version
-3.10.0.0 includes features from the Python 3.10.0 standard library's `typing` module. A
-new release that doesn't include any new standard library features would be called
-3.10.0.1.
+Starting with version 4.0.0, `typing_extensions` uses
+[Semantic Versioning](https://semver.org/). The major version is incremented for all
+backwards-incompatible changes.
 
 # Workflow for PyPI releases
 

--- a/typing_extensions/CHANGELOG
+++ b/typing_extensions/CHANGELOG
@@ -1,0 +1,4 @@
+# Changes in version 4.0.0
+
+Starting with version 4.0.0, typing_extensions uses Semantic Versioning.
+See the README for more information.

--- a/typing_extensions/MANIFEST.in
+++ b/typing_extensions/MANIFEST.in
@@ -1,3 +1,3 @@
-include LICENSE README.rst
+include CHANGELOG LICENSE README.rst
 include src_py3/typing_extensions.py
 include src_py3/test_typing_extensions.py

--- a/typing_extensions/README.rst
+++ b/typing_extensions/README.rst
@@ -19,6 +19,13 @@ the ``typing`` module from PyPi instead of using this one unless
 specifically writing code that must be compatible with multiple Python
 versions or requires experimental types.
 
+Starting with version 4.0.0, ``typing_extensions`` uses
+`Semantic Versioning <https://semver.org/>`_. The
+major version is incremented for all backwards-incompatible changes, including
+dropping support for older Python versions. Therefore, it's safe to depend
+on ``typing_extensions`` like this: ``typing_extensions >=x.y, <(x+1)``,
+where ``x.y`` is the first version that includes all features you need.
+
 Included items
 ==============
 

--- a/typing_extensions/setup.cfg
+++ b/typing_extensions/setup.cfg
@@ -1,4 +1,5 @@
 [metadata]
+version = 4.0.0-pre
 license-file = LICENSE
 
 [options]

--- a/typing_extensions/setup.py
+++ b/typing_extensions/setup.py
@@ -9,7 +9,6 @@ if sys.version_info < (3, 6, 0):
                      'to install typing_extensions.\n')
     exit(1)
 
-version = '3.10.0.2'
 description = 'Backported and Experimental Type Hints for Python 3.6+'
 long_description = '''\
 Typing Extensions -- Backported and Experimental Type Hints for Python
@@ -40,7 +39,6 @@ classifiers = [
 ]
 
 setup(name='typing_extensions',
-      version=version,
       description=description,
       long_description=long_description,
       author='Guido van Rossum, Jukka Lehtosalo, Łukasz Langa, Michael Lee',


### PR DESCRIPTION
Bump version to 4.0.0-pre

Closes: python/typing_extensions#32