### PR TITLE
Update results for pyright 1.1.358

### DIFF
--- a/conformance/results/pyright/aliases_explicit.toml
+++ b/conformance/results/pyright/aliases_explicit.toml
@@ -37,9 +37,7 @@ aliases_explicit.py:89:22 - error: Invalid expression form for type alias defini
 aliases_explicit.py:89:22 - error: Expected type expression but received "Literal[1]" (reportGeneralTypeIssues)
 aliases_explicit.py:90:22 - error: Invalid expression form for type alias definition (reportInvalidTypeForm)
 aliases_explicit.py:90:22 - error: Binary operator not allowed in type annotation (reportInvalidTypeForm)
-aliases_explicit.py:91:22 - error: Expected expression
-aliases_explicit.py:91:22 - error: Tuple expression not allowed in type annotation
-  Use tuple[T1, ..., Tn] to indicate a tuple type or Union[T1, T2] to indicate a union type (reportInvalidTypeForm)
+aliases_explicit.py:91:22 - error: Type annotations cannot use format string literals (f-strings) (reportGeneralTypeIssues)
 aliases_explicit.py:100:5 - error: Type "list[Unknown]" is already specialized (reportInvalidTypeArguments)
 aliases_explicit.py:101:6 - error: Object of type "UnionType" is not callable (reportCallIssue)
 aliases_explicit.py:102:5 - error: Type "list[Unknown]" is already specialized (reportInvalidTypeArguments)

--- a/conformance/results/pyright/aliases_type_statement.toml
+++ b/conformance/results/pyright/aliases_type_statement.toml
@@ -34,9 +34,7 @@ aliases_type_statement.py:45:22 - error: Variable not allowed in type expression
 aliases_type_statement.py:46:23 - error: Expected type expression but received "Literal[True]" (reportGeneralTypeIssues)
 aliases_type_statement.py:47:23 - error: Expected type expression but received "Literal[1]" (reportGeneralTypeIssues)
 aliases_type_statement.py:48:23 - error: Binary operator not allowed in type annotation (reportInvalidTypeForm)
-aliases_type_statement.py:49:23 - error: Expected expression
-aliases_type_statement.py:49:23 - error: Tuple expression not allowed in type annotation
-  Use tuple[T1, ..., Tn] to indicate a tuple type or Union[T1, T2] to indicate a union type (reportInvalidTypeForm)
+aliases_type_statement.py:49:23 - error: Type annotations cannot use format string literals (f-strings) (reportGeneralTypeIssues)
 aliases_type_statement.py:52:10 - error: Type alias declaration "BadTypeAlias14" is obscured by a declaration of the same name (reportRedeclaration)
 aliases_type_statement.py:58:10 - error: A type statement can be used only within a module or class scope (reportGeneralTypeIssues)
 aliases_type_statement.py:64:23 - error: Type parameter "V" is not included in the type parameter list for "TA1" (reportGeneralTypeIssues)

--- a/conformance/results/pyright/aliases_typealiastype.toml
+++ b/conformance/results/pyright/aliases_typealiastype.toml
@@ -25,9 +25,7 @@ aliases_typealiastype.py:60:42 - error: Variable not allowed in type expression 
 aliases_typealiastype.py:61:42 - error: Expected type expression but received "Literal[True]" (reportGeneralTypeIssues)
 aliases_typealiastype.py:62:42 - error: Expected type expression but received "Literal[1]" (reportGeneralTypeIssues)
 aliases_typealiastype.py:63:42 - error: Binary operator not allowed in type annotation (reportInvalidTypeForm)
-aliases_typealiastype.py:64:42 - error: Expected expression
-aliases_typealiastype.py:64:42 - error: Tuple expression not allowed in type annotation
-  Use tuple[T1, ..., Tn] to indicate a tuple type or Union[T1, T2] to indicate a union type (reportInvalidTypeForm)
+aliases_typealiastype.py:64:42 - error: Type annotations cannot use format string literals (f-strings) (reportGeneralTypeIssues)
 """
 conformance_automated = "Pass"
 errors_diff = """

--- a/conformance/results/pyright/annotations_forward_refs.toml
+++ b/conformance/results/pyright/annotations_forward_refs.toml
@@ -26,9 +26,7 @@ annotations_forward_refs.py:50:11 - error: Expected type expression but received
 annotations_forward_refs.py:51:11 - error: Expected type expression but received "Literal[1]" (reportGeneralTypeIssues)
 annotations_forward_refs.py:52:11 - error: Unary operator not allowed in type annotation (reportInvalidTypeForm)
 annotations_forward_refs.py:53:11 - error: Binary operator not allowed in type annotation (reportInvalidTypeForm)
-annotations_forward_refs.py:54:11 - error: Expected expression
-annotations_forward_refs.py:54:11 - error: Tuple expression not allowed in type annotation
-  Use tuple[T1, ..., Tn] to indicate a tuple type or Union[T1, T2] to indicate a union type (reportInvalidTypeForm)
+annotations_forward_refs.py:54:11 - error: Type annotations cannot use format string literals (f-strings) (reportGeneralTypeIssues)
 annotations_forward_refs.py:55:10 - error: Module cannot be used as a type (reportGeneralTypeIssues)
 annotations_forward_refs.py:66:26 - error: "ClassB" is not defined (reportUndefinedVariable)
 annotations_forward_refs.py:80:14 - error: Type of "ClassF" could not be determined because it refers to itself (reportGeneralTypeIssues)

--- a/conformance/results/pyright/annotations_typeexpr.toml
+++ b/conformance/results/pyright/annotations_typeexpr.toml
@@ -22,9 +22,7 @@ annotations_typeexpr.py:97:10 - error: Expected type expression but received "Li
 annotations_typeexpr.py:98:10 - error: Expected type expression but received "Literal[1]" (reportGeneralTypeIssues)
 annotations_typeexpr.py:99:10 - error: Unary operator not allowed in type annotation (reportInvalidTypeForm)
 annotations_typeexpr.py:100:10 - error: Binary operator not allowed in type annotation (reportInvalidTypeForm)
-annotations_typeexpr.py:101:10 - error: Expected expression
-annotations_typeexpr.py:101:10 - error: Tuple expression not allowed in type annotation
-  Use tuple[T1, ..., Tn] to indicate a tuple type or Union[T1, T2] to indicate a union type (reportInvalidTypeForm)
+annotations_typeexpr.py:101:10 - error: Type annotations cannot use format string literals (f-strings) (reportGeneralTypeIssues)
 annotations_typeexpr.py:102:10 - error: Module cannot be used as a type (reportGeneralTypeIssues)
 """
 conformance_automated = "Pass"

--- a/conformance/results/pyright/narrowing_typeis.toml
+++ b/conformance/results/pyright/narrowing_typeis.toml
@@ -1,10 +1,6 @@
-conformant = "Partial"
-notes = """
-Does not reject covariant use of TypeIs.
-"""
-conformance_automated = "Fail"
+conformant = "Pass"
+conformance_automated = "Pass"
 errors_diff = """
-Line 191: Expected 1 errors
 """
 output = """
 narrowing_typeis.py:105:9 - error: User-defined type guard functions and methods must have at least one input parameter (reportGeneralTypeIssues)
@@ -28,6 +24,12 @@ narrowing_typeis.py:170:14 - error: Argument of type "(val: object) -> TypeGuard
   Type "(val: object) -> TypeGuard[int]" cannot be assigned to type "(object) -> TypeIs[int]"
     Function return type "TypeGuard[int]" is incompatible with type "TypeIs[int]"
       "TypeGuard[int]" is incompatible with "TypeIs[int]"
+      "bool" is incompatible with "TypeIs[int]" (reportArgumentType)
+narrowing_typeis.py:191:18 - error: Argument of type "(val: object) -> TypeIs[bool]" cannot be assigned to parameter "f" of type "(object) -> TypeIs[int]" in function "takes_int_typeis"
+  Type "(val: object) -> TypeIs[bool]" cannot be assigned to type "(object) -> TypeIs[int]"
+    Function return type "TypeIs[bool]" is incompatible with type "TypeIs[int]"
+      "TypeIs[bool]" is incompatible with "TypeIs[int]"
+        Type parameter "T@TypeIs" is invariant, but "bool" is not the same as "int"
       "bool" is incompatible with "TypeIs[int]" (reportArgumentType)
 narrowing_typeis.py:195:27 - error: Return type of TypeIs ("str") is not consistent with value parameter type ("int") (reportGeneralTypeIssues)
 narrowing_typeis.py:199:45 - error: Return type of TypeIs ("list[int]") is not consistent with value parameter type ("list[object]") (reportGeneralTypeIssues)

--- a/conformance/results/pyright/qualifiers_annotated.toml
+++ b/conformance/results/pyright/qualifiers_annotated.toml
@@ -15,9 +15,7 @@ qualifiers_annotated.py:50:17 - error: "var1" is not defined (reportUndefinedVar
 qualifiers_annotated.py:51:17 - error: Expected type expression but received "Literal[True]" (reportGeneralTypeIssues)
 qualifiers_annotated.py:52:18 - error: Expected type expression but received "Literal[1]" (reportGeneralTypeIssues)
 qualifiers_annotated.py:53:18 - error: Binary operator not allowed in type annotation (reportInvalidTypeForm)
-qualifiers_annotated.py:54:18 - error: Expected expression
-qualifiers_annotated.py:54:18 - error: Tuple expression not allowed in type annotation
-  Use tuple[T1, ..., Tn] to indicate a tuple type or Union[T1, T2] to indicate a union type (reportInvalidTypeForm)
+qualifiers_annotated.py:54:18 - error: Type annotations cannot use format string literals (f-strings) (reportGeneralTypeIssues)
 qualifiers_annotated.py:64:8 - error: Expected one type argument and one or more annotations for "Annotated"
 qualifiers_annotated.py:76:24 - error: Expression of type "type[int]" cannot be assigned to declared type "type[Any]" (reportAssignmentType)
 qualifiers_annotated.py:77:24 - error: Expression of type "SmallInt" cannot be assigned to declared type "type[Any]" (reportAssignmentType)

--- a/conformance/results/pyright/version.toml
+++ b/conformance/results/pyright/version.toml
@@ -1,2 +1,2 @@
-version = "pyright 1.1.357"
+version = "pyright 1.1.358"
 test_duration = 1.6

--- a/conformance/results/results.html
+++ b/conformance/results/results.html
@@ -161,7 +161,7 @@
 <th class='tc-header'><div class='tc-name'>mypy 1.9.0</div>
 <div class='tc-time'>2.2sec</div>
 </th>
-<th class='tc-header'><div class='tc-name'>pyright 1.1.357</div>
+<th class='tc-header'><div class='tc-name'>pyright 1.1.358</div>
 <div class='tc-time'>1.6sec</div>
 </th>
 <th class='tc-header'><div class='tc-name'>pyre 0.9.19</div>
@@ -298,7 +298,7 @@
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>False negative on generic class nested within generic class with same type variable.</p></span></div></th>
 <th class="column col2 conformant">Pass</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>False negative on generic class nested within generic function with same type variable.</p><p>False negative on generic class nested within generic class with same type variable.</p></span></div></th>
-<th class="column col2 conformant">Pass</th>
+<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Fails to reject type alias within generic class that uses class's type variable.</p><p>Fails to reject unbound type variable in constructor call in global scope.</p></span></div></th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;generics_self_advanced</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not infer the type of an unannotated `self` parameter to be type `Self`.</p><p>Does not retain `Self` when calling method that returns `Self`.</p><p>Does not infer the type of an unannotated `cls` parameter to be type `type[Self]`.</p><p>Does not retain `Self` when accessing attribute through `type[Self]`.</p></span></div></th>
@@ -848,7 +848,7 @@
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;narrowing_typeis</th>
 <th class="column col2 not-conformant">Unsupported</th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not reject covariant use of TypeIs.</p></span></div></th>
+<th class="column col2 conformant">Pass</th>
 <th class="column col2 not-conformant">Unsupported</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not narrow correctly on generic tuple type</p><p>Does not reject covariant use of TypeIs</p><p>Does not reject TypeIs where return type is not consistent with input type due to variance</p></span></div></th>
 </tr>


### PR DESCRIPTION
Pyright now passes the `TypeIs` test and the error messages for f-string annotations are better, thanks @erictraut!