### PR TITLE
Spec: add `Self` reference to link from PEP 673

### DIFF
--- a/docs/spec/generics.rst
+++ b/docs/spec/generics.rst
@@ -1754,6 +1754,8 @@ overloads for each possible rank is, of course, a rather cumbersome
 solution. However, it's the best we can do without additional type
 manipulation mechanisms.)
 
+.. _`self`:
+
 ``Self``
 --------
 


### PR DESCRIPTION
Like https://github.com/python/typing/pull/1566, so we can mark PEP 673 as Final and refer to the typing spec as the canonical docs.