### PR TITLE
Add Dependabot to keep GitHub Actions up-to-date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: monthly
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Monthly grouped updates to keep it less spammy.