### PR TITLE
Add `assert_type` to `__all__`

### DIFF
--- a/typing_extensions/src/typing_extensions.py
+++ b/typing_extensions/src/typing_extensions.py
@@ -43,6 +43,7 @@ __all__ = [
     # One-off things.
     'Annotated',
     'assert_never',
+    'assert_type',
     'dataclass_transform',
     'final',
     'get_args',


### PR DESCRIPTION
Looks like this is in `typing.__all__` but was missed out of `typing_extensions.__all__`