### PR TITLE
Conformance tests: mark pytype as failing assert_type test

### DIFF
--- a/conformance/results/pytype/directives_assert_type.toml
+++ b/conformance/results/pytype/directives_assert_type.toml
@@ -1,4 +1,7 @@
-conformant = "Pass"
+conformant = "Partial"
+notes = """
+Incorrectly allows assert(x, int) where x is a Literal.
+"""
 output = """
 File "directives_assert_type.py", line 27, in func1: Union[int, str] [assert-type]
 File "directives_assert_type.py", line 28, in func1: Any [assert-type]

--- a/conformance/results/results.html
+++ b/conformance/results/results.html
@@ -859,7 +859,7 @@
 <th class="column col2 conformant">Pass</th>
 <th class="column col2 conformant">Pass</th>
 <th class="column col2 not-conformant"><div class="hover-text">Unsupported<span class="tooltip-text" id="bottom"><p>Does not understand "assert_type".</p></span></div></th>
-<th class="column col2 conformant">Pass</th>
+<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Incorrectly allows assert(x, int) where x is a Literal.</p></span></div></th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;directives_cast</th>
 <th class="column col2 conformant">Pass</th>


### PR DESCRIPTION
It does not produce an error for `x: Literal[4]; assert_type(x, int)`.

Part of #1692
