### PR TITLE
Spec: add TypeGuard reference to link from PEP 647

### DIFF
--- a/docs/spec/narrowing.rst
+++ b/docs/spec/narrowing.rst
@@ -1,8 +1,12 @@
+.. _`type-narrowing`:
+
 Type narrowing
 ==============
 
 Type checkers should narrow the types of expressions in
 certain contexts. This behavior is currently largely unspecified.
+
+.. _`typeguard`:
 
 TypeGuard
 ---------


### PR DESCRIPTION
Like https://github.com/python/typing/pull/1566, so we can mark PEP 647 as Final and refer to the typing spec as the canonical docs.

(I'll re-open https://github.com/python/peps/pull/3577)