### PR TITLE
Conformance tests: Fix pyright scoring for protocols_variance

### DIFF
--- a/conformance/results/pyright/protocols_definition.toml
+++ b/conformance/results/pyright/protocols_definition.toml
@@ -96,3 +96,4 @@ protocols_definition.py:341:22 - error: Expression of type "Concrete6_Bad3" cann
 conformance_automated = "Pass"
 errors_diff = """
 """
+ignore_errors = ["Static methods should not take a \"self\" or \"cls\" parameter"]

--- a/conformance/results/pyright/protocols_variance.toml
+++ b/conformance/results/pyright/protocols_variance.toml
@@ -10,13 +10,6 @@ protocols_variance.py:71:7 - warning: Type variable "T1_contra" used in generic 
 protocols_variance.py:72:21 - error: Contravariant type variable cannot be used in return type (reportGeneralTypeIssues)
 protocols_variance.py:104:7 - warning: Type variable "T1" used in generic protocol "Protocol12" should be covariant (reportInvalidTypeVarUse)
 """
-conformance_automated = "Fail"
+conformance_automated = "Pass"
 errors_diff = """
-Line 21: Expected 1 errors
-Line 40: Expected 1 errors
-Line 56: Expected 1 errors
-Line 61: Expected 1 errors
-Line 66: Expected 1 errors
-Line 71: Expected 1 errors
-Line 104: Expected 1 errors
 """

--- a/conformance/results/pyright/qualifiers_final_decorator.toml
+++ b/conformance/results/pyright/qualifiers_final_decorator.toml
@@ -18,3 +18,4 @@ qualifiers_final_decorator.py:126:5 - error: Function "func1" cannot be marked @
 conformance_automated = "Pass"
 errors_diff = """
 """
+ignore_errors = ["reportMissingModuleSource"]

--- a/conformance/src/type_checker.py
+++ b/conformance/src/type_checker.py
@@ -191,7 +191,7 @@ class PyrightTypeChecker(TypeChecker):
             assert line.count(":") >= 3, f"Failed to parse line: {line!r}"
             _, lineno, kind, _ = line.split(":", maxsplit=3)
             kind = kind.split()[-1]
-            if kind != "error":
+            if kind not in ("error", "warning"):
                 continue
             line_to_errors.setdefault(int(lineno), []).append(line)
         return line_to_errors


### PR DESCRIPTION
Pyright produces warnings instead of errors for many issues in this test case.

Part of #1692
