### PR TITLE
Script to mail regular issue summaries to typing-sig

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,2 @@
+requests>=2.25.0,<3
+types-requests>=2.25.0,<3

--- a/scripts/typing-summary.py
+++ b/scripts/typing-summary.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import datetime
+from dataclasses import dataclass
+from typing import Any, Iterable, Sequence
+
+import requests
+
+ISSUES_API_URL = "https://api.github.com/repos/python/typing/issues"
+ISSUES_URL = "https://github.com/python/typing/issues?q=label%3A%22topic%3A+feature%22"
+
+
+@dataclass
+class Issue:
+    number: int
+    title: str
+    url: str
+    created: datetime.datetime
+    user: str
+    pull_request: bool = False
+
+
+def main() -> None:
+    since = previous_week_start()
+    issues = fetch_issues(since)
+    if len(issues) > 0:
+        new, updated = split_issues(issues, since)
+        print_summary(since, new, updated)
+
+
+def previous_week_start() -> datetime.date:
+    today = datetime.date.today()
+    return today - datetime.timedelta(days=today.weekday() + 7)
+
+
+def fetch_issues(since: datetime.date) -> list[Issue]:
+    """Return (new, updated) issues."""
+    j = requests.get(
+        ISSUES_API_URL,
+        params={
+            "labels": "topic: feature",
+            "since": f"{since:%Y-%m-%d}T00:00:00Z",
+            "per_page": "100",
+            "state": "open",
+        },
+        headers={"Accept": "application/vnd.github.v3+json"},
+    ).json()
+    assert isinstance(j, list)
+    return [parse_issue(j_i) for j_i in j]
+
+
+def parse_issue(j: Any) -> Issue:
+    number = j["number"]
+    title = j["title"]
+    url = j["url"]
+    created_at = datetime.datetime.fromisoformat(j["created_at"][:-1])
+    user = j["user"]["login"]
+    pull_request = "pull_request" in j
+    assert isinstance(number, int)
+    assert isinstance(title, str)
+    assert isinstance(url, str)
+    assert isinstance(user, str)
+    return Issue(number, title, url, created_at, user, pull_request)
+
+
+def split_issues(
+    issues: Iterable[Issue], since: datetime.date
+) -> tuple[list[Issue], list[Issue]]:
+    new = []
+    updated = []
+    for issue in issues:
+        if issue.created.date() >= since:
+            new.append(issue)
+        else:
+            updated.append(issue)
+    new.sort(key=lambda i: i.number)
+    updated.sort(key=lambda i: i.number)
+    return new, updated
+
+
+def print_summary(
+    since: datetime.date, new: Sequence[Issue], changed: Sequence[Issue]
+) -> None:
+    print("From: Typing Bot <noreply@python.org>")
+    print("To: typing-sig@python.org")
+    print(f"Subject: Opened and changed typing issues week {since:%G-W%V}")
+    print()
+    print(generate_mail(new, changed))
+
+
+def generate_mail(new: Sequence[Issue], changed: Sequence[Issue]) -> str:
+    s = (
+        "The following is an overview of all issues and pull requests in the\n"
+        "typing repository on GitHub with the label 'topic: feature'\n"
+        "that were opened or updated last week, exluding closed issues.\n\n"
+        "---------------------------------------------------\n\n"
+    )
+    if len(new) >= 0:
+        s += "The following issues and pull requests were opened last week: \n\n"
+        s += "".join(generate_issue_text(issue) for issue in new)
+        s += "\n---------------------------------------------------\n\n"
+    if len(changed) >= 0:
+        s += "The following issues and pull requests were updated last week: \n\n"
+        s += "".join(generate_issue_text(issue) for issue in changed)
+        s += "\n---------------------------------------------------\n\n"
+    s += (
+        "All issues and pull requests with the label 'topic: feature'\n"
+        "can be viewed under the following URL:\n\n"
+    )
+    s += ISSUES_URL
+    return s
+
+
+def generate_issue_text(issue: Issue) -> str:
+    s = f"#{issue.number:<5} "
+    if issue.pull_request:
+        s += "[PR] "
+    s += f"{issue.title}\n"
+    s += f"       opened by @{issue.user}\n"
+    s += f"       {issue.url}\n"
+    return s
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/typing-summary.py
+++ b/scripts/typing-summary.py
@@ -114,11 +114,11 @@ def generate_mail(new: Sequence[Issue], changed: Sequence[Issue]) -> str:
             "that were opened or updated last week, excluding closed issues.\n\n"
             "---------------------------------------------------\n\n"
         )
-    if len(new) >= 0:
+    if len(new) > 0:
         s += "The following issues and pull requests were opened last week: \n\n"
         s += "".join(generate_issue_text(issue) for issue in new)
         s += "\n---------------------------------------------------\n\n"
-    if len(changed) >= 0:
+    if len(changed) > 0:
         s += "The following issues and pull requests were updated last week: \n\n"
         s += "".join(generate_issue_text(issue) for issue in changed)
         s += "\n---------------------------------------------------\n\n"

--- a/scripts/typing-summary.py
+++ b/scripts/typing-summary.py
@@ -101,7 +101,7 @@ def generate_mail(new: Sequence[Issue], changed: Sequence[Issue]) -> str:
         s = (
             "The following is an overview of all issues and pull requests in the\n"
             "typing repository on GitHub with the label 'topic: feature'\n"
-            "that were opened or updated last week, exluding closed issues.\n\n"
+            "that were opened or updated last week, excluding closed issues.\n\n"
             "---------------------------------------------------\n\n"
         )
     if len(new) >= 0:

--- a/scripts/typing-summary.py
+++ b/scripts/typing-summary.py
@@ -53,7 +53,7 @@ def fetch_issues(since: datetime.date) -> list[Issue]:
 def parse_issue(j: Any) -> Issue:
     number = j["number"]
     title = j["title"]
-    url = j["url"]
+    url = j["html_url"]
     created_at = datetime.datetime.fromisoformat(j["created_at"][:-1])
     user = j["user"]["login"]
     pull_request = "pull_request" in j

--- a/scripts/typing-summary.py
+++ b/scripts/typing-summary.py
@@ -25,9 +25,8 @@ class Issue:
 def main() -> None:
     since = previous_week_start()
     issues = fetch_issues(since)
-    if len(issues) > 0:
-        new, updated = split_issues(issues, since)
-        print_summary(since, new, updated)
+    new, updated = split_issues(issues, since)
+    print_summary(since, new, updated)
 
 
 def previous_week_start() -> datetime.date:
@@ -91,12 +90,18 @@ def print_summary(
 
 
 def generate_mail(new: Sequence[Issue], changed: Sequence[Issue]) -> str:
-    s = (
-        "The following is an overview of all issues and pull requests in the\n"
-        "typing repository on GitHub with the label 'topic: feature'\n"
-        "that were opened or updated last week, exluding closed issues.\n\n"
-        "---------------------------------------------------\n\n"
-    )
+    if len(new) == 0 and len(changed) == 0:
+        s = (
+            "No issues or pull requests with the label 'topic: feature' were opened\n"
+            "or updated last week in the typing repository on GitHub.\n\n"
+        )
+    else:
+        s = (
+            "The following is an overview of all issues and pull requests in the\n"
+            "typing repository on GitHub with the label 'topic: feature'\n"
+            "that were opened or updated last week, exluding closed issues.\n\n"
+            "---------------------------------------------------\n\n"
+        )
     if len(new) >= 0:
         s += "The following issues and pull requests were opened last week: \n\n"
         s += "".join(generate_issue_text(issue) for issue in new)

--- a/scripts/typing-summary.py
+++ b/scripts/typing-summary.py
@@ -1,5 +1,14 @@
 #!/usr/bin/env python3
 
+"""
+Generate a summary of last week's issues tagged with "topic: feature".
+
+The summary will include a list of new and changed issues and is sent each
+Monday at 0200 CE(S)T to the typing-sig mailing list. Due to limitation
+with GitHub Actions, the mail is sent from a private server, currently
+maintained by @srittau.
+"""
+
 from __future__ import annotations
 
 import datetime
@@ -10,6 +19,7 @@ import requests
 
 ISSUES_API_URL = "https://api.github.com/repos/python/typing/issues"
 ISSUES_URL = "https://github.com/python/typing/issues?q=label%3A%22topic%3A+feature%22"
+ISSUES_LABEL = "topic: feature"
 SENDER_EMAIL = "Typing Bot <noreply@python.org>"
 RECEIVER_EMAIL = "typing-sig@python.org"
 
@@ -41,7 +51,7 @@ def fetch_issues(since: datetime.date) -> list[Issue]:
     j = requests.get(
         ISSUES_API_URL,
         params={
-            "labels": "topic: feature",
+            "labels": ISSUES_LABEL,
             "since": f"{since:%Y-%m-%d}T00:00:00Z",
             "per_page": "100",
             "state": "open",

--- a/scripts/typing-summary.py
+++ b/scripts/typing-summary.py
@@ -10,6 +10,8 @@ import requests
 
 ISSUES_API_URL = "https://api.github.com/repos/python/typing/issues"
 ISSUES_URL = "https://github.com/python/typing/issues?q=label%3A%22topic%3A+feature%22"
+SENDER_EMAIL = "Typing Bot <noreply@python.org>"
+RECEIVER_EMAIL = "typing-sig@python.org"
 
 
 @dataclass
@@ -82,8 +84,8 @@ def split_issues(
 def print_summary(
     since: datetime.date, new: Sequence[Issue], changed: Sequence[Issue]
 ) -> None:
-    print("From: Typing Bot <noreply@python.org>")
-    print("To: typing-sig@python.org")
+    print(f"From: {SENDER_EMAIL}")
+    print(f"To: {RECEIVER_EMAIL}")
     print(f"Subject: Opened and changed typing issues week {since:%G-W%V}")
     print()
     print(generate_mail(new, changed))


### PR DESCRIPTION
Example output (with cheated "since" date, since last week I touched all issues):

```
From: Typing Bot <noreply@python.org>
To: typing-sig@python.org
Subject: Opened and changed typing issues week 2021-W44

The following is an overview of all issues and pull requests in the
typing repository on GitHub with the label 'topic: feature'
that were opened or updated last week, exluding closed issues.

---------------------------------------------------

The following issues and pull requests were opened last week: 

#928   Add a `import type` feature (like typescript)
       opened by @KotlinIsland
       https://api.github.com/repos/python/typing/issues/928

---------------------------------------------------

The following issues and pull requests were updated last week: 

#802   Wrapper/Proxy Generic Type
       opened by @hatal175
       https://api.github.com/repos/python/typing/issues/802
#926   Change PEP 647 to allow for narrowing in the negative case
       opened by @Zomatree
       https://api.github.com/repos/python/typing/issues/926

---------------------------------------------------

All issues and pull requests with the label 'topic: feature'
can be viewed under the following URL:

https://github.com/python/typing/issues?q=label%3A%22topic%3A+feature%22
```

This script would be run once a week as a cron job. Unfortunately it seems that we can't mail directly from GitHub Actions (at least not without a mail server configured for it), but I can set up a cron job on a company server.

One possible caveat: It's possible the Python mail server will reject the mail with a python.org-From from a remote web server, in which case we need to change the `From` to something else.

@gvanrossum Would this weekly report be okay for typing-sig?

Cc @shannonzhu 