### PR TITLE
Update tox config to add Python 3.10, support PEP517 build-backend

### DIFF
--- a/typing_extensions/tox.ini
+++ b/typing_extensions/tox.ini
@@ -1,5 +1,6 @@
 [tox]
-envlist = py36, py37, py38, py39
+isolated_build = True
+envlist = py36, py37, py38, py39, py310
 
 [testenv]
 changedir = src


### PR DESCRIPTION
Error running tox without `isolated_build` in config:

```
ERROR: pyproject.toml file found.
To use a PEP 517 build-backend you are required to configure tox to use an isolated_build:
Update tox to support Python 3.10, PEP517 build-backend
Update tox config to add Python 3.10, support PEP517 build-backend
https://tox.readthedocs.io/en/latest/example/package.html
```