### PR TITLE
Fix tests on Python 3.11

### DIFF
--- a/typing_extensions/CHANGELOG
+++ b/typing_extensions/CHANGELOG
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Re-export `typing.Unpack` and `typing.TypeVarTuple` on Python 3.11.
 - Update `typing_extensions.dataclass_transform` to rename the
   `field_descriptors` parameter to `field_specifiers` and accept
   arbitrary keyword arguments.

--- a/typing_extensions/src/typing_extensions.py
+++ b/typing_extensions/src/typing_extensions.py
@@ -1672,8 +1672,8 @@ else:
             Ts = TypeVarTuple('Ts')
 
         In the same way that a normal type variable is a stand-in for a single
-        type such as ``int``, a type variable *tuple* is a stand-in for a *tuple* type such as
-        ``Tuple[int, str]``.
+        type such as ``int``, a type variable *tuple* is a stand-in for a *tuple*
+        type such as ``Tuple[int, str]``.
 
         Type variable tuples can be used in ``Generic`` declarations.
         Consider the following example::

--- a/typing_extensions/src/typing_extensions.py
+++ b/typing_extensions/src/typing_extensions.py
@@ -1603,7 +1603,9 @@ else:
         """)
 
 
-if sys.version_info[:2] >= (3, 9):
+if hasattr(typing, "Unpack"):  # 3.11+
+    Unpack = typing.Unpack
+elif sys.version_info[:2] >= (3, 9):
     class _UnpackSpecialForm(typing._SpecialForm, _root=True):
         def __repr__(self):
             return 'typing_extensions.' + self._name
@@ -1659,84 +1661,87 @@ else:
         return isinstance(obj, _UnpackAlias)
 
 
-class TypeVarTuple:
-    """Type variable tuple.
+if hasattr(typing, "TypeVarTuple"):  # 3.11+
+    TypeVarTuple = typing.TypeVarTuple
+else:
+    class TypeVarTuple:
+        """Type variable tuple.
 
-    Usage::
+        Usage::
 
-        Ts = TypeVarTuple('Ts')
+            Ts = TypeVarTuple('Ts')
 
-    In the same way that a normal type variable is a stand-in for a single
-    type such as ``int``, a type variable *tuple* is a stand-in for a *tuple* type such as
-    ``Tuple[int, str]``.
+        In the same way that a normal type variable is a stand-in for a single
+        type such as ``int``, a type variable *tuple* is a stand-in for a *tuple* type such as
+        ``Tuple[int, str]``.
 
-    Type variable tuples can be used in ``Generic`` declarations.
-    Consider the following example::
+        Type variable tuples can be used in ``Generic`` declarations.
+        Consider the following example::
 
-        class Array(Generic[*Ts]): ...
+            class Array(Generic[*Ts]): ...
 
-    The ``Ts`` type variable tuple here behaves like ``tuple[T1, T2]``,
-    where ``T1`` and ``T2`` are type variables. To use these type variables
-    as type parameters of ``Array``, we must *unpack* the type variable tuple using
-    the star operator: ``*Ts``. The signature of ``Array`` then behaves
-    as if we had simply written ``class Array(Generic[T1, T2]): ...``.
-    In contrast to ``Generic[T1, T2]``, however, ``Generic[*Shape]`` allows
-    us to parameterise the class with an *arbitrary* number of type parameters.
+        The ``Ts`` type variable tuple here behaves like ``tuple[T1, T2]``,
+        where ``T1`` and ``T2`` are type variables. To use these type variables
+        as type parameters of ``Array``, we must *unpack* the type variable tuple using
+        the star operator: ``*Ts``. The signature of ``Array`` then behaves
+        as if we had simply written ``class Array(Generic[T1, T2]): ...``.
+        In contrast to ``Generic[T1, T2]``, however, ``Generic[*Shape]`` allows
+        us to parameterise the class with an *arbitrary* number of type parameters.
 
-    Type variable tuples can be used anywhere a normal ``TypeVar`` can.
-    This includes class definitions, as shown above, as well as function
-    signatures and variable annotations::
+        Type variable tuples can be used anywhere a normal ``TypeVar`` can.
+        This includes class definitions, as shown above, as well as function
+        signatures and variable annotations::
 
-        class Array(Generic[*Ts]):
+            class Array(Generic[*Ts]):
 
-            def __init__(self, shape: Tuple[*Ts]):
-                self._shape: Tuple[*Ts] = shape
+                def __init__(self, shape: Tuple[*Ts]):
+                    self._shape: Tuple[*Ts] = shape
 
-            def get_shape(self) -> Tuple[*Ts]:
-                return self._shape
+                def get_shape(self) -> Tuple[*Ts]:
+                    return self._shape
 
-        shape = (Height(480), Width(640))
-        x: Array[Height, Width] = Array(shape)
-        y = abs(x)  # Inferred type is Array[Height, Width]
-        z = x + x   #        ...    is Array[Height, Width]
-        x.get_shape()  #     ...    is tuple[Height, Width]
+            shape = (Height(480), Width(640))
+            x: Array[Height, Width] = Array(shape)
+            y = abs(x)  # Inferred type is Array[Height, Width]
+            z = x + x   #        ...    is Array[Height, Width]
+            x.get_shape()  #     ...    is tuple[Height, Width]
 
-    """
+        """
 
-    # Trick Generic __parameters__.
-    __class__ = typing.TypeVar
+        # Trick Generic __parameters__.
+        __class__ = typing.TypeVar
 
-    def __iter__(self):
-        yield self.__unpacked__
+        def __iter__(self):
+            yield self.__unpacked__
 
-    def __init__(self, name):
-        self.__name__ = name
+        def __init__(self, name):
+            self.__name__ = name
 
-        # for pickling:
-        try:
-            def_mod = sys._getframe(1).f_globals.get('__name__', '__main__')
-        except (AttributeError, ValueError):
-            def_mod = None
-        if def_mod != 'typing_extensions':
-            self.__module__ = def_mod
+            # for pickling:
+            try:
+                def_mod = sys._getframe(1).f_globals.get('__name__', '__main__')
+            except (AttributeError, ValueError):
+                def_mod = None
+            if def_mod != 'typing_extensions':
+                self.__module__ = def_mod
 
-        self.__unpacked__ = Unpack[self]
+            self.__unpacked__ = Unpack[self]
 
-    def __repr__(self):
-        return self.__name__
+        def __repr__(self):
+            return self.__name__
 
-    def __hash__(self):
-        return object.__hash__(self)
+        def __hash__(self):
+            return object.__hash__(self)
 
-    def __eq__(self, other):
-        return self is other
+        def __eq__(self, other):
+            return self is other
 
-    def __reduce__(self):
-        return self.__name__
+        def __reduce__(self):
+            return self.__name__
 
-    def __init_subclass__(self, *args, **kwds):
-        if '_root' not in kwds:
-            raise TypeError("Cannot subclass special typing classes")
+        def __init_subclass__(self, *args, **kwds):
+            if '_root' not in kwds:
+                raise TypeError("Cannot subclass special typing classes")
 
 
 if hasattr(typing, "reveal_type"):


### PR DESCRIPTION
- Defer to the PEP 646 implementation in typing.py on 3.11
- Adjust some tests accordingly. Noted a bug in
  https://github.com/python/cpython/pull/32341#issuecomment-1100466389
- typing._type_check() is more lenient in 3.11 and no longer rejects ints
- The representation of the empty tuple type changed

Tests pass for me on a 3.11 build from today now.
