### PR TITLE
Bump GitHub Actions

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
     - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python 3
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3
           cache: "pip"


### PR DESCRIPTION
To fix some deprecation warings:

![image](https://github.com/python/typing/assets/1324225/ff1e8236-2251-4498-b56f-57248f1d9e02)

Would Dependabot be useful here? To make it less spammy, we can set it to monthly and group updates into a single PR.

https://github.com/python/typing/actions/runs/7818405828?pr=1621
