### PR TITLE
Spec: add Protocols reference to link from PEP 544

### DIFF
--- a/docs/spec/protocol.rst
+++ b/docs/spec/protocol.rst
@@ -1,3 +1,5 @@
+.. _protocols:
+
 Protocols
 ---------
 


### PR DESCRIPTION
Like https://github.com/python/typing/pull/1566, to mark https://peps.python.org/pep-0544/ as final.