### PR TITLE
Update docs for tools that inline pyi

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -80,7 +80,7 @@ Type-Hint and Stub Integration
 
 * `autotyping <https://github.com/JelleZijlstra/autotyping>`_, a tool which infers simple types from their context and inserts them as inline type-hints.
 * `merge_pyi <https://google.github.io/pytype/developers/tools.html#merge_pyi>`_, integrates .pyi signatures as inline type-hints in Python source code.
-* `retype <https://github.com/ambv/retype>`_, Re-applies type annotations from .pyi stubs to your codebase.
+  This is a thin wrapper around ``ApplyTypeAnnotationsVisitor`` from `libCST <https://libcst.readthedocs.io/en/latest/>`_.
 
 Typing PEPs
 ===========


### PR DESCRIPTION
retype is no longer maintained. Since it's based on lib2to3, its corpse is not going to be useful for too long. merge_pyi now just wraps libCST, so mention that.

If someone seeing this is looking for things to do, I think libCST's support here could be improved. E.g., I filed https://github.com/Instagram/LibCST/pull/868 But maybe that should convert to typing.Union. I'm sure there are other things that could be improved!