### PR TITLE
Link to English version of Pycharm's landing site in index

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,7 +43,7 @@ Type Checkers
 Development Environments
 ------------------------
 
-* `PyCharm <https://www.jetbrains.com/de-de/pycharm/>`_, an IDE that supports
+* `PyCharm <https://www.jetbrains.com/pycharm/>`_, an IDE that supports
   type stubs both for type checking and code completion.
 * `Visual Studio Code <https://code.visualstudio.com/>`_, a code editor that
   supports type checking using mypy, pyright, or the


### PR DESCRIPTION
The previous link sent the user to the German version of the site which needs the language to be changed manually to the English version if the user wants to use it.