### PR TITLE
Spec: add `paramspec` reference to link from PEP 612

### DIFF
--- a/docs/spec/generics.rst
+++ b/docs/spec/generics.rst
@@ -589,6 +589,8 @@ while the following is prohibited::
   def bad_func(x: B_co) -> B_co:  # Flagged as error by a type checker
       ...
 
+.. _`paramspec`:
+
 ParamSpec
 ---------
 


### PR DESCRIPTION
This will allow referencing via intersphinx from other Sphinx sites, specifically from PEP 612. 

I'm about to update https://github.com/python/peps/pull/3575 so that it can use this to refer to here as the canonical documentation.

This is how the PyPA packaging specs do it, for example:

* https://peps.python.org/pep-0376/
* https://github.com/python/peps/blob/9498cb7107bcb14e816fbf533ca6bd968aedd953/peps/pep-0376.rst?plain=1#L13
* https://github.com/pypa/packaging.python.org/blob/8079afc6fc3bca0135df3646b97dbae1e7ab00af/source/specifications/core-metadata.rst?plain=1#L3