### PR TITLE
Recommend a consistent naming scheme for stub-only packages

### DIFF
--- a/docs/source/stubs.rst
+++ b/docs/source/stubs.rst
@@ -79,7 +79,7 @@ packages. The stubs for the standard library are usually distributed with type c
 require separate installation. Stubs for third-party libraries are
 available on the `Python Package Index <https://pypi.org>`_.
 By convention, a stub package for a library called ``widget`` would be named
-``types-widget``.
+``widget-stubs``.
 
 Supported Constructs
 ====================


### PR DESCRIPTION
As per PEP 561 [[1]](https://peps.python.org/pep-0561/):

> The name of the stub package MUST follow the scheme `foopkg-stubs` for type stubs for the package named `foopkg`.

This is already correctly stated in `libraries.rst` [[2]](https://github.com/python/typing/blob/master/docs/source/libraries.rst#companion-type-stub-package):

> The name of the stub package should be the name of the runtime package suffixed with `-stubs.`

---
[1] https://peps.python.org/pep-0561/
[2] https://github.com/python/typing/blob/master/docs/source/libraries.rst#companion-type-stub-package
