### PR TITLE
Added the spec part of PEP 705 to the typing spec.

### DIFF
--- a/docs/spec/typeddict.rst
+++ b/docs/spec/typeddict.rst
@@ -579,7 +579,7 @@ may also enforce this restriction.
 
 The :pep:`alternative functional syntax <589#alternative-syntax>`
 for TypedDict also supports
-``Required[]`` and ``NotRequired[]``:
+``Required[]``, ``NotRequired[]``, and ``ReadOnly[]``:
 
 ::
 
@@ -660,13 +660,6 @@ The ``typing.ReadOnly`` type qualifier is used to indicate that an item declared
     blur["members"] = ["Damon Albarn"]  # Type check error: "members" is read-only
     blur["members"].append("Damon Albarn")  # OK: list is mutable
 
-
-Alternative functional syntax
------------------------------
-
-The :pep:`alternative functional syntax <589#alternative-syntax>` for TypedDict also supports the new type qualifier::
-
-   Band = TypedDict("Band", {"name": str, "members": ReadOnly[list[str]]})
 
 Interaction with other special types
 ------------------------------------
@@ -809,7 +802,7 @@ Note: Nothing will ever match the ``Never`` type, so an item annotated with it m
 Keyword argument typing
 -----------------------
 
-:pep:`692` introduced ``Unpack`` to annotate ``**kwargs`` with a ``TypedDict``. Marking one or more of the items of a ``TypedDict`` used in this way as read-only will have no effect on the type signature of the method. However, it *will* prevent the item from being modified in the body of the function::
+As discussed in the section `unpack-kwargs`_, an unpacked ``TypedDict`` can be used to annotate ``**kwargs``. Marking one or more of the items of a ``TypedDict`` used in this way as read-only will have no effect on the type signature of the method. However, it *will* prevent the item from being modified in the body of the function::
 
     class Args(TypedDict):
         key1: int

--- a/docs/spec/typeddict.rst
+++ b/docs/spec/typeddict.rst
@@ -822,7 +822,7 @@ Keyword argument typing
     class Function(Protocol):
         def __call__(self, **kwargs: Unpack[Args]) -> None: ...
 
-    def impl(self, **kwargs: Unpack[ReadOnlyArgs]) -> None:
+    def impl(**kwargs: Unpack[ReadOnlyArgs]) -> None:
         kwargs["key1"] = 3  # Type check error: key1 is readonly
 
     fn: Function = impl  # Accepted by type checker: function signatures are identical

--- a/docs/spec/typeddict.rst
+++ b/docs/spec/typeddict.rst
@@ -637,3 +637,193 @@ In particular allowing ``Annotated[]`` to be the outermost annotation
 for an item allows better interoperability with non-typing uses of
 annotations, which may always want ``Annotated[]`` as the outermost annotation
 (`discussion <https://bugs.python.org/issue46491>`__).
+
+
+Read-only Items
+===============
+
+(Originally specified in :pep:`705`.)
+
+``typing.ReadOnly`` type qualifier
+----------------------------------
+
+The ``typing.ReadOnly`` type qualifier is used to indicate that an item declared in a ``TypedDict`` definition may not be mutated (added, modified, or removed)::
+
+    from typing import ReadOnly
+
+    class Band(TypedDict):
+        name: str
+        members: ReadOnly[list[str]]
+
+    blur: Band = {"name": "blur", "members": []}
+    blur["name"] = "Blur"  # OK: "name" is not read-only
+    blur["members"] = ["Damon Albarn"]  # Type check error: "members" is read-only
+    blur["members"].append("Damon Albarn")  # OK: list is mutable
+
+
+Alternative functional syntax
+-----------------------------
+
+The :pep:`alternative functional syntax <589#alternative-syntax>` for TypedDict also supports the new type qualifier::
+
+   Band = TypedDict("Band", {"name": str, "members": ReadOnly[list[str]]})
+
+Interaction with other special types
+------------------------------------
+
+``ReadOnly[]`` can be used with ``Required[]``, ``NotRequired[]`` and ``Annotated[]``, in any nesting order:
+
+::
+
+    class Movie(TypedDict):
+        title: ReadOnly[Required[str]]  # OK
+        year: ReadOnly[NotRequired[Annotated[int, ValueRange(-9999, 9999)]]]  # OK
+
+::
+
+    class Movie(TypedDict):
+        title: Required[ReadOnly[str]]  # OK
+        year: Annotated[NotRequired[ReadOnly[int]], ValueRange(-9999, 9999)]  # OK
+
+
+Inheritance
+-----------
+
+Subclasses can redeclare read-only items as non-read-only, allowing them to be mutated::
+
+    class NamedDict(TypedDict):
+        name: ReadOnly[str]
+
+    class Album(NamedDict):
+        name: str
+        year: int
+
+    album: Album = { "name": "Flood", "year": 1990 }
+    album["year"] = 1973
+    album["name"] = "Dark Side Of The Moon"  # OK: "name" is not read-only in Album
+
+If a read-only item is not redeclared, it remains read-only::
+
+    class Album(NamedDict):
+        year: int
+
+    album: Album = { "name": "Flood", "year": 1990 }
+    album["name"] = "Dark Side Of The Moon"  # Type check error: "name" is read-only in Album
+
+Subclasses can narrow value types of read-only items::
+
+    class AlbumCollection(TypedDict):
+        albums: ReadOnly[Collection[Album]]
+
+    class RecordShop(AlbumCollection):
+        name: str
+        albums: ReadOnly[list[Album]]  # OK: "albums" is read-only in AlbumCollection
+
+Subclasses can require items that are read-only but not required in the superclass::
+
+    class OptionalName(TypedDict):
+        name: ReadOnly[NotRequired[str]]
+
+    class RequiredName(OptionalName):
+        name: ReadOnly[Required[str]]
+
+    d: RequiredName = {}  # Type check error: "name" required
+
+Subclasses can combine these rules::
+
+    class OptionalIdent(TypedDict):
+        ident: ReadOnly[NotRequired[str | int]]
+
+    class User(OptionalIdent):
+        ident: str  # Required, mutable, and not an int
+
+Note that these are just consequences of structural typing, but they are highlighted here as the behavior now differs from the rules specified in :pep:`589`.
+
+Type consistency
+----------------
+
+*This section updates the type consistency rules described above that were created prior to the introduction of ReadOnly*
+
+A TypedDict type ``A`` is consistent with TypedDict ``B`` if ``A`` is structurally compatible with ``B``. This is true if and only if all of the following are satisfied:
+
+* For each item in ``B``, ``A`` has the corresponding key, unless the item in ``B`` is read-only, not required, and of top value type (``ReadOnly[NotRequired[object]]``).
+* For each item in ``B``, if ``A`` has the corresponding key, the corresponding value type in ``A`` is consistent with the value type in ``B``.
+* For each non-read-only item in ``B``, its value type is consistent with the corresponding value type in ``A``.
+* For each required key in ``B``, the corresponding key is required in ``A``.
+* For each non-required key in ``B``, if the item is not read-only in ``B``, the corresponding key is not required in ``A``.
+
+Discussion:
+
+* All non-specified items in a TypedDict implicitly have value type ``ReadOnly[NotRequired[object]]``.
+
+* Read-only items behave covariantly, as they cannot be mutated. This is similar to container types such as ``Sequence``, and different from non-read-only items, which behave invariantly. Example::
+
+    class A(TypedDict):
+        x: ReadOnly[int | None]
+
+    class B(TypedDict):
+        x: int
+
+    def f(a: A) -> None:
+        print(a["x"] or 0)
+
+    b: B = {"x": 1}
+    f(b)  # Accepted by type checker
+
+* A TypedDict type ``A`` with no explicit key ``'x'`` is not consistent with a TypedDict type ``B`` with a non-required key ``'x'``, since at runtime the key ``'x'`` could be present and have an incompatible type (which may not be visible through ``A`` due to structural subtyping). The only exception to this rule is if the item in ``B`` is read-only, and the value type is of top type (``object``). For example::
+
+    class A(TypedDict):
+        x: int
+
+    class B(TypedDict):
+        x: int
+        y: ReadOnly[NotRequired[object]]
+
+    a: A = { "x": 1 }
+    b: B = a  # Accepted by type checker
+
+Update method
+-------------
+
+In addition to existing type checking rules, type checkers should error if a TypedDict with a read-only item is updated with another TypedDict that declares that key::
+
+    class A(TypedDict):
+        x: ReadOnly[int]
+        y: int
+
+    a1: A = { "x": 1, "y": 2 }
+    a2: A = { "x": 3, "y": 4 }
+    a1.update(a2)  # Type check error: "x" is read-only in A
+
+Unless the declared value is of bottom type (:data:`~typing.Never`)::
+
+    class B(TypedDict):
+        x: NotRequired[typing.Never]
+        y: ReadOnly[int]
+
+    def update_a(a: A, b: B) -> None:
+        a.update(b)  # Accepted by type checker: "x" cannot be set on b
+
+Note: Nothing will ever match the ``Never`` type, so an item annotated with it must be absent.
+
+Keyword argument typing
+-----------------------
+
+:pep:`692` introduced ``Unpack`` to annotate ``**kwargs`` with a ``TypedDict``. Marking one or more of the items of a ``TypedDict`` used in this way as read-only will have no effect on the type signature of the method. However, it *will* prevent the item from being modified in the body of the function::
+
+    class Args(TypedDict):
+        key1: int
+        key2: str
+
+    class ReadOnlyArgs(TypedDict):
+        key1: ReadOnly[int]
+        key2: ReadOnly[str]
+
+    class Function(Protocol):
+        def __call__(self, **kwargs: Unpack[Args]) -> None: ...
+
+    def impl(self, **kwargs: Unpack[ReadOnlyArgs]) -> None:
+        kwargs["key1"] = 3  # Type check error: key1 is readonly
+
+    fn: Function = impl  # Accepted by type checker: function signatures are identical
+


### PR DESCRIPTION
This is related to https://github.com/python/typing/issues/1643.