### PR TITLE
Suggest to use `_` prefix for stubs-only types

### DIFF
--- a/docs/source/stubs.rst
+++ b/docs/source/stubs.rst
@@ -590,7 +590,7 @@ of stub-only objects is to model types that are best described by their
 structure. These objects are called protocols [#pep544]_, and it is encouraged
 to use them freely to describe simple structural types.
 
-It is recommended to prefix stubs-only objects with ``_``.
+It is `recommended <private-definitions>`_ to prefix stubs-only objects with ``_``.
 
 Incomplete Stubs
 ----------------
@@ -922,6 +922,8 @@ No::
     def to_int2(x: str) -> int:
         ...
     def to_int3(x: str) -> int: pass
+
+.. _private-definitions:
 
 Private Definitions
 -------------------

--- a/docs/source/stubs.rst
+++ b/docs/source/stubs.rst
@@ -577,18 +577,20 @@ public method for which a library does not provided a usable runtime type::
 
   from typing import Protocol
 
-  class Readable(Protocol):
+  class _Readable(Protocol):
       def read(self) -> str: ...
 
-  def get_reader() -> Readable: ...
+  def get_reader() -> _Readable: ...
 
 Structural Types
 ----------------
 
-As seen in the example with ``Readable`` in the previous section, a common use
+As seen in the example with ``_Readable`` in the previous section, a common use
 of stub-only objects is to model types that are best described by their
 structure. These objects are called protocols [#pep544]_, and it is encouraged
 to use them freely to describe simple structural types.
+
+It is recommended to use ``_`` prefix for stubs-only objects.
 
 Incomplete Stubs
 ----------------

--- a/docs/source/stubs.rst
+++ b/docs/source/stubs.rst
@@ -590,7 +590,7 @@ of stub-only objects is to model types that are best described by their
 structure. These objects are called protocols [#pep544]_, and it is encouraged
 to use them freely to describe simple structural types.
 
-It is `recommended <private-definitions>`_ to prefix stubs-only objects with ``_``.
+It is `recommended <private-definitions>`_ to prefix stubs-only object names with ``_``.
 
 Incomplete Stubs
 ----------------

--- a/docs/source/stubs.rst
+++ b/docs/source/stubs.rst
@@ -590,7 +590,7 @@ of stub-only objects is to model types that are best described by their
 structure. These objects are called protocols [#pep544]_, and it is encouraged
 to use them freely to describe simple structural types.
 
-It is recommended to use ``_`` prefix for stubs-only objects.
+It is recommended to prefix stubs-only objects with ``_``.
 
 Incomplete Stubs
 ----------------


### PR DESCRIPTION
This is what we do in [django-stubs](https://github.com/typeddjango/django-stubs/), I've seen multiple examples of the same pattern in `typeshed`:
- https://github.com/python/typeshed/blob/8d5d2520ac82b64e93ae7bcfa0d5e46451c02a25/stdlib/pickle.pyi#L10 and https://github.com/python/typeshed/blob/8d5d2520ac82b64e93ae7bcfa0d5e46451c02a25/stdlib/pickle.pyi#L14
- https://github.com/python/typeshed/blob/df0a724c0f0ca558396aeb0f2fe755dc57c967a4/stdlib/asyncio/proactor_events.pyi#L9
- https://github.com/python/typeshed/blob/ee487304d76c671aa353a15e34bc1102bffa2362/stdlib/asyncio/unix_events.pyi#L53