### PR TITLE
Updated conformance results for pyright 1.1.361. 

### DIFF
--- a/conformance/results/mypy/version.toml
+++ b/conformance/results/mypy/version.toml
@@ -1,2 +1,2 @@
 version = "mypy 1.10.0"
-test_duration = 1.5
+test_duration = 1.3

--- a/conformance/results/pyre/version.toml
+++ b/conformance/results/pyre/version.toml
@@ -1,2 +1,2 @@
 version = "pyre 0.9.19"
-test_duration = 4.2
+test_duration = 3.7

--- a/conformance/results/pyright/aliases_recursive.toml
+++ b/conformance/results/pyright/aliases_recursive.toml
@@ -54,11 +54,11 @@ aliases_recursive.py:52:24 - error: Expression of type "dict[str, str | int | di
       Type parameter "_VT_co@Mapping" is covariant, but "str | int | dict[str, str | int | list[int]]" is not a subtype of "RecursiveMapping" (reportAssignmentType)
 aliases_recursive.py:63:38 - error: Expression of type "list[str | list[float]]" is incompatible with declared type "GenericTypeAlias1[str]"
   Type "float" is incompatible with type "GenericTypeAlias1[T1@GenericTypeAlias1] | str"
-    "float" is incompatible with "GenericTypeAlias1[T1@GenericTypeAlias1]"
+    "float" is incompatible with "list[GenericTypeAlias1 | str]"
     "float" is incompatible with "str" (reportAssignmentType)
 aliases_recursive.py:69:51 - error: Expression of type "list[list[int | list[str | int | list[float]]] | str]" is incompatible with declared type "GenericTypeAlias2[str, int]"
   Type "float" is incompatible with type "GenericTypeAlias2[T1@GenericTypeAlias2, T2@GenericTypeAlias2] | str | int"
-    "float" is incompatible with "GenericTypeAlias2[T1@GenericTypeAlias2, T2@GenericTypeAlias2]"
+    "float" is incompatible with "list[GenericTypeAlias2 | str | int]"
     "float" is incompatible with "str"
     "float" is incompatible with "int" (reportAssignmentType)
 aliases_recursive.py:72:29 - error: Type alias "RecursiveUnion" cannot use itself in its definition (reportGeneralTypeIssues)

--- a/conformance/results/pyright/generics_typevartuple_specialization.toml
+++ b/conformance/results/pyright/generics_typevartuple_specialization.toml
@@ -2,14 +2,14 @@ conformant = "Pass"
 output = """
 generics_typevartuple_specialization.py:109:18 - error: Type variable "Ts" has no meaning in this context (reportGeneralTypeIssues)
 generics_typevartuple_specialization.py:109:18 - error: Could not specialize type "IntTupleGeneric[T@IntTupleGeneric]"
-  Unpacked arguments cannot be used in type argument lists
+  Unpacked arguments cannot be used in this context
 generics_typevartuple_specialization.py:110:18 - error: Could not specialize type "IntTupleGeneric[T@IntTupleGeneric]"
-  Unpacked arguments cannot be used in type argument lists
+  Unpacked arguments cannot be used in this context
 generics_typevartuple_specialization.py:121:27 - error: Type argument list can have at most one unpacked TypeVarTuple or tuple
 generics_typevartuple_specialization.py:122:27 - error: Type argument list can have at most one unpacked TypeVarTuple or tuple
 generics_typevartuple_specialization.py:127:9 - error: Too few type arguments provided for "TA7[*Ts@TA7, T1@TA7, T2@TA7]"; expected 3 but received 2
 generics_typevartuple_specialization.py:163:14 - error: Could not specialize type "TA11[T@TA11, *Ts1@TA11]"
-  Unpacked arguments cannot be used in type argument lists
+  Unpacked arguments cannot be used in this context
 """
 conformance_automated = "Pass"
 errors_diff = """

--- a/conformance/results/pyright/namedtuples_define_class.toml
+++ b/conformance/results/pyright/namedtuples_define_class.toml
@@ -4,15 +4,15 @@ namedtuples_define_class.py:32:7 - error: Index 3 is out of range for type Point
 namedtuples_define_class.py:33:7 - error: Index -4 is out of range for type Point (reportGeneralTypeIssues)
 namedtuples_define_class.py:44:6 - error: Argument missing for parameter "y" (reportCallIssue)
 namedtuples_define_class.py:45:6 - error: Argument missing for parameter "y" (reportCallIssue)
-namedtuples_define_class.py:46:15 - error: Argument of type "Literal['']" cannot be assigned to parameter "y" of type "int" in function "__init__"
+namedtuples_define_class.py:46:15 - error: Argument of type "Literal['']" cannot be assigned to parameter "y" of type "int" in function "__new__"
   "Literal['']" is incompatible with "int" (reportArgumentType)
-namedtuples_define_class.py:47:24 - error: Argument of type "Literal[3]" cannot be assigned to parameter "units" of type "str" in function "__init__"
+namedtuples_define_class.py:47:24 - error: Argument of type "Literal[3]" cannot be assigned to parameter "units" of type "str" in function "__new__"
   "Literal[3]" is incompatible with "str" (reportArgumentType)
 namedtuples_define_class.py:48:22 - error: Expected 3 positional arguments (reportCallIssue)
 namedtuples_define_class.py:49:23 - error: No parameter named "other" (reportCallIssue)
 namedtuples_define_class.py:59:5 - error: Fields without default values cannot appear after fields with default values (reportGeneralTypeIssues)
 namedtuples_define_class.py:79:5 - error: Cannot override "x" because parent class "Point" is a named tuple (reportIncompatibleVariableOverride)
-namedtuples_define_class.py:98:19 - error: Argument of type "float" cannot be assigned to parameter "value" of type "str" in function "__init__"
+namedtuples_define_class.py:98:19 - error: Argument of type "float" cannot be assigned to parameter "value" of type "str" in function "__new__"
   "float" is incompatible with "str" (reportArgumentType)
 namedtuples_define_class.py:105:7 - error: Multiple inheritance with NamedTuple is not supported (reportGeneralTypeIssues)
 """

--- a/conformance/results/pyright/narrowing_typeis.toml
+++ b/conformance/results/pyright/narrowing_typeis.toml
@@ -1,8 +1,15 @@
-conformant = "Pass"
-conformance_automated = "Pass"
+conformant = "Partial"
+notes = """
+Does not correctly narrow types in negative (else) case.
+"""
+conformance_automated = "Fail"
 errors_diff = """
+Line 19: Unexpected errors ['narrowing_typeis.py:19:21 - error: "assert_type" mismatch: expected "tuple[str, str]" but received "tuple[str, ...]" (reportAssertTypeFailure)']
+Line 38: Unexpected errors ['narrowing_typeis.py:38:21 - error: "assert_type" mismatch: expected "int" but received "int | Awaitable[int]" (reportAssertTypeFailure)']
 """
 output = """
+narrowing_typeis.py:19:21 - error: "assert_type" mismatch: expected "tuple[str, str]" but received "tuple[str, ...]" (reportAssertTypeFailure)
+narrowing_typeis.py:38:21 - error: "assert_type" mismatch: expected "int" but received "int | Awaitable[int]" (reportAssertTypeFailure)
 narrowing_typeis.py:105:9 - error: User-defined type guard functions and methods must have at least one input parameter (reportGeneralTypeIssues)
 narrowing_typeis.py:110:9 - error: User-defined type guard functions and methods must have at least one input parameter (reportGeneralTypeIssues)
 narrowing_typeis.py:132:20 - error: Argument of type "(val: object) -> TypeIs[int]" cannot be assigned to parameter "f" of type "(object) -> str" in function "takes_callable_str"

--- a/conformance/results/pyright/version.toml
+++ b/conformance/results/pyright/version.toml
@@ -1,2 +1,2 @@
-version = "pyright 1.1.360"
+version = "pyright 1.1.361"
 test_duration = 1.6

--- a/conformance/results/pytype/version.toml
+++ b/conformance/results/pytype/version.toml
@@ -1,2 +1,2 @@
 version = "pytype 2024.04.11"
-test_duration = 34.4
+test_duration = 35.5

--- a/conformance/results/results.html
+++ b/conformance/results/results.html
@@ -159,16 +159,16 @@
         <div class="table_container"><table><tbody>
 <tr><th class="col1">&nbsp;</th>
 <th class='tc-header'><div class='tc-name'>mypy 1.10.0</div>
-<div class='tc-time'>1.5sec</div>
+<div class='tc-time'>1.3sec</div>
 </th>
-<th class='tc-header'><div class='tc-name'>pyright 1.1.360</div>
+<th class='tc-header'><div class='tc-name'>pyright 1.1.361</div>
 <div class='tc-time'>1.6sec</div>
 </th>
 <th class='tc-header'><div class='tc-name'>pyre 0.9.19</div>
-<div class='tc-time'>4.2sec</div>
+<div class='tc-time'>3.7sec</div>
 </th>
 <th class='tc-header'><div class='tc-name'>pytype 2024.04.11</div>
-<div class='tc-time'>34.4sec</div>
+<div class='tc-time'>35.5sec</div>
 </th>
 </tr>
 <tr><th class="column" colspan="5">
@@ -896,7 +896,7 @@
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;narrowing_typeis</th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 conformant">Pass</th>
+<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not correctly narrow types in negative (else) case.</p></span></div></th>
 <th class="column col2 not-conformant">Unsupported</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not narrow correctly on generic tuple type.</p><p>Does not reject covariant use of TypeIs.</p><p>Does not reject TypeIs where return type is not consistent with input type due to variance.</p></span></div></th>
 </tr>


### PR DESCRIPTION
The tests found a regression that was introduced in this version related to the `TypeIs` special form. All other changes are due to minor tweaks in error messages.