### PR TITLE
conformance tests: fix scoring for typeddicts_inheritance

### DIFF
--- a/conformance/results/pyre/typeddicts_inheritance.toml
+++ b/conformance/results/pyre/typeddicts_inheritance.toml
@@ -9,6 +9,4 @@ typeddicts_inheritance.py:65:0 Invalid inheritance [39]: Field `x` has type `int
 conformance_automated = "Fail"
 errors_diff = """
 Line 44: Expected 1 errors
-Line 55: Expected 1 errors
-Line 54: Unexpected errors ['typeddicts_inheritance.py:54:0 Inconsistent override [15]: `x` overrides attribute defined in `X1` inconsistently. Type `int` is not a subtype of the overridden attribute `str`.']
 """

--- a/conformance/results/pytype/typeddicts_inheritance.toml
+++ b/conformance/results/pytype/typeddicts_inheritance.toml
@@ -4,8 +4,6 @@ File "typeddicts_inheritance.py", line 44, in <module>: Invalid base class: NonT
 File "typeddicts_inheritance.py", line 54, in <module>: Invalid base class: X1 [base-class-error]
 File "typeddicts_inheritance.py", line 65, in <module>: Invalid base class: Y2 [base-class-error]
 """
-conformance_automated = "Fail"
+conformance_automated = "Pass"
 errors_diff = """
-Line 55: Expected 1 errors
-Line 54: Unexpected errors ['File "typeddicts_inheritance.py", line 54, in <module>: Invalid base class: X1 [base-class-error]']
 """

--- a/conformance/tests/typeddicts_inheritance.py
+++ b/conformance/tests/typeddicts_inheritance.py
@@ -51,8 +51,8 @@ class BadTypedDict(TypedDict, NonTypedDict):  # E
 class X1(TypedDict):
    x: str
 
-class Y1(X1):
-   x: int  # E: cannot overwrite TypedDict field "x"
+class Y1(X1):  # E[Y1]
+   x: int  # E[Y1]: cannot overwrite TypedDict field "x"
 
 
 # > Multiple inheritance does not allow conflict types for the same name field:


### PR DESCRIPTION
Pyre and pytype produced an expected error on the wrong line.

Part of #1692
