### PR TITLE
Add `Self` type to the README of typing-extensions

### DIFF
--- a/typing_extensions/README.rst
+++ b/typing_extensions/README.rst
@@ -59,6 +59,7 @@ This module currently contains the following:
 - ``Protocol``
 - ``Required``
 - ``runtime_checkable``
+- ``Self``
 - ``Text``
 - ``Type``
 - ``TypedDict``


### PR DESCRIPTION
This type was missing from the README even though it is part of the typing-extensions package.