### PR TITLE
spec: clarify interaction of Final and dataclass

### DIFF
--- a/docs/spec/dataclasses.rst
+++ b/docs/spec/dataclasses.rst
@@ -516,13 +516,15 @@ This includes, but is not limited to, the following semantics:
 * ClassVar attributes are not considered dataclass fields and are
   `ignored by dataclass mechanisms <https://docs.python.org/3/library/dataclasses.html#class-variables>`_.
 
-* Dataclass fields annotated with ``Final`` and initialized in the class body
-  are not considered class attributes unless explicitly annotated with
-  ``ClassVar``. For example, ``x: Final[int] = 3`` in a dataclass body is a
-  dataclass field (and thus instance attribute) named ``x`` with a default
-  value of ``3`` in the generated ``__init__`` method, which cannot be
-  reassigned after ``__init__``. A final class variable on a dataclass should
-  be explicitly annotated as ``x: ClassVar[Final[int]] = 3``.
+* A dataclass field may be annotated with ``Final[...]``. For example, ``x:
+  Final[int]`` in a dataclass body specifies a dataclass field ``x``, which
+  will be initialized in the generated ``__init__`` and cannot be assigned to
+  thereafter. A ``Final`` dataclass field initialized in the class body is not
+  a class attribute unless explicitly annotated with ``ClassVar``. For example,
+  ``x: Final[int] = 3`` is a dataclass field named ``x`` with a default value
+  of ``3`` in the generated ``__init__`` method. A final class variable on a
+  dataclass must be explicitly annotated as e.g. ``x: ClassVar[Final[int]] =
+  3``.
 
 
 Undefined behavior

--- a/docs/spec/dataclasses.rst
+++ b/docs/spec/dataclasses.rst
@@ -516,6 +516,14 @@ This includes, but is not limited to, the following semantics:
 * ClassVar attributes are not considered dataclass fields and are
   `ignored by dataclass mechanisms <https://docs.python.org/3/library/dataclasses.html#class-variables>`_.
 
+* Dataclass fields annotated with ``Final`` and initialized in the class body
+  are not considered class attributes unless explicitly annotated with
+  ``ClassVar``. For example, ``x: Final[int] = 3`` in a dataclass body is a
+  dataclass field (and thus instance attribute) named ``x`` with a default
+  value of ``3`` in the generated ``__init__`` method, which cannot be
+  reassigned after ``__init__``. A final class variable on a dataclass should
+  be explicitly annotated as ``x: ClassVar[Final[int]] = 3``.
+
 
 Undefined behavior
 ^^^^^^^^^^^^^^^^^^

--- a/docs/spec/qualifiers.rst
+++ b/docs/spec/qualifiers.rst
@@ -147,6 +147,10 @@ be initialized in the ``__init__`` method (except in stub files)::
        def __init__(self) -> None:
            self.x = 1  # Good
 
+The generated ``__init__`` method of :doc:`dataclasses` qualifies for this
+requirement: a bare ``x: Final[int]`` is permitted in a dataclass body, because
+the generated ``__init__`` will initialize ``x``.
+
 Type checkers should infer a final attribute that is initialized in a class
 body as being a class variable, except in the case of :doc:`dataclasses`, where
 ``x: Final[int] = 3`` creates a dataclass field and instance-level final

--- a/docs/spec/qualifiers.rst
+++ b/docs/spec/qualifiers.rst
@@ -147,18 +147,26 @@ be initialized in the ``__init__`` method (except in stub files)::
        def __init__(self) -> None:
            self.x = 1  # Good
 
-Type checkers should infer a final attribute that is initialized in
-a class body as being a class variable. Variables should not be annotated
-with both ``ClassVar`` and ``Final``.
+Type checkers should infer a final attribute that is initialized in a class
+body as being a class variable, except in the case of :doc:`dataclasses`, where
+``x: Final[int] = 3`` creates a dataclass field and instance-level final
+attribute ``x`` with default value ``3``; ``x: ClassVar[Final[int]] = 3`` is
+necessary to create a final class variable with value ``3``. In
+non-dataclasses, combining ``ClassVar`` and ``Final`` is redundant, and type
+checkers may choose to warn or error on the redundancy.
 
-``Final`` may only be used as the outermost type in assignments or variable
-annotations. Using it in any other position is an error. In particular,
-``Final`` can't be used in annotations for function arguments::
+``Final`` may only be used in assignments or variable annotations. Using it in
+any other position is an error. In particular, ``Final`` can't be used in
+annotations for function arguments::
 
    x: list[Final[int]] = []  # Error!
 
    def fun(x: Final[List[int]]) ->  None:  # Error!
        ...
+
+``Final`` may be wrapped only by other type qualifiers (e.g. ``ClassVar`` or
+``Annotation``). It cannot be used in a type parameter (e.g.
+``list[Final[int]]`` is not permitted.)
 
 Note that declaring a name as final only guarantees that the name will
 not be re-bound to another value, but does not make the value


### PR DESCRIPTION
See discussion thread at https://discuss.python.org/t/treatment-of-final-attributes-in-dataclass-likes/47154 and issue at https://github.com/python/cpython/issues/89547

Consider a dataclass with a Final-annotated initialized assignment in the class body:

```
@dataclass
class C:
    x: Final[int] = 3
```

This is currently under-specified in the typing spec. Neither PEP 591 or PEP 681 clearly specified this composition.

There are two possible consistent interpretations:

1) It could be a class-only variable (implicit `ClassVar`) `C.x` with final value `3`. In this interpretation, it should not be a dataclass field, because dataclass fields are inherently set on instances, they cannot be ClassVar. This is the interpretation suggested by PEP 591 (and thus also the current typing spec for Final), which say that Final with an assigned value in a class body is always implicitly a ClassVar.

2) It could be a dataclass field ``x`` with default value ``3``, which cannot be reassigned on an instance after it is initialized in the generated ``__init__`` method.

This pull request specifies option 2.

I will also provide an update to the conformance suite for this, if the Typing Council accepts the spec change.

## Current runtime behavior

The stdlib dataclasses module considers `x` in this example to be a dataclass field.

If the assigned value is a default value (as in the example above), dataclasses leaves that default value in place as a class attribute (so `x` is a class-and-instance variable, and `C.x == 3`.) If the assigned value is a `field(...)` call, dataclasses does not leave any attribute `x` on the class at all, so `x` is purely a dataclass field / instance variable.

## Current type-checker behavior

Playground links:

[mypy](https://mypy-play.net/?mypy=latest&python=3.12&gist=f9b653fe9073ca191e990e7d65013734)
[pyre](https://pyre-check.org/play?input=from%20typing%20import%20assert_type%2C%20Final%0Afrom%20dataclasses%20import%20dataclass%2C%20field%0A%0A%40dataclass%0Aclass%20Item%3A%0A%20%20%20%20x%3A%20Final%5Bint%5D%20%3D%203%0A%20%20%20%20y%3A%20Final%5Bint%5D%20%3D%20field(default%3D4)%0A%20%20%20%20%0Adef%20f()%20-%3E%20None%3A%0A%20%20%20%20item%20%3D%20Item()%0A%20%20%20%20assert_type(item.x%2C%20int)%0A%20%20%20%20item2%20%3D%20Item(x%3D2)%0A%20%20%20%20assert_type(item2.x%2C%20int)%0A%20%20%20%20item2.x%20%3D%204%0A%20%20%20%20reveal_type(Item.x)%0A%20%20%20%20reveal_type(Item.y))
[pyright](https://pyright-play.net/?strict=true&enableExperimentalFeatures=true&code=GYJw9gtgBALgngBwJYDsDmUkQWEMoCGAzkQKZ4D68CpANFAGKoEA2AUKJFACYEwEBjFsTJFM2XPl78hI%2BsCSkW3NmwAC0wcJJtZJKAEkYpCAC42US1AAepxsxYBtVDAC6UALxQAzBatw7JhRWZxQ3TygFJW4ACm5SYAIAVxYYDwAWAEo-SzZ44EiYzKgAWgA%2BKAA5MBRScytMY2gvIxMinMISchgqRFIYpCaAOmt6F2yGwZMAJgjWiBjrD2mJqxFu3poBpumRsbDVyymIXesI9I6QUgA3UlZN-vmRw6gr2-vqR%2BG4bKA)

All three agree with the runtime behavior of dataclasses, considering `x` to be a dataclass field which is included in the dataclass `__init__` method and set on instances in `__init__`. All three prohibit further assignments to `x` on instances, noting that it is a final attribute. Pyright also mentions that it is a ClassVar, which is confusing given that "ClassVar" and "dataclass field" are (or should be) mutually exclusive.

All three assume that `C.x` is available and of type `int`, whether we have `x: Final[int] = 3` or `x: Final[int] = field(default_value=3)`. That is, none of the type checkers model the actual runtime behavior that `field()` objects are removed from the class and not replaced with anything. (Arguably this behavior is just a bug/inconsistency in the dataclasses runtime implementation.)

## Considerations

* Option 2 (proposed in this PR) is clearly less disruptive to existing code, as it effectively just specifies the de facto current behavior of the runtime and all type checkers. The only practical change to type checker behavior in the given examples that would occur as a result of this spec change is that Pyright should not claim in its error message that `x` is a ClassVar, but otherwise behavior would remain as it is; errors would still be raised on exactly the same lines by all three type checkers.
* Option 2 has the downside that one cannot assume as an invariant that the syntax `x: Final[int] = 3` always means that `x` will always have value exactly `3`. In dataclass bodies this will be more nuanced: the class attribute will always be `3`, but it will be shadowed by an instance attribute that may have a different value on any given instance. On the other hand, it is already the case that the semantics of annotated assignments in dataclass bodies differ from other contexts: `x: int = field(...)` when `field(...)` does not return `int` would obviously be a type error anywhere else. This example illustrates that in dataclasses, the annotation generally does not apply to the immediate assignment, but to the type of the dataclass field (instance var) specified by the annotated assignment.
* If we select Option 1, it will be quite cumbersome to achieve a Final dataclass field (one would have to write out the `__init__` method manually instead of allowing dataclass to generate it, eliminating a key benefit of dataclasses.) If we select Option 2, it remains quite easy to have a final classvar on a dataclass, using a `ClassVar[Final[...]]` annotation.