### PR TITLE
Don't increase the major version when dropping support for a Python version

### DIFF
--- a/typing_extensions/README.rst
+++ b/typing_extensions/README.rst
@@ -25,8 +25,8 @@ haven't yet figured out how to deal with that possibility.
 
 Starting with version 4.0.0, ``typing_extensions`` uses
 `Semantic Versioning <https://semver.org/>`_. The
-major version is incremented for all backwards-incompatible changes, including
-dropping support for older Python versions. Therefore, it's safe to depend
+major version is incremented for all backwards-incompatible changes.
+Therefore, it's safe to depend
 on ``typing_extensions`` like this: ``typing_extensions >=x.y, <(x+1)``,
 where ``x.y`` is the first version that includes all features you need.
 


### PR DESCRIPTION
As pointed out in #1023, there is no risk of incompatibility, since the
requires-python field will prevent installation on older Python versions.