### PR TITLE
pyproject.toml: Add PyPI Project URLs

### DIFF
--- a/typing_extensions/pyproject.toml
+++ b/typing_extensions/pyproject.toml
@@ -43,6 +43,13 @@ classifiers = [
     "Topic :: Software Development"
 ]
 
+[project.urls]
+Repository = "https://github.com/python/typing"
+Changes = "https://github.com/python/typing/blob/master/typing_extensions/CHANGELOG"
+Documentation = "https://typing.readthedocs.io/"
+"Bug Tracker" = "https://github.com/python/typing/issues"
+"Q & A" = "https://github.com/python/typing/discussions"
+
 # Project metadata -- authors. Flit stores this as a list of dicts, so it can't
 # be inline above.
 [[project.authors]]

--- a/typing_extensions/pyproject.toml
+++ b/typing_extensions/pyproject.toml
@@ -10,7 +10,6 @@ version = "4.2.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
 readme = "README.rst"
 requires-python = ">=3.7"
-urls.Home = "https://github.com/python/typing/blob/master/typing_extensions/README.rst"
 license.file = "LICENSE"
 keywords = [
     "annotations",
@@ -44,6 +43,7 @@ classifiers = [
 ]
 
 [project.urls]
+Home = "https://github.com/python/typing/blob/master/typing_extensions/README.rst"
 Repository = "https://github.com/python/typing"
 Changes = "https://github.com/python/typing/blob/master/typing_extensions/CHANGELOG"
 Documentation = "https://typing.readthedocs.io/"


### PR DESCRIPTION
PyPI: These add links to changelog, docs, issue tracker and discussions for easy clicking

Before:
![image](https://user-images.githubusercontent.com/26336/163809624-35eca0ab-92e4-4b8f-8f23-56b92e808626.png)

After:
![image](https://user-images.githubusercontent.com/26336/163811364-8a2933fa-521b-4301-ac51-0ca87790bb3f.png)

<details>

<summary>Preview</summary>

![image](https://user-images.githubusercontent.com/26336/163811391-bcfd7740-f0b9-4aca-979c-988267ab7a55.png)

</details>