### PR TITLE
test_typing_extensions: fix lint

### DIFF
--- a/typing_extensions/src/test_typing_extensions.py
+++ b/typing_extensions/src/test_typing_extensions.py
@@ -2646,7 +2646,7 @@ class FinalDecoratorTests(BaseTestCase):
             def prop(self): ...
 
             @final
-            @lru_cache()
+            @lru_cache()  # noqa: B019
             def cached(self): ...
 
         # Use getattr_static because the descriptor returns the


### PR DESCRIPTION
This is from a new check in a new version of flake8-bugbear