### PR TITLE
Improve distribution package

### DIFF
--- a/typing_extensions/MANIFEST.in
+++ b/typing_extensions/MANIFEST.in
@@ -1,3 +1,0 @@
-include CHANGELOG LICENSE README.rst
-include src/typing_extensions.py
-include src/test_typing_extensions.py

--- a/typing_extensions/pyproject.toml
+++ b/typing_extensions/pyproject.toml
@@ -8,20 +8,7 @@ build-backend = "flit_core.buildapi"
 name = "typing_extensions"
 version = "4.1.1"
 description = "Backported and Experimental Type Hints for Python 3.6+"
-readme.text = """\
-Typing Extensions -- Backported and Experimental Type Hints for Python
-
-The ``typing`` module was added to the standard library in Python 3.5, but
-many new features have been added to the module since then.
-This means users of older Python versions who are unable to upgrade will not be
-able to take advantage of new types added to the ``typing`` module, such as
-``typing.Protocol`` or ``typing.TypedDict``.
-
-The ``typing_extensions`` module contains backports of these changes.
-Experimental types that may eventually be added to the ``typing``
-module are also included in ``typing_extensions``.
-"""
-readme.content-type = "text/x-rst"
+readme = "README.rst"
 requires-python = ">=3.6"
 urls.Home = "https://github.com/python/typing/blob/master/typing_extensions/README.rst"
 license.file = "LICENSE"
@@ -61,3 +48,12 @@ classifiers = [
 [[project.authors]]
 name = "Guido van Rossum, Jukka Lehtosalo, Łukasz Langa, Michael Lee"
 email = "levkivskyi@gmail.com"
+
+[tool.flit.sdist]
+include = [
+    "CHANGELOG",
+    "README.rst",
+]
+exclude = [
+    "*/test*.py"
+]

--- a/typing_extensions/pyproject.toml
+++ b/typing_extensions/pyproject.toml
@@ -53,7 +53,6 @@ email = "levkivskyi@gmail.com"
 include = [
     "CHANGELOG",
     "README.rst",
-]
-exclude = [
     "*/test*.py"
 ]
+exclude = []


### PR DESCRIPTION
* Explicitly include `CHANGELOG` and `README.rst` in the `sdist`. (`LICENSE` is already included through `license.file`.) https://flit.readthedocs.io/en/latest/pyproject_toml.html#sdist-section
_This will not change that `CHANGELOG` and `README.rst` are **not** included in the `wheel`. (which is by design)_
* ~~Explicitly exclude any test files. Those should not be part of the distribution. Anyone who needs them should clone the repo instead.~~
* Use contents of `README.rst` for long description. Suggested [here](https://github.com/python/typing/issues/1094#issuecomment-1054217803).
* Remove `MANIFEST.in` as it wasn't used to begin with.

Fixes: #1094