### PR TITLE
Add is_typeddict from Python 3.10

### DIFF
--- a/typing_extensions/CHANGELOG
+++ b/typing_extensions/CHANGELOG
@@ -1,3 +1,8 @@
+# Release 4.x.x
+
+- Add `is_typeddict`. Patch by Chris Moradi (@chrismoradi) and James
+  Hilton-Balfe (@Gobot1234).
+
 # Release 4.0.1 (November 30, 2021)
 
 - Fix broken sdist in release 4.0.0. Patch by Adam Turner (@AA-Turner).

--- a/typing_extensions/README.rst
+++ b/typing_extensions/README.rst
@@ -49,6 +49,7 @@ This module currently contains the following:
   - ``ParamSpecKwargs`` (see PEP 612)
   - ``TypeAlias`` (see PEP 610)
   - ``TypeGuard`` (see PEP 647)
+  - ``is_typeddict``
 
 - In ``typing`` since Python 3.9
 

--- a/typing_extensions/pyproject.toml
+++ b/typing_extensions/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "flit_core.buildapi"
 # Project metadata
 [project]
 name = "typing_extensions"
-version = "4.0.1"
+version = "4.1.0"
 description = "Backported and Experimental Type Hints for Python 3.6+"
 readme.text = """\
 Typing Extensions -- Backported and Experimental Type Hints for Python

--- a/typing_extensions/pyproject.toml
+++ b/typing_extensions/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "flit_core.buildapi"
 # Project metadata
 [project]
 name = "typing_extensions"
-version = "4.1.0"
+version = "4.0.1"
 description = "Backported and Experimental Type Hints for Python 3.6+"
 readme.text = """\
 Typing Extensions -- Backported and Experimental Type Hints for Python

--- a/typing_extensions/src/test_typing_extensions.py
+++ b/typing_extensions/src/test_typing_extensions.py
@@ -19,7 +19,7 @@ import typing_extensions
 from typing_extensions import NoReturn, ClassVar, Final, IntVar, Literal, Type, NewType, TypedDict, Self
 from typing_extensions import TypeAlias, ParamSpec, Concatenate, ParamSpecArgs, ParamSpecKwargs, TypeGuard
 from typing_extensions import Awaitable, AsyncIterator, AsyncContextManager, Required, NotRequired
-from typing_extensions import Protocol, runtime, runtime_checkable, Annotated, overload
+from typing_extensions import Protocol, runtime, runtime_checkable, Annotated, overload, is_typeddict
 try:
     from typing_extensions import get_type_hints
 except ImportError:
@@ -1680,6 +1680,13 @@ class TypedDictTests(BaseTestCase):
             'tail': bool,
             'voice': str,
         }
+
+    def test_is_typeddict(self):
+        assert is_typeddict(Point2D) is True
+        assert is_typeddict(Union[str, int]) is False
+        # classes, not instances
+        assert is_typeddict(Point2D()) is False
+
 
 
 class AnnotatedTests(BaseTestCase):

--- a/typing_extensions/src/test_typing_extensions.py
+++ b/typing_extensions/src/test_typing_extensions.py
@@ -1684,6 +1684,7 @@ class TypedDictTests(BaseTestCase):
 
     def test_is_typeddict(self):
         assert is_typeddict(Point2D) is True
+        assert is_typeddict(Point2Dor3D) is True
         assert is_typeddict(Union[str, int]) is False
         # classes, not instances
         assert is_typeddict(Point2D()) is False
@@ -1691,7 +1692,17 @@ class TypedDictTests(BaseTestCase):
     @skipUnless(TYPING_3_8_0, "Python 3.8+ required")
     def test_is_typeddict_against_typeddict_from_typing(self):
         Point = typing.TypedDict('Point', {'x': int, 'y': int})
+
+        class PointDict2D(typing.TypedDict):
+            x: int
+            y: int
+
+        class PointDict3D(PointDict2D, total=False):
+            z: int
+
         assert is_typeddict(Point) is True
+        assert is_typeddict(PointDict2D) is True
+        assert is_typeddict(PointDict3D) is True
 
 
 class AnnotatedTests(BaseTestCase):

--- a/typing_extensions/src/test_typing_extensions.py
+++ b/typing_extensions/src/test_typing_extensions.py
@@ -36,6 +36,7 @@ except ImportError:
 # Flags used to mark tests that only apply after a specific
 # version of the typing module.
 TYPING_3_6_1 = sys.version_info[:3] >= (3, 6, 1)
+TYPING_3_8_0 = sys.version_info[:3] >= (3, 8, 0)
 TYPING_3_10_0 = sys.version_info[:3] >= (3, 10, 0)
 TYPING_3_11_0 = sys.version_info[:3] >= (3, 11, 0)
 
@@ -1687,6 +1688,10 @@ class TypedDictTests(BaseTestCase):
         # classes, not instances
         assert is_typeddict(Point2D()) is False
 
+    @skipUnless(TYPING_3_8_0, "Python 3.8+ required")
+    def test_is_typeddict_against_typeddict_from_typing(self):
+        Point = typing.TypedDict('Point', {'x': int, 'y': int})
+        assert is_typeddict(Point) is True
 
 
 class AnnotatedTests(BaseTestCase):

--- a/typing_extensions/src/typing_extensions.py
+++ b/typing_extensions/src/typing_extensions.py
@@ -1125,16 +1125,24 @@ else:
         """
 
 
-def is_typeddict(tp):
-    """Check if an annotation is a TypedDict class
-    For example::
-        class Film(TypedDict):
-            title: str
-            year: int
-        is_typeddict(Film)  # => True
-        is_typeddict(Union[list, str])  # => False
-    """
-    return isinstance(tp, _TypedDictMeta)
+if hasattr(typing, "is_typeddict"):
+    is_typeddict = typing.is_typeddict
+else:
+    def is_typeddict(tp):
+        """Check if an annotation is a TypedDict class
+        For example::
+            class Film(TypedDict):
+                title: str
+                year: int
+            is_typeddict(Film)  # => True
+            is_typeddict(Union[list, str])  # => False
+        """
+        typeddict_types = [_TypedDictMeta]
+        try:
+            typeddict_types.append(typing._TypedDictMeta)
+        except AttributeError:
+            pass
+        return isinstance(tp, tuple(typeddict_types))
 
 
 # Python 3.9+ has PEP 593 (Annotated and modified get_type_hints)

--- a/typing_extensions/src/typing_extensions.py
+++ b/typing_extensions/src/typing_extensions.py
@@ -1128,6 +1128,8 @@ else:
 if hasattr(typing, "is_typeddict"):
     is_typeddict = typing.is_typeddict
 else:
+    _TYPEDDICT_TYPES = (typing._TypedDictMeta, _TypedDictMeta) if hasattr(typing, "_TypedDictMeta") else (_TypedDictMeta,)
+
     def is_typeddict(tp):
         """Check if an annotation is a TypedDict class
         For example::
@@ -1137,12 +1139,7 @@ else:
             is_typeddict(Film)  # => True
             is_typeddict(Union[list, str])  # => False
         """
-        typeddict_types = [_TypedDictMeta]
-        try:
-            typeddict_types.append(typing._TypedDictMeta)
-        except AttributeError:
-            pass
-        return isinstance(tp, tuple(typeddict_types))
+        return isinstance(tp, tuple(_TYPEDDICT_TYPES))
 
 
 # Python 3.9+ has PEP 593 (Annotated and modified get_type_hints)

--- a/typing_extensions/src/typing_extensions.py
+++ b/typing_extensions/src/typing_extensions.py
@@ -1128,7 +1128,10 @@ else:
 if hasattr(typing, "is_typeddict"):
     is_typeddict = typing.is_typeddict
 else:
-    _TYPEDDICT_TYPES = (typing._TypedDictMeta, _TypedDictMeta) if hasattr(typing, "_TypedDictMeta") else (_TypedDictMeta,)
+    if hasattr(typing, "_TypedDictMeta"):
+        _TYPEDDICT_TYPES = (typing._TypedDictMeta, _TypedDictMeta)
+    else:
+        _TYPEDDICT_TYPES = (_TypedDictMeta,)
 
     def is_typeddict(tp):
         """Check if an annotation is a TypedDict class

--- a/typing_extensions/src/typing_extensions.py
+++ b/typing_extensions/src/typing_extensions.py
@@ -72,6 +72,7 @@ __all__ = [
     'Annotated',
     'final',
     'IntVar',
+    'is_typeddict',
     'Literal',
     'NewType',
     'overload',
@@ -979,6 +980,7 @@ if sys.version_info >= (3, 9, 2):
     # The standard library TypedDict in Python 3.9.0/1 does not honour the "total"
     # keyword with old-style TypedDict().  See https://bugs.python.org/issue42059
     TypedDict = typing.TypedDict
+    _TypedDictMeta = typing._TypedDictMeta
 else:
     def _check_fails(cls, other):
         try:
@@ -1121,6 +1123,18 @@ else:
         The class syntax is only supported in Python 3.6+, while two other
         syntax forms work for Python 2.7 and 3.2+
         """
+
+
+def is_typeddict(tp):
+    """Check if an annotation is a TypedDict class
+    For example::
+        class Film(TypedDict):
+            title: str
+            year: int
+        is_typeddict(Film)  # => True
+        is_typeddict(Union[list, str])  # => False
+    """
+    return isinstance(tp, _TypedDictMeta)
 
 
 # Python 3.9+ has PEP 593 (Annotated and modified get_type_hints)

--- a/typing_extensions/src/typing_extensions.py
+++ b/typing_extensions/src/typing_extensions.py
@@ -1132,10 +1132,12 @@ else:
 
     def is_typeddict(tp):
         """Check if an annotation is a TypedDict class
+
         For example::
             class Film(TypedDict):
                 title: str
                 year: int
+
             is_typeddict(Film)  # => True
             is_typeddict(Union[list, str])  # => False
         """


### PR DESCRIPTION
I'm a first time contributor. Still need to sign the PSF Contributor Agreement, but wanted to check that this is a contribution that you're open to accepting first. All changes are copied from Python 3.10.