### PR TITLE
Allow walrus operators in allow-list of statically parseable `__all__` extensions

### DIFF
--- a/docs/source/libraries.rst
+++ b/docs/source/libraries.rst
@@ -231,6 +231,7 @@ determine the value of ``__all__``.
 -  ``__all__ = ('a', b')``
 -  ``__all__ = ['a', b']``
 -  ``__all__ += ['a', b']``
+-  ``__all__ += (variable := ['a', b'])``
 -  ``__all__ += submodule.__all__``
 -  ``__all__.extend(['a', b'])``
 -  ``__all__.extend(submodule.__all__)``


### PR DESCRIPTION
X-ref https://github.com/astral-sh/ruff/issues/7672 where this was first noticed.

There are a set of ways to extend `__all__` that can be passed statically and should be supported by static type checkers. However, I think that this list is incomplete, particularly that it is lacking support for expressions containing walrus operators.

For example
```python
__all__ = ["a", "b"]
__all__ += (variable := ["c", "d"])
```
is parseable statically to understand that the assignment to `variable` does not change what is assigned to ``__all__``.

I have added this to the list of supported idioms.