### PR TITLE
Added clarification about pre-3.8 way to specify positional-only parameters.

### DIFF
--- a/docs/spec/historical.rst
+++ b/docs/spec/historical.rst
@@ -188,25 +188,30 @@ When checking Python 2.7 code, type checkers should treat the ``int`` and
 type ``str`` as well as ``unicode`` should be acceptable.
 
 
-Positional-only arguments
--------------------------
+Positional-only parameters
+--------------------------
 
 Some functions are designed to take their arguments only positionally,
 and expect their callers never to use the argument's name to provide
 that argument by keyword. Before Python 3.8 (:pep:`570`), Python did
-not provide a way to declare positional-only arguments.
+not provide a way to declare positional-only parameters.
 
-To support positional-only arguments on older Python versions, type
-checkers support the following special case:
-all arguments with names beginning with
-``__`` are assumed to be positional-only, except if their names also
-end with ``__``::
+To support positional-only parameters on older Python versions, type
+checkers should support the following special case: all parameters with
+names beginning with ``__`` are assumed to be positional-only unless their
+names also end with ``__``::
 
-  def quux(__x: int, __y__: int = 0) -> None: ...
+  def f(__x: int, __y__: int = 0) -> None: ...
 
-  quux(3, __y__=1)  # This call is fine.
+  f(3, __y__=1)  # This call is fine.
 
-  quux(__x=3)  # This call is an error.
+  f(__x=3)  # This call is an error.
+
+Consistent with :pep:`570` syntax, positional-only parameters cannot appear
+after parameters that accept keyword arguments. Type checkers should enforce
+this requirement::
+
+  def g(x: int, __y: int) -> None: ...  # Type error
 
 
 Generics in standard collections

--- a/docs/spec/historical.rst
+++ b/docs/spec/historical.rst
@@ -196,7 +196,7 @@ and expect their callers never to use the argument's name to provide
 that argument by keyword. Before Python 3.8 (:pep:`570`), Python did
 not provide a way to declare positional-only parameters.
 
-To support positional-only parameters for code that is intended to work
+To support positional-only parameters in code that must remain compatible
 with older versions of Python, type checkers should support the following
 special case: all parameters with names beginning with ``__`` are assumed to 
 be positional-only unless their names also end with ``__``::

--- a/docs/spec/historical.rst
+++ b/docs/spec/historical.rst
@@ -198,8 +198,8 @@ not provide a way to declare positional-only parameters.
 
 To support positional-only parameters in code that must remain compatible
 with older versions of Python, type checkers should support the following
-special case: all parameters with names beginning with ``__`` are assumed to 
-be positional-only unless their names also end with ``__``::
+special case: all parameters with names that begin but don't end with ``__``
+are assumed to be positional-only::
 
   def f(__x: int, __y__: int = 0) -> None: ...
 

--- a/docs/spec/historical.rst
+++ b/docs/spec/historical.rst
@@ -196,10 +196,10 @@ and expect their callers never to use the argument's name to provide
 that argument by keyword. Before Python 3.8 (:pep:`570`), Python did
 not provide a way to declare positional-only parameters.
 
-To support positional-only parameters on older Python versions, type
-checkers should support the following special case: all parameters with
-names beginning with ``__`` are assumed to be positional-only unless their
-names also end with ``__``::
+To support positional-only parameters for code that is intended to work
+with older versions of Python, type checkers should support the following
+special case: all parameters with names beginning with ``__`` are assumed to 
+be positional-only unless their names also end with ``__``::
 
   def f(__x: int, __y__: int = 0) -> None: ...
 


### PR DESCRIPTION
This is a draft proposal related to [this discussion](https://discuss.python.org/t/ambiguities-about-positional-only-parameters/42328).