### PR TITLE
Fix docs warnings

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -83,7 +83,7 @@ Linters and Formatters
   stubs.
 
 Type-Hint and Stub Integration
-----------------------
+------------------------------
 
 * `autotyping <https://github.com/JelleZijlstra/autotyping>`_, a tool which infers simple types from their context and inserts them as inline type-hints.
 * `merge_pyi <https://google.github.io/pytype/developers/tools.html#merge_pyi>`_, integrates .pyi signatures as inline type-hints in Python source code.

--- a/docs/source/generics.rst
+++ b/docs/source/generics.rst
@@ -287,8 +287,6 @@ or a deserialization method returns the actual type of self. Therefore
 you may need to silence the type checker inside these methods (but not at the call site),
 possibly by making use of the ``Any`` type or a ``# type: ignore`` comment.
 
-For some advanced uses of self types, see :ref:`additional examples <advanced_self>`.
-
 Automatic self types using typing.Self
 **************************************
 
@@ -641,7 +639,7 @@ Here's how one could annotate the decorator:
 
 This still has some shortcomings. First, we need to use the unsafe
 :py:func:`~typing.cast` to convince type checkers that ``wrapper()`` has the same
-signature as ``func``. See :ref:`casts <casts>`.
+signature as ``func``.
 
 Second, the ``wrapper()`` function is not tightly type checked, although
 wrapper functions are typically small enough that this is not a big

--- a/docs/source/protocols.rst
+++ b/docs/source/protocols.rst
@@ -507,8 +507,7 @@ See also :py:class:`~typing.SupportsRound`.
 Async protocols
 ...............
 
-These protocols can be useful in async code. See :ref:`async-and-await`
-for more information.
+These protocols can be useful in async code.
 
 Awaitable[T]
 ------------


### PR DESCRIPTION
See #1513.

I didn't address warnings like `typing/docs/source/annotations.rst: WARNING: document isn't included in any toctree` because those documents are all empty.