### PR TITLE
Fix PEP number for `TypeAlias`.

### DIFF
--- a/typing_extensions/README.rst
+++ b/typing_extensions/README.rst
@@ -47,7 +47,7 @@ This module currently contains the following:
   - ``ParamSpec`` (see PEP 612)
   - ``ParamSpecArgs`` (see PEP 612)
   - ``ParamSpecKwargs`` (see PEP 612)
-  - ``TypeAlias`` (see PEP 610)
+  - ``TypeAlias`` (see PEP 613)
   - ``TypeGuard`` (see PEP 647)
 
 - In ``typing`` since Python 3.9


### PR DESCRIPTION
Per the Python docs and PEPs, `TypeAlias` appears to have been defined in PEP 613, not PEP 610.

https://docs.python.org/3/library/typing.html#relevant-peps
https://www.python.org/dev/peps/pep-0613/

PEP 610 is titled "Recording the Direct URL Origin of installed distributions" and does not appear related to `TypeAlias`.