### PR TITLE
Make library docs more FAQ-like

### DIFF
--- a/docs/source/libraries.rst
+++ b/docs/source/libraries.rst
@@ -171,6 +171,9 @@ For example:
 Users are then able to install the stubs-only package separately to provide
 types for the original library.
 
+Inclusion in sdist
+^^^^^^^^^^^^^^^^^^
+
 Note that to ensure inclusion of ``.pyi`` and ``py.typed`` files in an sdist
 (.tar.gz archive), you may also need to modify the inclusion rules in your
 ``MANIFEST.in`` (see the

--- a/docs/source/libraries.rst
+++ b/docs/source/libraries.rst
@@ -135,14 +135,14 @@ included like so:
    )
 
 The presence of ``.pyi`` files does not affect the Python interpreter at runtime
-in any way. However, static type checkers will only look at ``.pyi`` file and
+in any way. However, static type checkers will only look at the ``.pyi`` file and
 ignore the corresponding ``.py`` file.
 
 Companion type stub package
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-These are often referred to as "stub-only" packages. The package should have a
-prefix of the runtime package name with a suffix of ``-stubs``. The py.typed
+These are often referred to as "stub-only" packages. The name of the stub package
+should be the name of the runtime package suffixed with ``-stubs``. The ``py.typed``
 marker file is not necessary for stub-only packages. This approach can be useful
 to develop type stubs independently from your library.
 


### PR DESCRIPTION
In the discussion that ensued in [this thread](https://mail.python.org/archives/list/python-dev@python.org/thread/VIZEBX5EYMSYIJNDBF6DMUMZOCWHARSO/#LAR7R5MCAC74N7H7NQXJUGXG7LCOA4CB), there was feedback that we could use better docs for library authors looking to understand what it entails to add types to their package.

Some of this was based on https://mypy.readthedocs.io/en/stable/installed_packages.html