### PR TITLE
spec: Separate "Glossary" section

### DIFF
--- a/docs/spec/distributing.rst
+++ b/docs/spec/distributing.rst
@@ -3,6 +3,8 @@
 Distributing type information
 =============================
 
+.. _stub-files:
+
 Stub files
 ----------
 
@@ -119,7 +121,7 @@ type checking as well.
 
 To have this file including with the package, maintainers can use existing packaging
 options such as ``package_data`` in ``setuptools``. For more details, see
-:ref:`the guide to providing type annotations <providing-type-annotations>`_.
+:ref:`the guide to providing type annotations <providing-type-annotations>`.
 
 For namespace packages (see :pep:`420`), the ``py.typed`` file should be in the
 submodules of the namespace, to avoid conflicts and for clarity.
@@ -154,7 +156,7 @@ information.
 Third parties seeking to distribute stub files are encouraged to contact the
 maintainer of the package about distribution alongside the package. If the
 maintainer does not wish to maintain or package stub files or type information
-inline, then a third party stub-only package can be created.
+:term:`inline`, then a third party stub-only package can be created.
 
 In addition, stub-only distributions MAY indicate which version(s)
 of the runtime package are targeted by indicating the runtime distribution's
@@ -192,7 +194,7 @@ Many stub packages will only have part of the type interface for libraries
 completed, especially initially. For the benefit of type checking and code
 editors, packages can be "partial". This means modules not found in the stub
 package SHOULD be searched for in part four of the module resolution
-order below, namely inline packages.
+order below, namely :term:`inline` packages.
 
 Type checkers should merge the stub package and runtime package
 directories. This can be thought of as the functional equivalent of copying the
@@ -220,14 +222,14 @@ The following is the order in which type checkers supporting this specification 
 resolve modules containing type information:
 
 
-1. Stubs or Python source manually put in the beginning of the path. Type
+1. :term:`Stubs <stub>` or Python source manually put in the beginning of the path. Type
    checkers SHOULD provide this to allow the user complete control of which
-   stubs to use, and to patch broken stubs/inline types from packages.
+   stubs to use, and to patch broken stubs or :term:`inline` types from packages.
    In mypy the ``$MYPYPATH`` environment variable can be used for this.
 
 2. User code - the files the type checker is running on.
 
-3. Stub packages - these packages SHOULD supersede any installed inline
+3. :term:`Stub <stub>` packages - these packages SHOULD supersede any installed inline
    package. They can be found in directories named ``foopkg-stubs`` for
    package ``foopkg``.
 

--- a/docs/spec/glossary.rst
+++ b/docs/spec/glossary.rst
@@ -5,9 +5,6 @@ Glossary
 
 This section defines a few terms that may be used elsewhere in the specification.
 
-The definition of "MAY", "MUST", and "SHOULD", and "SHOULD NOT" are
-to be interpreted as described in :rfc:`2119`.
-
 .. glossary::
 
    distribution

--- a/docs/spec/glossary.rst
+++ b/docs/spec/glossary.rst
@@ -1,0 +1,33 @@
+.. _`glossary`:
+
+Glossary
+========
+
+This section defines a few terms that may be used elsewhere in the specification.
+
+The definition of "MAY", "MUST", and "SHOULD", and "SHOULD NOT" are
+to be interpreted as described in :rfc:`2119`.
+
+.. glossary::
+
+   distribution
+      The packaged file which is used to publish and distribute
+      a release. (:pep:`426`)
+
+   inline
+      Inline type annotations are annotations that are included in the
+      runtime code using :pep:`526` and
+      :pep:`3107` syntax (the filename ends in ``.py``).
+
+   module
+      A file containing Python runtime code or stubbed type information.
+
+   package
+      A directory or directories that namespace Python modules.
+      (Note the distinction between packages and :term:`distributions <distribution>`.
+      While most distributions are named after the one package they install, some
+      distributions install multiple packages.)
+
+   stub
+      A file containing only type information, empty of runtime code
+      (the filename ends in ``.pyi``). See :ref:`stub-files`.

--- a/docs/spec/index.rst
+++ b/docs/spec/index.rst
@@ -26,3 +26,4 @@ Specification for the Python type system
    directives
    distributing
    historical
+   glossary

--- a/docs/spec/protocol.rst
+++ b/docs/spec/protocol.rst
@@ -234,7 +234,7 @@ Now the protocol ``SizedAndClosable`` is a protocol with two methods,
 ``__len__`` and ``close``. If one omits ``Protocol`` in the base class list,
 this would be a regular (non-protocol) class that must implement ``Sized``.
 Alternatively, one can implement ``SizedAndClosable`` protocol by merging
-the ``SupportsClose`` protocol from the example in the `definition`_ section
+the ``SupportsClose`` protocol from the example in the `protocol-definition`_ section
 with ``typing.Sized``::
 
   from collections.abc import Sized

--- a/docs/spec/type-system.rst
+++ b/docs/spec/type-system.rst
@@ -43,29 +43,3 @@ optimizations is left as an exercise for the reader.
 It should also be emphasized that **Python will remain a dynamically
 typed language, and there is no desire to ever make type hints
 mandatory, even by convention.**
-
-.. _`definitions`:
-
-Definition of terms
--------------------
-
-This section defines a few terms that may be used elsewhere in the specification.
-
-The definition of "MAY", "MUST", and "SHOULD", and "SHOULD NOT" are
-to be interpreted as described in :rfc:`2119`.
-
-"inline" - the types are part of the runtime code using :pep:`526` and
-:pep:`3107` syntax (the filename ends in ``.py``).
-
-"stubs" - files containing only type information, empty of runtime code
-(the filename ends in ``.pyi``).
-
-"Distributions" are the packaged files which are used to publish and distribute
-a release. (:pep:`426`)
-
-"Module" a file containing Python runtime code or stubbed type information.
-
-"Package" a directory or directories that namespace Python modules.
-(Note the distinction between packages and distributions.  While most
-distributions are named after the one package they install, some
-distributions install multiple packages.)

--- a/docs/spec/type-system.rst
+++ b/docs/spec/type-system.rst
@@ -43,3 +43,9 @@ optimizations is left as an exercise for the reader.
 It should also be emphasized that **Python will remain a dynamically
 typed language, and there is no desire to ever make type hints
 mandatory, even by convention.**
+
+Interpretation
+--------------
+
+The definition of "MAY", "MUST", and "SHOULD", and "SHOULD NOT" are
+to be interpreted as described in :rfc:`2119`.


### PR DESCRIPTION
I'd like to add a glossary section for https://discuss.python.org/t/basic-terminology-for-types-and-type-forms/46741,
but felt it was better to do the housekeeping in a separate PR.

This PR makes no substantive changes; it just moves text around and uses the Sphinx glossary format. Therefore, I don't think it needs Typing Council approval.