### PR TITLE
Conformance tests: Fix generics_defaults scoring for pyright

### DIFF
--- a/conformance/results/pyright/generics_defaults.toml
+++ b/conformance/results/pyright/generics_defaults.toml
@@ -7,7 +7,7 @@ generics_defaults.py:111:40 - error: TypeVar default type must be one of the con
 generics_defaults.py:138:7 - error: TypeVar "T5" has a default value and cannot follow TypeVarTuple "Ts" (reportGeneralTypeIssues)
 generics_defaults.py:167:18 - error: Access to generic instance variable through class is ambiguous (reportGeneralTypeIssues)
 """
-conformance_automated = "Fail"
+conformance_automated = "Pass"
 errors_diff = """
-Line 167: Unexpected errors ['generics_defaults.py:167:18 - error: Access to generic instance variable through class is ambiguous (reportGeneralTypeIssues)']
 """
+ignore_errors = ["Access to generic instance variable through class is ambiguous"]


### PR DESCRIPTION
Pyright produces an error unrelated to the purpose of the test, and I
don't see a good way to write the test to avoid the error.

Part of #1692
