### PR TITLE
Add information about Python discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Chat at https://gitter.im/python/typing](https://badges.gitter.im/python/typing.svg)](https://gitter.im/python/typing?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-
 # Static Typing for Python
 
 ## Documentation and Support
@@ -13,6 +11,10 @@ Improvements to the type system should be discussed on the
 [typing-sig](https://mail.python.org/mailman3/lists/typing-sig.python.org/)
 mailing list, although the [issues](https://github.com/python/typing/issues) in this
 repository contain some historic discussions.
+
+For conversations that are more suitable to a chat platform, you can use one of the following:
+- [gitter](https://gitter.im/python/typing?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+- [discord](https://discord.com/channels/267624335836053506/891788761371906108) `#type-hinting` channel
 
 ## Repository Content
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 
 The documentation for Python's static typing can be found at
 [typing.readthedocs.io](https://typing.readthedocs.io/). You can get
-help either in our [support forum](https://github.com/python/typing/discussions) or
-chat with us on [Gitter](https://gitter.im/python/typing).
+help in our [support forum](https://github.com/python/typing/discussions).
 
 Improvements to the type system should be discussed on the
 [typing-sig](https://mail.python.org/mailman3/lists/typing-sig.python.org/)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ mailing list, although the [issues](https://github.com/python/typing/issues) in 
 repository contain some historic discussions.
 
 For conversations that are more suitable to a chat platform, you can use one of the following:
-- [gitter](https://gitter.im/python/typing?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+- [gitter](https://gitter.im/python/typing)
 - [discord](https://discord.com/channels/267624335836053506/891788761371906108) `#type-hinting` channel
 
 ## Repository Content


### PR DESCRIPTION
Python discord is a vibrant python community built on the modern social platform. A lot of people moved from gitter there.

This PR adds link to the discord, over time ~we would like to consolidate all conversations~ it's possible that discord can consolidate conversations from gitter.