### PR TITLE
Vendor typing._SpecialForm to fool typing._type_check

### DIFF
--- a/typing_extensions/src/test_typing_extensions.py
+++ b/typing_extensions/src/test_typing_extensions.py
@@ -2199,6 +2199,12 @@ class SelfTests(BaseTestCase):
         with self.assertRaises(TypeError):
             issubclass(int, Self)
 
+    def test_alias(self):
+        TupleSelf = Tuple[Self, Self]
+        class Alias:
+            def return_tuple(self) -> TupleSelf:
+                return (self, self)
+
 class AllTests(BaseTestCase):
 
     def test_typing_extensions_includes_standard(self):

--- a/typing_extensions/src/typing_extensions.py
+++ b/typing_extensions/src/typing_extensions.py
@@ -2077,10 +2077,10 @@ if not hasattr(typing, "Self") and sys.version_info[:2] >= (3, 7):
             raise TypeError(f"Cannot instantiate {self!r}")
 
         def __or__(self, other):
-            return Union[self, other]
+            return typing.Union[self, other]
 
         def __ror__(self, other):
-            return Union[other, self]
+            return typing.Union[other, self]
 
         def __instancecheck__(self, obj):
             raise TypeError(f"{self} cannot be used with isinstance()")

--- a/typing_extensions/src/typing_extensions.py
+++ b/typing_extensions/src/typing_extensions.py
@@ -2048,12 +2048,55 @@ else:
 
     TypeGuard = _TypeGuard(_root=True)
 
+if not hasattr(typing, "Self") and sys.version_info[:2] >= (3, 7):
+    # Vendored from cpython typing._SpecialFrom
+    class _SpecialForm(typing._Final, _root=True):
+        __slots__ = ('_name', '__doc__', '_getitem')
+
+        def __init__(self, getitem):
+            self._getitem = getitem
+            self._name = getitem.__name__
+            self.__doc__ = getitem.__doc__
+
+        def __getattr__(self, item):
+            if item in {'__name__', '__qualname__'}:
+                return self._name
+
+            raise AttributeError(item)
+
+        def __mro_entries__(self, bases):
+            raise TypeError(f"Cannot subclass {self!r}")
+
+        def __repr__(self):
+            return 'typing.' + self._name
+
+        def __reduce__(self):
+            return self._name
+
+        def __call__(self, *args, **kwds):
+            raise TypeError(f"Cannot instantiate {self!r}")
+
+        def __or__(self, other):
+            return Union[self, other]
+
+        def __ror__(self, other):
+            return Union[other, self]
+
+        def __instancecheck__(self, obj):
+            raise TypeError(f"{self} cannot be used with isinstance()")
+
+        def __subclasscheck__(self, cls):
+            raise TypeError(f"{self} cannot be used with issubclass()")
+
+        @typing._tp_cache
+        def __getitem__(self, parameters):
+            return self._getitem(self, parameters)
 
 if hasattr(typing, "Self"):
     Self = typing.Self
 
-elif sys.version_info[:2] >= (3, 9):
-    class _SelfForm(typing._SpecialForm, _root=True):
+elif sys.version_info[:2] >= (3, 7):
+    class _SelfForm(_SpecialForm, _root=True):
         def __repr__(self):
             return 'typing_extensions.' + self._name
 
@@ -2073,27 +2116,6 @@ elif sys.version_info[:2] >= (3, 9):
         """
 
         raise TypeError(f"{self} is not subscriptable")
-
-elif sys.version_info[:2] >= (3, 7):
-    class _SelfForm(typing._SpecialForm, _root=True):
-        def __repr__(self):
-            return 'typing_extensions.' + self._name
-
-    Self = _SelfForm(
-        "Self",
-        doc="""Used to spell the type of "self" in classes.
-
-        Example::
-
-          from typing import Self
-
-          class ReturnsSelf:
-              def parse(self, data: bytes) -> Self:
-                  ...
-                  return self
-
-        """
-    )
 else:
     class _Self(typing._FinalTypingBase, _root=True):
         """Used to spell the type of "self" in classes.

--- a/typing_extensions/src/typing_extensions.py
+++ b/typing_extensions/src/typing_extensions.py
@@ -2048,7 +2048,9 @@ else:
 
     TypeGuard = _TypeGuard(_root=True)
 
-if not hasattr(typing, "Self") and sys.version_info[:2] >= (3, 7):
+if hasattr(typing, "Self"):
+    Self = typing.Self
+elif sys.version_info[:2] >= (3, 7):
     # Vendored from cpython typing._SpecialFrom
     class _SpecialForm(typing._Final, _root=True):
         __slots__ = ('_name', '__doc__', '_getitem')
@@ -2092,15 +2094,7 @@ if not hasattr(typing, "Self") and sys.version_info[:2] >= (3, 7):
         def __getitem__(self, parameters):
             return self._getitem(self, parameters)
 
-if hasattr(typing, "Self"):
-    Self = typing.Self
-
-elif sys.version_info[:2] >= (3, 7):
-    class _SelfForm(_SpecialForm, _root=True):
-        def __repr__(self):
-            return 'typing_extensions.' + self._name
-
-    @_SelfForm
+    @_SpecialForm
     def Self(self, params):
         """Used to spell the type of "self" in classes.
 

--- a/typing_extensions/src/typing_extensions.py
+++ b/typing_extensions/src/typing_extensions.py
@@ -2068,7 +2068,7 @@ if not hasattr(typing, "Self") and sys.version_info[:2] >= (3, 7):
             raise TypeError(f"Cannot subclass {self!r}")
 
         def __repr__(self):
-            return 'typing.' + self._name
+            return f'typing_extensions.{self._name}'
 
         def __reduce__(self):
             return self._name


### PR DESCRIPTION
Adds a local copy of _SpecialForm in our namespace, so
typing._type_check won't raise TypeError. (#964)