### PR TITLE
dataclass_transform: accept **kwargs, rename field_descriptors

### DIFF
--- a/typing_extensions/CHANGELOG
+++ b/typing_extensions/CHANGELOG
@@ -1,5 +1,8 @@
 # Unreleased
 
+- Update `typing_extensions.dataclass_transform` to rename the
+  `field_descriptors` parameter to `field_specifiers` and accept
+  arbitrary keyword arguments.
 - Add `typing.assert_type`. Backport from bpo-46480.
 - Drop support for Python 3.6. Original patch by Adam Turner (@AA-Turner).
 

--- a/typing_extensions/src/test_typing_extensions.py
+++ b/typing_extensions/src/test_typing_extensions.py
@@ -2646,7 +2646,8 @@ class DataclassTransformTests(BaseTestCase):
                 "eq_default": True,
                 "order_default": False,
                 "kw_only_default": True,
-                "field_descriptors": (),
+                "field_specifiers": (),
+                "kwargs": {},
             }
         )
         self.assertIs(
@@ -2658,7 +2659,12 @@ class DataclassTransformTests(BaseTestCase):
         class ModelBase:
             def __init_subclass__(cls, *, frozen: bool = False): ...
 
-        Decorated = dataclass_transform(eq_default=True, order_default=True)(ModelBase)
+        Decorated = dataclass_transform(
+            eq_default=True,
+            order_default=True,
+            # Arbitrary unrecognized kwargs are accepted at runtime.
+            make_everything_awesome=True,
+        )(ModelBase)
 
         class CustomerModel(Decorated, frozen=True):
             id: int
@@ -2670,7 +2676,8 @@ class DataclassTransformTests(BaseTestCase):
                 "eq_default": True,
                 "order_default": True,
                 "kw_only_default": False,
-                "field_descriptors": (),
+                "field_specifiers": (),
+                "kwargs": {"make_everything_awesome": True},
             }
         )
         self.assertIsSubclass(CustomerModel, Decorated)
@@ -2685,7 +2692,7 @@ class DataclassTransformTests(BaseTestCase):
                 return super().__new__(cls, name, bases, namespace)
 
         Decorated = dataclass_transform(
-            order_default=True, field_descriptors=(Field,)
+            order_default=True, field_specifiers=(Field,)
         )(ModelMeta)
 
         class ModelBase(metaclass=Decorated): ...
@@ -2700,7 +2707,8 @@ class DataclassTransformTests(BaseTestCase):
                 "eq_default": True,
                 "order_default": True,
                 "kw_only_default": False,
-                "field_descriptors": (Field,),
+                "field_specifiers": (Field,),
+                "kwargs": {},
             }
         )
         self.assertIsInstance(CustomerModel, Decorated)

--- a/typing_extensions/src/typing_extensions.py
+++ b/typing_extensions/src/typing_extensions.py
@@ -1795,10 +1795,11 @@ else:
         eq_default: bool = True,
         order_default: bool = False,
         kw_only_default: bool = False,
-        field_descriptors: typing.Tuple[
+        field_specifiers: typing.Tuple[
             typing.Union[typing.Type[typing.Any], typing.Callable[..., typing.Any]],
             ...
         ] = (),
+        **kwargs: typing.Any,
     ) -> typing.Callable[[T], T]:
         """Decorator that marks a function, class, or metaclass as providing
         dataclass-like behavior.
@@ -1850,7 +1851,7 @@ else:
           assumed to be True or False if it is omitted by the caller.
         - ``kw_only_default`` indicates whether the ``kw_only`` parameter is
           assumed to be True or False if it is omitted by the caller.
-        - ``field_descriptors`` specifies a static list of supported classes
+        - ``field_specifiers`` specifies a static list of supported classes
           or functions, that describe fields, similar to ``dataclasses.field()``.
 
         At runtime, this decorator records its arguments in the
@@ -1864,7 +1865,8 @@ else:
                 "eq_default": eq_default,
                 "order_default": order_default,
                 "kw_only_default": kw_only_default,
-                "field_descriptors": field_descriptors,
+                "field_specifiers": field_specifiers,
+                "kwargs": kwargs,
             }
             return cls_or_fn
         return decorator

--- a/typing_extensions/src/typing_extensions.py
+++ b/typing_extensions/src/typing_extensions.py
@@ -1852,7 +1852,7 @@ else:
         - ``kw_only_default`` indicates whether the ``kw_only`` parameter is
           assumed to be True or False if it is omitted by the caller.
         - ``field_specifiers`` specifies a static list of supported classes
-          or functions, that describe fields, similar to ``dataclasses.field()``.
+          or functions that describe fields, similar to ``dataclasses.field()``.
 
         At runtime, this decorator records its arguments in the
         ``__dataclass_transform__`` attribute on the decorated object.


### PR DESCRIPTION
cc @debonte @erictraut. This implements the field_descriptors -> field_specifiers rename that was changed in the PEP yesterday and the **kwargs idea I just shared. Just a draft for now to share what the idea would look like at runtime.