### PR TITLE
Modify docs to comment out unpopulated toctrees

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,12 +1,12 @@
 *************************
 Static Typing with Python
 *************************
-
-.. toctree::
-   :maxdepth: 2
-   :caption: Contents:
-
-   source/introduction
+.. 
+.. .. toctree::
+..    :maxdepth: 2
+..    :caption: Contents:
+.. 
+..    source/introduction
 
 .. toctree::
    :maxdepth: 3
@@ -20,6 +20,10 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`search`
 
+Python Language Documentation
+=============================
+
+* `typing Module Documentation <https://docs.python.org/3/library/typing.html>`_
 
 Discussions and Support
 =======================

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -6,10 +6,17 @@ Type System Reference
    :maxdepth: 2
    :caption: Contents:
 
-   basics
-   type_system
-   annotations
-   inference
-   type_compatibility
-   dependencies
-   faq
+   libraries
+   stubs
+
+
+.. The following pages are desired in a new TOC which will cover multiple
+.. topics. For now, they are not linked because the pages are empty.
+..
+..   basics
+..   type_system
+..   annotations
+..   inference
+..   type_compatibility
+..   dependencies
+..   faq


### PR DESCRIPTION
Prior to this, the toctree directives pointed at numerous planned but unpopulated docs. The result is a mostly empty site with the real content buried.

To revert without discarding work, the toctrees which list empty files are commented out, and new tables of contents are added to link to `libraries` and `stubs` (the existing, populated sections).

Stub docs are left in place, producing sphinx warnings about unlinked docs. These are expected.

The link to the typing module docs has been restored, now in a dedicated section.

@srittau, I think you were asking for a change something like this?
I can't tell what the plan is for the empty/stub pages and how they'll be incorporated into the site, but for now this gets back to a state where all of the links go to real docs.