### PR TITLE
Make pytype conformance test a little faster.

### DIFF
--- a/conformance/requirements.txt
+++ b/conformance/requirements.txt
@@ -1,5 +1,6 @@
 tomli
 tomlkit
+tqdm
 pyright
 mypy
 pyre-check

--- a/conformance/results/pytype/aliases_type_statement.toml
+++ b/conformance/results/pytype/aliases_type_statement.toml
@@ -3,5 +3,4 @@ notes = """
 Does not support `type` statement.
 """
 output = """
-File "aliases_type_statement.py", line 8: Type statement is only supported in Python 3.12 and greater [python-compiler-error]
-"""
+SyntaxError: Type statement is only supported in Python 3.12 and greater (<unknown>, line 8)"""

--- a/conformance/results/pytype/literals_literalstring.toml
+++ b/conformance/results/pytype/literals_literalstring.toml
@@ -3,4 +3,29 @@ notes = """
 Does not understand `LiteralString` special form.
 """
 output = """
+File "literals_literalstring.py", line 8, in <module>: typing.LiteralString not supported yet [not-supported-yet]
+File "literals_literalstring.py", line 24, in my_function: bad return type [bad-return-type]
+           Expected: str
+  Actually returned: None
+File "literals_literalstring.py", line 36, in <module>: Invalid type annotation 'Literal'  [invalid-annotation]
+  Bad parameter 'str' at index 1
+File "literals_literalstring.py", line 37, in <module>: Invalid type annotation 'Literal'  [invalid-annotation]
+  Bad parameter 'str' at index 0
+File "literals_literalstring.py", line 43, in func1: Type annotation for x2 does not match type of assignment [annotation-type-mismatch]
+  Annotation: Literal['']
+  Assignment: Literal['two']
+File "literals_literalstring.py", line 74, in func2: Type annotation for x3 does not match type of assignment [annotation-type-mismatch]
+  Annotation: str
+  Assignment: int
+File "literals_literalstring.py", line 75, in func2: Type annotation for x4 does not match type of assignment [annotation-type-mismatch]
+  Annotation: str
+  Assignment: bytes
+File "literals_literalstring.py", line 157, in func8: bad return type [bad-return-type]
+           Expected: int
+  Actually returned: None
+Called from (traceback):
+  line 160, in current file
+File "literals_literalstring.py", line 162, in <module>: bool [assert-type]
+  Expected: str
+    Actual: bool
 """

--- a/conformance/results/pytype/typeddicts_operations.toml
+++ b/conformance/results/pytype/typeddicts_operations.toml
@@ -9,15 +9,24 @@ output = """
 File "typeddicts_operations.py", line 28, in <module>: Type annotation for movie does not match type of assignment [annotation-type-mismatch]
   Annotation: Movie(TypedDict)
   Assignment: Dict[str, str]
+  
+  TypedDict missing keys: year
 File "typeddicts_operations.py", line 29, in <module>: Type annotation for movie does not match type of assignment [annotation-type-mismatch]
   Annotation: Movie(TypedDict)
   Assignment: Dict[str, Union[float, str]]
+  
+  TypedDict type errors: 
+    {'year': ...}: expected int, got float
 File "typeddicts_operations.py", line 32, in <module>: Type annotation for movie does not match type of assignment [annotation-type-mismatch]
   Annotation: Movie(TypedDict)
   Assignment: Dict[str, Union[int, str]]
+  
+  TypedDict extra keys: other
 File "typeddicts_operations.py", line 37, in func1: Type annotation for movie does not match type of assignment [annotation-type-mismatch]
   Annotation: Movie(TypedDict)
   Assignment: Dict[str, Union[int, str]]
+  
+  TypedDict missing keys: name
 File "typeddicts_operations.py", line 60, in <module>: str [assert-type]
   Expected: Optional[str]
     Actual: str

--- a/conformance/results/pytype/typeddicts_required.toml
+++ b/conformance/results/pytype/typeddicts_required.toml
@@ -5,4 +5,4 @@ Does not reject use of `Required` in function parameter annotation.
 Does not reject nested use of `Required` in type annotation.
 """
 output = """
-"""
+RecursionError: maximum recursion depth exceeded"""

--- a/conformance/results/pytype/typeddicts_type_consistency.toml
+++ b/conformance/results/pytype/typeddicts_type_consistency.toml
@@ -8,13 +8,22 @@ output = """
 File "typeddicts_type_consistency.py", line 62, in <module>: Type annotation for a3 does not match type of assignment [annotation-type-mismatch]
   Annotation: A3(TypedDict)
   Assignment: B3
+  
+  TypedDict extra keys: y
 File "typeddicts_type_consistency.py", line 65, in <module>: Type annotation for b3 does not match type of assignment [annotation-type-mismatch]
   Annotation: B3(TypedDict)
   Assignment: Dict[str, int]
+  
+  TypedDict missing keys: y
 File "typeddicts_type_consistency.py", line 69, in <module>: Type annotation for a3_1 does not match type of assignment [annotation-type-mismatch]
   Annotation: A3(TypedDict)
   Assignment: Dict[str, int]
+  
+  TypedDict extra keys: y
 File "typeddicts_type_consistency.py", line 124, in <module>: Type annotation for o2 does not match type of assignment [annotation-type-mismatch]
   Annotation: Outer1(TypedDict)
   Assignment: Dict[str, Dict[str, Dict[str, int]]]
+  
+  TypedDict type errors: 
+    {'outer_key': ...}: expected Inner2, got Dict[str, Dict[str, int]]
 """

--- a/conformance/results/pytype/typeddicts_usage.toml
+++ b/conformance/results/pytype/typeddicts_usage.toml
@@ -11,4 +11,7 @@ File "typeddicts_usage.py", line 24, in <module>: Type annotation for key year i
 File "typeddicts_usage.py", line 28, in <module>: Type annotation for movie2 does not match type of assignment [annotation-type-mismatch]
   Annotation: Movie(TypedDict)
   Assignment: Dict[str, Union[int, str]]
+  
+  TypedDict missing keys: name
+  TypedDict extra keys: title
 """

--- a/conformance/results/pytype/version.toml
+++ b/conformance/results/pytype/version.toml
@@ -1,2 +1,2 @@
 version = "pytype 2023.12.18"
-test_duration = 51.5667941570282
+test_duration = 28.1415696144104

--- a/conformance/results/results.html
+++ b/conformance/results/results.html
@@ -340,7 +340,7 @@
 <tr><th>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</th><th class="column col1">narrowing_typeguard</th><th class="column col2 partially-conformant">Partial</th><th class="column col3">Does not support `tuple` in `assert_type` call.<br>Does not reject TypeGuard method with too few parameters.<br></th></tr>
 <tr><th class="column spacer" colspan="4"></th></tr>
 </table></div>
-<div class='tc-header'><span class='tc-name'>pytype 2023.12.18<span class='tc-time'>(51.57sec)</span>
+<div class='tc-header'><span class='tc-name'>pytype 2023.12.18<span class='tc-time'>(28.14sec)</span>
 </div>
 <div class="table_container"><table>
 <tr><th class="column spacer" colspan="4"></th></tr>


### PR DESCRIPTION
This change gets the pytype test down to ~30s. It's still considerably slower than the others, but any further improvements will likely require untangling the sad state of affairs that is
https://github.com/google/pytype/issues/1501, which will take some time.

* Runs pytype's 'check' option through pytype.io.check_py to skip the costly type inference that it does by default.
* Adds a progress bar so that it doesn't look like pytype is hanging.

This generates a few changes to results/pytype/, mostly due to error messages being formatted and parsed differently.