### PR TITLE
Conformance tests: mark pytype as failing generics_scope

### DIFF
--- a/conformance/results/pyre/generics_scoping.toml
+++ b/conformance/results/pyre/generics_scoping.toml
@@ -20,6 +20,5 @@ conformance_automated = "Fail"
 errors_diff = """
 Line 65: Expected 1 errors
 Line 75: Expected 1 errors
-Line 74: Unexpected errors ['generics_scoping.py:74:0 Uninitialized attribute [13]: Attribute `attr` is declared in class `Outer` to have type `Outer.Inner[Variable[T]]` but is never initialized.']
-Line 77: Unexpected errors ['generics_scoping.py:77:4 Uninitialized attribute [13]: Attribute `x` is declared in class `Outer.AlsoBad` to have type `typing.List[Variable[T]]` but is never initialized.']
 """
+ignore_errors = ["Uninitialized attribute [13]"]

--- a/conformance/results/pytype/generics_scoping.toml
+++ b/conformance/results/pytype/generics_scoping.toml
@@ -1,12 +1,10 @@
-conformant = "Pass"
+conformant = "Partial"
+notes = """
+Fails to reject type alias within generic class that uses class's type variable.
+Fails to reject unbound type variable in constructor call in global scope.
+"""
 output = """
 File "generics_scoping.py", line 29, in <module>: Function MyClass.meth_2 was called with the wrong arguments [wrong-arg-types]
-File "generics_scoping.py", line 39, in method: bad return type [bad-return-type]
-Called from (traceback):
-  line 43, in current file
-File "generics_scoping.py", line 39, in method: bad return type [bad-return-type]
-Called from (traceback):
-  line 42, in current file
 File "generics_scoping.py", line 50, in fun_3: Invalid type annotation 'List[S]' for z [invalid-annotation]
 File "generics_scoping.py", line 54, in Bar: Invalid type annotation 'List[S]' for an_attr [invalid-annotation]
 File "generics_scoping.py", line 63, in fun_4: Invalid type annotation 'T'  [invalid-annotation]
@@ -21,7 +19,6 @@ Line 65: Expected 1 errors
 Line 75: Expected 1 errors
 Line 84: Expected 1 errors
 Line 90: Expected 1 errors
-Line 39: Unexpected errors ['File "generics_scoping.py", line 39, in method: bad return type [bad-return-type]', 'File "generics_scoping.py", line 39, in method: bad return type [bad-return-type]']
 Line 63: Unexpected errors ['File "generics_scoping.py", line 63, in fun_4: Invalid type annotation \\'T\\'  [invalid-annotation]']
 Line 74: Unexpected errors ['File "generics_scoping.py", line 74, in <module>: Invalid type annotation \\'Outer\\'  [invalid-annotation]']
 """

--- a/conformance/tests/generics_scoping.py
+++ b/conformance/tests/generics_scoping.py
@@ -36,7 +36,7 @@ S = TypeVar("S")
 
 class Foo(Generic[T]):
     def method(self, x: T, y: S) -> S:
-        ...
+        return y
 
 x: Foo[int] = Foo()
 assert_type(x.method(0, "abc"), str)
@@ -54,7 +54,7 @@ class Bar(Generic[T]):
     an_attr: list[S] = []  # E
 
     def do_something(self, x: S) -> S:  # OK
-        ...
+        return x
 
 # A generic class definition that appears inside a generic function
 # should not use type variables that parameterize the generic function.


### PR DESCRIPTION
It fails to produce errors on a few lines expected by the test.

Also fix an unrelated pytype error and ignore an unrelated pyre error.

Part of #1692
