### PR TITLE
Add a minimal setup.py file to typing_extensions

### DIFF
--- a/typing_extensions/setup.py
+++ b/typing_extensions/setup.py
@@ -1,0 +1,4 @@
+import setuptools
+
+if __name__ == "__main__":
+    setuptools.setup()


### PR DESCRIPTION
For some purposes it's useful to have a `setup.py` file. I think this is the correct way to have `setup.py` defer to `pyproject.toml`.