### PR TITLE
Backport tests from `test_typing.py`

### DIFF
--- a/typing_extensions/src/test_typing_extensions.py
+++ b/typing_extensions/src/test_typing_extensions.py
@@ -2117,13 +2117,55 @@ class ConcatenateTests(BaseTestCase):
     def test_valid_uses(self):
         P = ParamSpec('P')
         T = TypeVar('T')
-        C1 = typing.Callable[Concatenate[int, P], int]
-        C2 = typing.Callable[Concatenate[int, T, P], T]
+
+        C1 = Callable[Concatenate[int, P], int]
+        self.assertEqual(C1.__args__, (Concatenate[int, P], int))
+        self.assertEqual(C1.__parameters__, (P,))
+        C2 = Callable[Concatenate[int, T, P], T]
+        self.assertEqual(C2.__args__, (Concatenate[int, T, P], T))
+        self.assertEqual(C2.__parameters__, (T, P))
+
+        # As a return type.
+        C3 = Callable[[str], Concatenate[int, P]]
+        self.assertEqual(C3.__args__, (str, Concatenate[int, P]))
+        self.assertEqual(C3.__parameters__, (P,))
+        C4 = Callable[[str], Concatenate[int, T, P]]
+        self.assertEqual(C4.__args__, (str, Concatenate[int, T, P]))
+        self.assertEqual(C4.__parameters__, (T, P))
 
         # Test collections.abc.Callable too.
         if sys.version_info[:2] >= (3, 9):
-            C3 = collections.abc.Callable[Concatenate[int, P], int]
-            C4 = collections.abc.Callable[Concatenate[int, T, P], T]
+            C5 = collections.abc.Callable[Concatenate[int, P], int]
+            self.assertEqual(C5.__args__, (Concatenate[int, P], int))
+            self.assertEqual(C5.__parameters__, (P,))
+            C6 = collections.abc.Callable[Concatenate[int, T, P], T]
+            self.assertEqual(C6.__args__, (Concatenate[int, T, P], T))
+            self.assertEqual(C6.__parameters__, (T, P))
+            C7 = collections.abc.Callable[[str], Concatenate[int, T, P]]
+            self.assertEqual(C7.__args__, (str, Concatenate[int, T, P]))
+            self.assertEqual(C7.__parameters__, (T, P))
+
+    def test_invalid_uses(self):
+        P = ParamSpec('P')
+        T = TypeVar('T')
+
+        with self.assertRaisesRegex(
+            TypeError,
+            'Cannot take a Concatenate of no types',
+        ):
+            Concatenate[()]
+
+        with self.assertRaisesRegex(
+            TypeError,
+            'The last parameter to Concatenate should be a ParamSpec variable',
+        ):
+            Concatenate[P, T]
+
+        with self.assertRaisesRegex(
+            TypeError,
+            'each arg must be a type',
+        ):
+            Concatenate[1, P]
 
     def test_basic_introspection(self):
         P = ParamSpec('P')

--- a/typing_extensions/src/test_typing_extensions.py
+++ b/typing_extensions/src/test_typing_extensions.py
@@ -2121,15 +2121,10 @@ class ConcatenateTests(BaseTestCase):
         C1 = Callable[Concatenate[int, P], int]
         C2 = Callable[Concatenate[int, T, P], T]
 
-        # As a return type.
-        C3 = Callable[[str], Concatenate[int, P]]
-        C4 = Callable[[str], Concatenate[int, T, P]]
-
         # Test collections.abc.Callable too.
         if sys.version_info[:2] >= (3, 9):
-            C5 = collections.abc.Callable[Concatenate[int, P], int]
-            C6 = collections.abc.Callable[Concatenate[int, T, P], T]
-            C7 = collections.abc.Callable[[str], Concatenate[int, T, P]]
+            C3 = collections.abc.Callable[Concatenate[int, P], int]
+            C4 = collections.abc.Callable[Concatenate[int, T, P], T]
 
     def test_invalid_uses(self):
         P = ParamSpec('P')

--- a/typing_extensions/src/test_typing_extensions.py
+++ b/typing_extensions/src/test_typing_extensions.py
@@ -2119,31 +2119,17 @@ class ConcatenateTests(BaseTestCase):
         T = TypeVar('T')
 
         C1 = Callable[Concatenate[int, P], int]
-        self.assertEqual(C1.__args__, (Concatenate[int, P], int))
-        self.assertEqual(C1.__parameters__, (P,))
         C2 = Callable[Concatenate[int, T, P], T]
-        self.assertEqual(C2.__args__, (Concatenate[int, T, P], T))
-        self.assertEqual(C2.__parameters__, (T, P))
 
         # As a return type.
         C3 = Callable[[str], Concatenate[int, P]]
-        self.assertEqual(C3.__args__, (str, Concatenate[int, P]))
-        self.assertEqual(C3.__parameters__, (P,))
         C4 = Callable[[str], Concatenate[int, T, P]]
-        self.assertEqual(C4.__args__, (str, Concatenate[int, T, P]))
-        self.assertEqual(C4.__parameters__, (T, P))
 
         # Test collections.abc.Callable too.
         if sys.version_info[:2] >= (3, 9):
             C5 = collections.abc.Callable[Concatenate[int, P], int]
-            self.assertEqual(C5.__args__, (Concatenate[int, P], int))
-            self.assertEqual(C5.__parameters__, (P,))
             C6 = collections.abc.Callable[Concatenate[int, T, P], T]
-            self.assertEqual(C6.__args__, (Concatenate[int, T, P], T))
-            self.assertEqual(C6.__parameters__, (T, P))
             C7 = collections.abc.Callable[[str], Concatenate[int, T, P]]
-            self.assertEqual(C7.__args__, (str, Concatenate[int, T, P]))
-            self.assertEqual(C7.__parameters__, (T, P))
 
     def test_invalid_uses(self):
         P = ParamSpec('P')


### PR DESCRIPTION
As promised in https://bugs.python.org/issue46386

Backported:
- https://github.com/python/cpython/pull/30619

Not backported:
- https://github.com/python/cpython/pull/30613 (because `ParamSpec` is already tested with `pickle` using all protocols)