### PR TITLE
Add type-hint and stub integration section

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -74,6 +74,13 @@ Linters and Formatters
 * `flake8-pyi <https://github.com/ambv/flake8-pyi>`_, a plugin for the
   `flake8 <https://flake8.pycqa.org/>`_ linter that adds support for type
   stubs.
+  
+Type-Hint and Stub Integration
+----------------------
+
+* `autotyping <https://github.com/JelleZijlstra/autotyping>`_, a tool which infers types from their context and inserts them as inline type-hints.
+* `merge_pyi <https://google.github.io/pytype/developers/tools.html#merge_pyi>`_, integrates .pyi signatures as inline type-hints in Python source code.
+* `retype <https://github.com/ambv/retype>`_, Re-applies type annotations from .pyi stubs to your codebase.
 
 Typing PEPs
 ===========

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -78,7 +78,7 @@ Linters and Formatters
 Type-Hint and Stub Integration
 ----------------------
 
-* `autotyping <https://github.com/JelleZijlstra/autotyping>`_, a tool which infers types from their context and inserts them as inline type-hints.
+* `autotyping <https://github.com/JelleZijlstra/autotyping>`_, a tool which infers simple types from their context and inserts them as inline type-hints.
 * `merge_pyi <https://google.github.io/pytype/developers/tools.html#merge_pyi>`_, integrates .pyi signatures as inline type-hints in Python source code.
 * `retype <https://github.com/ambv/retype>`_, Re-applies type annotations from .pyi stubs to your codebase.
 


### PR DESCRIPTION
Partially addresses #1242

Adds a new index of tools which allow for integrating type information into an existing codebase.