### PR TITLE
Updated conformance results for pyright 1.1.362

### DIFF
--- a/conformance/results/mypy/callables_annotation.toml
+++ b/conformance/results/mypy/callables_annotation.toml
@@ -19,19 +19,18 @@ callables_annotation.py:58: error: Please use "Callable[[<parameters>], <return 
 callables_annotation.py:59: error: Unexpected "..."  [misc]
 callables_annotation.py:91: error: Incompatible types in assignment (expression has type "Callable[[], str]", variable has type "Callable[[int, VarArg(Any), KwArg(Any)], str]")  [assignment]
 callables_annotation.py:93: error: Incompatible types in assignment (expression has type "Callable[[NamedArg(int, 'a')], str]", variable has type "Callable[[int, VarArg(Any), KwArg(Any)], str]")  [assignment]
-callables_annotation.py:136: error: Expression is of type "Proto3", not "Callable[..., None]"  [assert-type]
-callables_annotation.py:139: error: Incompatible types in assignment (expression has type "Proto7", variable has type "Proto6")  [assignment]
-callables_annotation.py:139: note: Following member(s) of "Proto7" have conflicts:
-callables_annotation.py:139: note:     Expected:
-callables_annotation.py:139: note:         def __call__(self, int, /, *args: Any, k: str, **kwargs: Any) -> None
-callables_annotation.py:139: note:     Got:
-callables_annotation.py:139: note:         def __call__(self, float, /, b: int, *, k: str, m: str) -> None
-callables_annotation.py:152: error: Incompatible types in assignment (expression has type "Callable[[], str]", variable has type "Callable[[int, VarArg(Any), KwArg(Any)], str]")  [assignment]
-callables_annotation.py:167: error: Incompatible types in assignment (expression has type "Callable[[int, str], str]", variable has type "Callable[[str, VarArg(Any), KwArg(Any)], str]")  [assignment]
-callables_annotation.py:169: error: Incompatible types in assignment (expression has type "Callable[[int, str], str]", variable has type "Callable[[str, VarArg(Any), KwArg(Any)], str]")  [assignment]
+callables_annotation.py:157: error: Incompatible types in assignment (expression has type "Proto7", variable has type "Proto6")  [assignment]
+callables_annotation.py:157: note: Following member(s) of "Proto7" have conflicts:
+callables_annotation.py:157: note:     Expected:
+callables_annotation.py:157: note:         def __call__(self, int, /, *args: Any, k: str, **kwargs: Any) -> None
+callables_annotation.py:157: note:     Got:
+callables_annotation.py:157: note:         def __call__(self, float, /, b: int, *, k: str, m: str) -> None
+callables_annotation.py:172: error: Incompatible types in assignment (expression has type "Callable[[], str]", variable has type "Callable[[int, VarArg(Any), KwArg(Any)], str]")  [assignment]
+callables_annotation.py:187: error: Incompatible types in assignment (expression has type "Callable[[int, str], str]", variable has type "Callable[[str, VarArg(Any), KwArg(Any)], str]")  [assignment]
+callables_annotation.py:189: error: Incompatible types in assignment (expression has type "Callable[[int, str], str]", variable has type "Callable[[str, VarArg(Any), KwArg(Any)], str]")  [assignment]
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 134: Expected 1 errors
-Line 139: Unexpected errors ['callables_annotation.py:139: error: Incompatible types in assignment (expression has type "Proto7", variable has type "Proto6")  [assignment]']
+Line 159: Expected 1 errors
+Line 157: Unexpected errors ['callables_annotation.py:157: error: Incompatible types in assignment (expression has type "Proto7", variable has type "Proto6")  [assignment]']
 """

--- a/conformance/results/mypy/version.toml
+++ b/conformance/results/mypy/version.toml
@@ -1,2 +1,2 @@
 version = "mypy 1.10.0"
-test_duration = 1.3
+test_duration = 1.0

--- a/conformance/results/pyre/callables_annotation.toml
+++ b/conformance/results/pyre/callables_annotation.toml
@@ -17,22 +17,21 @@ callables_annotation.py:56:4 Invalid type [31]: Expression `typing.Callable[(int
 callables_annotation.py:57:4 Invalid type [31]: Expression `typing.Callable[([], [int])]` is not a valid type.
 callables_annotation.py:58:4 Invalid type [31]: Expression `typing.Callable[(int, int, int)]` is not a valid type.
 callables_annotation.py:89:5 Invalid type [31]: Expression `typing.Callable[(typing.Concatenate[(int, ...)], str)]` is not a valid type.
-callables_annotation.py:133:29 Incompatible parameter type [6]: In call `typing.GenericMeta.__getitem__`, for 1st positional argument, expected `Tuple[typing.Any, Type[Variable[$synthetic_attribute_resolution_variable]]]` but got `Tuple[typing.Any, None]`.
-callables_annotation.py:134:20 Undefined attribute [16]: `Proto5` has no attribute `__getitem__`.
-callables_annotation.py:135:29 Incompatible parameter type [6]: In call `typing.GenericMeta.__getitem__`, for 1st positional argument, expected `Tuple[typing.Any, Type[Variable[$synthetic_attribute_resolution_variable]]]` but got `Tuple[object, None]`.
-callables_annotation.py:136:29 Incompatible parameter type [6]: In call `typing.GenericMeta.__getitem__`, for 1st positional argument, expected `Tuple[typing.Any, Type[Variable[$synthetic_attribute_resolution_variable]]]` but got `Tuple[typing.Any, None]`.
-callables_annotation.py:137:20 Undefined attribute [16]: `Proto4` has no attribute `__getitem__`.
-callables_annotation.py:139:4 Incompatible variable type [9]: f1 is declared to have type `Proto6` but is used as type `Proto7`.
-callables_annotation.py:146:0 Incompatible variable type [9]: Callback1 is declared to have type `TypeAlias` but is used as type `Type[typing.Callable[..., str]]`.
-callables_annotation.py:147:0 Incompatible variable type [9]: Callback2 is declared to have type `TypeAlias` but is used as type `Type[typing.Callable[..., str]]`.
-callables_annotation.py:151:8 Undefined or invalid type [11]: Annotation `Callback1` is not defined as a type.
-callables_annotation.py:152:8 Undefined or invalid type [11]: Annotation `Callback2` is not defined as a type.
-callables_annotation.py:161:0 Incompatible variable type [9]: CallbackWithInt is declared to have type `TypeAlias` but is used as type `Type[typing.Callable[..., str]]`.
-callables_annotation.py:162:0 Incompatible variable type [9]: CallbackWithStr is declared to have type `TypeAlias` but is used as type `Type[typing.Callable[..., str]]`.
-callables_annotation.py:166:8 Invalid type [31]: Expression `typing.Callable[(typing.Concatenate[(int, ...)], str)]` is not a valid type.
-callables_annotation.py:167:8 Invalid type [31]: Expression `typing.Callable[(typing.Concatenate[(str, ...)], str)]` is not a valid type.
-callables_annotation.py:168:8 Undefined or invalid type [11]: Annotation `CallbackWithInt` is not defined as a type.
-callables_annotation.py:169:8 Undefined or invalid type [11]: Annotation `CallbackWithStr` is not defined as a type.
+callables_annotation.py:145:8 Invalid type [31]: Expression `typing.Callable[(typing.Concatenate[(int, ...)], None)]` is not a valid type.
+callables_annotation.py:151:9 Invalid type [31]: Expression `typing.Callable[(typing.Concatenate[(int, ...)], None)]` is not a valid type.
+callables_annotation.py:156:4 Incompatible variable type [9]: ok10 is declared to have type `Proto3` but is used as type `Proto4[[...]]`.
+callables_annotation.py:157:4 Incompatible variable type [9]: ok11 is declared to have type `Proto6` but is used as type `Proto7`.
+callables_annotation.py:159:4 Incompatible variable type [9]: err1 is declared to have type `Proto5[typing.Any]` but is used as type `Proto8`.
+callables_annotation.py:166:0 Incompatible variable type [9]: Callback1 is declared to have type `TypeAlias` but is used as type `Type[typing.Callable[..., str]]`.
+callables_annotation.py:167:0 Incompatible variable type [9]: Callback2 is declared to have type `TypeAlias` but is used as type `Type[typing.Callable[..., str]]`.
+callables_annotation.py:171:8 Undefined or invalid type [11]: Annotation `Callback1` is not defined as a type.
+callables_annotation.py:172:8 Undefined or invalid type [11]: Annotation `Callback2` is not defined as a type.
+callables_annotation.py:181:0 Incompatible variable type [9]: CallbackWithInt is declared to have type `TypeAlias` but is used as type `Type[typing.Callable[..., str]]`.
+callables_annotation.py:182:0 Incompatible variable type [9]: CallbackWithStr is declared to have type `TypeAlias` but is used as type `Type[typing.Callable[..., str]]`.
+callables_annotation.py:186:8 Invalid type [31]: Expression `typing.Callable[(typing.Concatenate[(int, ...)], str)]` is not a valid type.
+callables_annotation.py:187:8 Invalid type [31]: Expression `typing.Callable[(typing.Concatenate[(str, ...)], str)]` is not a valid type.
+callables_annotation.py:188:8 Undefined or invalid type [11]: Annotation `CallbackWithInt` is not defined as a type.
+callables_annotation.py:189:8 Undefined or invalid type [11]: Annotation `CallbackWithStr` is not defined as a type.
 """
 conformance_automated = "Fail"
 errors_diff = """
@@ -41,15 +40,15 @@ Line 91: Expected 1 errors
 Line 93: Expected 1 errors
 Line 51: Unexpected errors ['callables_annotation.py:51:28 Incompatible parameter type [6]: In call `typing.GenericMeta.__getitem__`, for 1st positional argument, expected `Type[Variable[_T_co](covariant)]` but got `Tuple[Type[int], typing.Any]`.']
 Line 89: Unexpected errors ['callables_annotation.py:89:5 Invalid type [31]: Expression `typing.Callable[(typing.Concatenate[(int, ...)], str)]` is not a valid type.']
-Line 133: Unexpected errors ['callables_annotation.py:133:29 Incompatible parameter type [6]: In call `typing.GenericMeta.__getitem__`, for 1st positional argument, expected `Tuple[typing.Any, Type[Variable[$synthetic_attribute_resolution_variable]]]` but got `Tuple[typing.Any, None]`.']
-Line 135: Unexpected errors ['callables_annotation.py:135:29 Incompatible parameter type [6]: In call `typing.GenericMeta.__getitem__`, for 1st positional argument, expected `Tuple[typing.Any, Type[Variable[$synthetic_attribute_resolution_variable]]]` but got `Tuple[object, None]`.']
-Line 137: Unexpected errors ['callables_annotation.py:137:20 Undefined attribute [16]: `Proto4` has no attribute `__getitem__`.']
-Line 139: Unexpected errors ['callables_annotation.py:139:4 Incompatible variable type [9]: f1 is declared to have type `Proto6` but is used as type `Proto7`.']
-Line 146: Unexpected errors ['callables_annotation.py:146:0 Incompatible variable type [9]: Callback1 is declared to have type `TypeAlias` but is used as type `Type[typing.Callable[..., str]]`.']
-Line 147: Unexpected errors ['callables_annotation.py:147:0 Incompatible variable type [9]: Callback2 is declared to have type `TypeAlias` but is used as type `Type[typing.Callable[..., str]]`.']
-Line 151: Unexpected errors ['callables_annotation.py:151:8 Undefined or invalid type [11]: Annotation `Callback1` is not defined as a type.']
-Line 161: Unexpected errors ['callables_annotation.py:161:0 Incompatible variable type [9]: CallbackWithInt is declared to have type `TypeAlias` but is used as type `Type[typing.Callable[..., str]]`.']
-Line 162: Unexpected errors ['callables_annotation.py:162:0 Incompatible variable type [9]: CallbackWithStr is declared to have type `TypeAlias` but is used as type `Type[typing.Callable[..., str]]`.']
-Line 166: Unexpected errors ['callables_annotation.py:166:8 Invalid type [31]: Expression `typing.Callable[(typing.Concatenate[(int, ...)], str)]` is not a valid type.']
-Line 168: Unexpected errors ['callables_annotation.py:168:8 Undefined or invalid type [11]: Annotation `CallbackWithInt` is not defined as a type.']
+Line 145: Unexpected errors ['callables_annotation.py:145:8 Invalid type [31]: Expression `typing.Callable[(typing.Concatenate[(int, ...)], None)]` is not a valid type.']
+Line 151: Unexpected errors ['callables_annotation.py:151:9 Invalid type [31]: Expression `typing.Callable[(typing.Concatenate[(int, ...)], None)]` is not a valid type.']
+Line 156: Unexpected errors ['callables_annotation.py:156:4 Incompatible variable type [9]: ok10 is declared to have type `Proto3` but is used as type `Proto4[[...]]`.']
+Line 157: Unexpected errors ['callables_annotation.py:157:4 Incompatible variable type [9]: ok11 is declared to have type `Proto6` but is used as type `Proto7`.']
+Line 166: Unexpected errors ['callables_annotation.py:166:0 Incompatible variable type [9]: Callback1 is declared to have type `TypeAlias` but is used as type `Type[typing.Callable[..., str]]`.']
+Line 167: Unexpected errors ['callables_annotation.py:167:0 Incompatible variable type [9]: Callback2 is declared to have type `TypeAlias` but is used as type `Type[typing.Callable[..., str]]`.']
+Line 171: Unexpected errors ['callables_annotation.py:171:8 Undefined or invalid type [11]: Annotation `Callback1` is not defined as a type.']
+Line 181: Unexpected errors ['callables_annotation.py:181:0 Incompatible variable type [9]: CallbackWithInt is declared to have type `TypeAlias` but is used as type `Type[typing.Callable[..., str]]`.']
+Line 182: Unexpected errors ['callables_annotation.py:182:0 Incompatible variable type [9]: CallbackWithStr is declared to have type `TypeAlias` but is used as type `Type[typing.Callable[..., str]]`.']
+Line 186: Unexpected errors ['callables_annotation.py:186:8 Invalid type [31]: Expression `typing.Callable[(typing.Concatenate[(int, ...)], str)]` is not a valid type.']
+Line 188: Unexpected errors ['callables_annotation.py:188:8 Undefined or invalid type [11]: Annotation `CallbackWithInt` is not defined as a type.']
 """

--- a/conformance/results/pyre/version.toml
+++ b/conformance/results/pyre/version.toml
@@ -1,2 +1,2 @@
 version = "pyre 0.9.19"
-test_duration = 4.1
+test_duration = 2.8

--- a/conformance/results/pyright/callables_annotation.toml
+++ b/conformance/results/pyright/callables_annotation.toml
@@ -1,7 +1,4 @@
-conformant = "Partial"
-notes = """
-Does not treat "*args: Any, **kwargs: Any" as "...".
-"""
+conformant = "Pass"
 output = """
 callables_annotation.py:25:5 - error: Expected 1 more positional argument (reportCallIssue)
 callables_annotation.py:26:11 - error: Argument of type "Literal[2]" cannot be assigned to parameter of type "str"
@@ -21,33 +18,24 @@ callables_annotation.py:91:7 - error: Expression of type "() -> str" is incompat
 callables_annotation.py:93:7 - error: Expression of type "(*, a: int) -> str" is incompatible with declared type "(int, ...) -> str"
   Type "(*, a: int) -> str" is incompatible with type "(int, ...) -> str"
     Function accepts too many positional parameters; expected 0 but received 2 (reportAssignmentType)
-callables_annotation.py:133:17 - error: "assert_type" mismatch: expected "(...) -> None" but received "Proto1" (reportAssertTypeFailure)
-callables_annotation.py:134:17 - error: "assert_type" mismatch: expected "Proto5[Any]" but received "Proto1" (reportAssertTypeFailure)
-callables_annotation.py:135:17 - error: "assert_type" mismatch: expected "(int, ...) -> None" but received "Proto2" (reportAssertTypeFailure)
-callables_annotation.py:136:17 - error: "assert_type" mismatch: expected "(...) -> None" but received "Proto3" (reportAssertTypeFailure)
-callables_annotation.py:137:17 - error: "assert_type" mismatch: expected "Proto4[...]" but received "Proto3" (reportAssertTypeFailure)
-callables_annotation.py:139:18 - error: Expression of type "Proto7" is incompatible with declared type "Proto6"
-  "Proto7" is incompatible with protocol "Proto6"
+callables_annotation.py:159:25 - error: Expression of type "Proto8" is incompatible with declared type "Proto5[Any]"
+  "Proto8" is incompatible with protocol "Proto5[Any]"
     "__call__" is an incompatible type
-      Type "(a: float, /, b: int, *, k: str, m: str) -> None" is incompatible with type "(a: int, /, *args: Any, k: str, **kwargs: Any) -> None"
+      Type "() -> None" is incompatible with type "(*args: T_contra@Proto5, **kwargs: T_contra@Proto5) -> None"
         Parameter "*args" has no corresponding parameter
         Parameter "**kwargs" has no corresponding parameter (reportAssignmentType)
-callables_annotation.py:152:26 - error: Expression of type "() -> str" is incompatible with declared type "Callback2[...]"
+callables_annotation.py:172:26 - error: Expression of type "() -> str" is incompatible with declared type "Callback2[...]"
   Type "() -> str" is incompatible with type "Callback2[...]"
     Function accepts too many positional parameters; expected 0 but received 2 (reportAssignmentType)
-callables_annotation.py:167:48 - error: Expression of type "(int, str) -> str" is incompatible with declared type "(str, ...) -> str"
+callables_annotation.py:187:48 - error: Expression of type "(int, str) -> str" is incompatible with declared type "(str, ...) -> str"
   Type "(int, str) -> str" is incompatible with type "(str, ...) -> str"
     Parameter 1: type "str" is incompatible with type "int"
       "str" is incompatible with "int" (reportAssignmentType)
-callables_annotation.py:169:32 - error: Expression of type "(int, str) -> str" is incompatible with declared type "CallbackWithStr[...]"
+callables_annotation.py:189:32 - error: Expression of type "(int, str) -> str" is incompatible with declared type "CallbackWithStr[...]"
   Type "(int, str) -> str" is incompatible with type "CallbackWithStr[...]"
     Parameter 1: type "str" is incompatible with type "int"
       "str" is incompatible with "int" (reportAssignmentType)
 """
-conformance_automated = "Fail"
+conformance_automated = "Pass"
 errors_diff = """
-Line 133: Unexpected errors ['callables_annotation.py:133:17 - error: "assert_type" mismatch: expected "(...) -> None" but received "Proto1" (reportAssertTypeFailure)']
-Line 135: Unexpected errors ['callables_annotation.py:135:17 - error: "assert_type" mismatch: expected "(int, ...) -> None" but received "Proto2" (reportAssertTypeFailure)']
-Line 137: Unexpected errors ['callables_annotation.py:137:17 - error: "assert_type" mismatch: expected "Proto4[...]" but received "Proto3" (reportAssertTypeFailure)']
-Line 139: Unexpected errors ['callables_annotation.py:139:18 - error: Expression of type "Proto7" is incompatible with declared type "Proto6"']
 """

--- a/conformance/results/pyright/constructors_call_init.toml
+++ b/conformance/results/pyright/constructors_call_init.toml
@@ -13,6 +13,6 @@ constructors_call_init.py:56:1 - error:
   Could not bind method "__init__" because "Class4[str]" is not assignable to parameter "self"
     "Class4[str]" is incompatible with "Class4[int]"
       Type parameter "T@Class4" is invariant, but "str" is not the same as "int" (reportGeneralTypeIssues)
-constructors_call_init.py:107:24 - warning: Type annotation for "self" parameter of "__init__" method cannot contain class-scoped type varaiables (reportInvalidTypeVarUse)
+constructors_call_init.py:107:24 - warning: Type annotation for "self" parameter of "__init__" method cannot contain class-scoped type variables (reportInvalidTypeVarUse)
 constructors_call_init.py:130:1 - error: Expected no arguments to "Class11" constructor (reportCallIssue)
 """

--- a/conformance/results/pyright/constructors_callable.toml
+++ b/conformance/results/pyright/constructors_callable.toml
@@ -18,7 +18,7 @@ constructors_callable.py:77:13 - information: Type of "r4" is "(x: int) -> int"
 constructors_callable.py:79:1 - error: Argument missing for parameter "x" (reportCallIssue)
 constructors_callable.py:80:1 - error: Argument missing for parameter "x" (reportCallIssue)
 constructors_callable.py:80:4 - error: No parameter named "y" (reportCallIssue)
-constructors_callable.py:97:13 - information: Type of "r5" is "(*args: Any, **kwargs: Any) -> NoReturn"
+constructors_callable.py:97:13 - information: Type of "r5" is "(...) -> NoReturn"
 constructors_callable.py:125:13 - information: Type of "r6" is "() -> Class6Proxy"
 constructors_callable.py:127:4 - error: Expected 0 positional arguments (reportCallIssue)
 constructors_callable.py:142:13 - information: Type of "r6_any" is "() -> Any"

--- a/conformance/results/pyright/generics_defaults.toml
+++ b/conformance/results/pyright/generics_defaults.toml
@@ -1,13 +1,22 @@
-conformant = "Pass"
+conformant = "Partial"
+notes = """
+Incorrectly evaluates `assert_type` when type involves a ParamSpec or TypeVarTuple with a default value.
+"""
 output = """
 generics_defaults.py:24:7 - error: "T" cannot appear after "DefaultStrT" in type parameter list because it has no default type (reportGeneralTypeIssues)
 generics_defaults.py:50:16 - error: Too few type arguments provided for "AllTheDefaults"; expected 2 but received 1 (reportInvalidTypeArguments)
+generics_defaults.py:79:13 - error: "assert_type" mismatch: expected "type[Class_ParamSpec[(str, int)]]" but received "type[Class_ParamSpec[(str, int)]]" (reportAssertTypeFailure)
+generics_defaults.py:80:13 - error: "assert_type" mismatch: expected "Class_ParamSpec[(str, int)]" but received "Class_ParamSpec[(str, int)]" (reportAssertTypeFailure)
 generics_defaults.py:104:39 - error: TypeVar default type must be a subtype of the bound type (reportGeneralTypeIssues)
 generics_defaults.py:111:40 - error: TypeVar default type must be one of the constrained types (reportGeneralTypeIssues)
 generics_defaults.py:138:7 - error: TypeVar "T5" has a default value and cannot follow TypeVarTuple "Ts" (reportGeneralTypeIssues)
+generics_defaults.py:151:13 - error: "assert_type" mismatch: expected "type[Foo6[int, str, (float, bool)]]" but received "type[Foo6[int, str, (float, bool)]]" (reportAssertTypeFailure)
 generics_defaults.py:167:18 - error: Access to generic instance variable through class is ambiguous (reportGeneralTypeIssues)
 """
-conformance_automated = "Pass"
+conformance_automated = "Fail"
 errors_diff = """
+Line 79: Unexpected errors ['generics_defaults.py:79:13 - error: "assert_type" mismatch: expected "type[Class_ParamSpec[(str, int)]]" but received "type[Class_ParamSpec[(str, int)]]" (reportAssertTypeFailure)']
+Line 80: Unexpected errors ['generics_defaults.py:80:13 - error: "assert_type" mismatch: expected "Class_ParamSpec[(str, int)]" but received "Class_ParamSpec[(str, int)]" (reportAssertTypeFailure)']
+Line 151: Unexpected errors ['generics_defaults.py:151:13 - error: "assert_type" mismatch: expected "type[Foo6[int, str, (float, bool)]]" but received "type[Foo6[int, str, (float, bool)]]" (reportAssertTypeFailure)']
 """
 ignore_errors = ["Access to generic instance variable through class is ambiguous"]

--- a/conformance/results/pyright/narrowing_typeis.toml
+++ b/conformance/results/pyright/narrowing_typeis.toml
@@ -1,15 +1,8 @@
-conformant = "Partial"
-notes = """
-Does not correctly narrow types in negative (else) case.
-"""
-conformance_automated = "Fail"
+conformant = "Pass"
+conformance_automated = "Pass"
 errors_diff = """
-Line 19: Unexpected errors ['narrowing_typeis.py:19:21 - error: "assert_type" mismatch: expected "tuple[str, str]" but received "tuple[str, ...]" (reportAssertTypeFailure)']
-Line 38: Unexpected errors ['narrowing_typeis.py:38:21 - error: "assert_type" mismatch: expected "int" but received "int | Awaitable[int]" (reportAssertTypeFailure)']
 """
 output = """
-narrowing_typeis.py:19:21 - error: "assert_type" mismatch: expected "tuple[str, str]" but received "tuple[str, ...]" (reportAssertTypeFailure)
-narrowing_typeis.py:38:21 - error: "assert_type" mismatch: expected "int" but received "int | Awaitable[int]" (reportAssertTypeFailure)
 narrowing_typeis.py:105:9 - error: User-defined type guard functions and methods must have at least one input parameter (reportGeneralTypeIssues)
 narrowing_typeis.py:110:9 - error: User-defined type guard functions and methods must have at least one input parameter (reportGeneralTypeIssues)
 narrowing_typeis.py:132:20 - error: Argument of type "(val: object) -> TypeIs[int]" cannot be assigned to parameter "f" of type "(object) -> str" in function "takes_callable_str"

--- a/conformance/results/pyright/version.toml
+++ b/conformance/results/pyright/version.toml
@@ -1,2 +1,2 @@
-version = "pyright 1.1.361"
-test_duration = 1.6
+version = "pyright 1.1.362"
+test_duration = 1.4

--- a/conformance/results/pytype/callables_annotation.toml
+++ b/conformance/results/pytype/callables_annotation.toml
@@ -20,9 +20,8 @@ Line 58: Expected 1 errors
 Line 59: Expected 1 errors
 Line 91: Expected 1 errors
 Line 93: Expected 1 errors
-Line 134: Expected 1 errors
-Line 136: Expected 1 errors
-Line 152: Expected 1 errors
-Line 167: Expected 1 errors
-Line 169: Expected 1 errors
+Line 159: Expected 1 errors
+Line 172: Expected 1 errors
+Line 187: Expected 1 errors
+Line 189: Expected 1 errors
 """

--- a/conformance/results/pytype/version.toml
+++ b/conformance/results/pytype/version.toml
@@ -1,2 +1,2 @@
 version = "pytype 2024.04.11"
-test_duration = 38.5
+test_duration = 31.9

--- a/conformance/results/results.html
+++ b/conformance/results/results.html
@@ -159,16 +159,16 @@
         <div class="table_container"><table><tbody>
 <tr><th class="col1">&nbsp;</th>
 <th class='tc-header'><div class='tc-name'>mypy 1.10.0</div>
-<div class='tc-time'>1.3sec</div>
+<div class='tc-time'>1.0sec</div>
 </th>
-<th class='tc-header'><div class='tc-name'>pyright 1.1.361</div>
-<div class='tc-time'>1.6sec</div>
+<th class='tc-header'><div class='tc-name'>pyright 1.1.362</div>
+<div class='tc-time'>1.4sec</div>
 </th>
 <th class='tc-header'><div class='tc-name'>pyre 0.9.19</div>
-<div class='tc-time'>4.1sec</div>
+<div class='tc-time'>2.8sec</div>
 </th>
 <th class='tc-header'><div class='tc-name'>pytype 2024.04.11</div>
-<div class='tc-time'>38.5sec</div>
+<div class='tc-time'>31.9sec</div>
 </th>
 </tr>
 <tr><th class="column" colspan="5">
@@ -254,7 +254,7 @@
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;generics_defaults</th>
 <th class="column col2 not-conformant">Unsupported</th>
-<th class="column col2 conformant">Pass</th>
+<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Incorrectly evaluates `assert_type` when type involves a ParamSpec or TypeVarTuple with a default value.</p></span></div></th>
 <th class="column col2 not-conformant">Unsupported</th>
 <th class="column col2 not-conformant">Unsupported</th>
 </tr>
@@ -602,7 +602,7 @@
 </th></tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;callables_annotation</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Incorrectly treats "*args: T, **kwargs: T" as "..." when T is specialized to Any.</p><p>Does not treat "*args: Any, **kargs: Any" as "..." when separated by keyword parameter.</p></span></div></th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not treat "*args: Any, **kwargs: Any" as "...".</p></span></div></th>
+<th class="column col2 conformant">Pass</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not evaluate correct type for `*args: int` parameter.</p><p>Does not reject illegal form `Callable[[...], int]`.</p><p>Does not correctly implement type compatibility rules for "...".</p><p>Does not treat "*args: Any, **kwargs: Any" as "...".</p></span></div></th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not support Concatenate.</p><p>Does not treat "*args: Any, **kwargs: Any" as "...".</p></span></div></th>
 </tr>
@@ -902,7 +902,7 @@
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;narrowing_typeis</th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not correctly narrow types in negative (else) case.</p></span></div></th>
+<th class="column col2 conformant">Pass</th>
 <th class="column col2 not-conformant">Unsupported</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not narrow correctly on generic tuple type.</p><p>Does not reject covariant use of TypeIs.</p><p>Does not reject TypeIs where return type is not consistent with input type due to variance.</p></span></div></th>
 </tr>

--- a/conformance/tests/callables_annotation.py
+++ b/conformance/tests/callables_annotation.py
@@ -129,14 +129,34 @@ class Proto7(Protocol):
         pass
 
 
-def func(p1: Proto1, p2: Proto2, p3: Proto3, p7: Proto7):
-    assert_type(p1, Callable[..., None])  # OK
-    assert_type(p1, Proto5[Any])  # E
-    assert_type(p2, Callable[Concatenate[int, ...], None])  # OK
-    assert_type(p3, Callable[..., None])  # E
-    assert_type(p3, Proto4[...])  # OK
+class Proto8(Protocol):
+    def __call__(self) -> None: ...
 
-    f1: Proto6 = p7  # OK
+
+def func5(
+    p1: Proto1,
+    p2: Proto2,
+    p3: Proto3,
+    p4: Proto4[...],
+    p5: Proto5[Any],
+    p7: Proto7,
+    p8: Proto8,
+    c1: Callable[..., None],
+    c2: Callable[Concatenate[int, ...], None],
+):
+    ok1: Callable[..., None] = p1  # OK
+    ok2: Proto1 = c1  # OK
+    ok3: Callable[..., None] = p5  # OK
+    ok4: Proto5[Any] = c1  # OK
+    ok5: Callable[Concatenate[int, ...], None] = p2  # OK
+    ok6: Proto2 = c2  # OK
+    ok7: Callable[..., None] = p3  # OK
+    ok8: Proto3 = c1  # OK
+    ok9: Proto4[...] = p3  # OK
+    ok10: Proto3 = p4  # OK
+    ok11: Proto6 = p7  # OK
+
+    err1: Proto5[Any] = p8  # E
 
 
 # > The ... syntax can also be used to provide a specialized value for a
@@ -147,7 +167,7 @@ Callback1: TypeAlias = Callable[P, str]
 Callback2: TypeAlias = Callable[Concatenate[int, P], str]
 
 
-def func5(cb1: Callable[[], str], cb2: Callable[[int], str]) -> None:
+def func6(cb1: Callable[[], str], cb2: Callable[[int], str]) -> None:
     f1: Callback1[...] = cb1  # OK
     f2: Callback2[...] = cb1  # E
 
@@ -162,7 +182,7 @@ CallbackWithInt: TypeAlias = Callable[Concatenate[int, P], str]
 CallbackWithStr: TypeAlias = Callable[Concatenate[str, P], str]
 
 
-def func6(cb: Callable[[int, str], str]) -> None:
+def func7(cb: Callable[[int, str], str]) -> None:
     f1: Callable[Concatenate[int, ...], str] = cb  # OK
     f2: Callable[Concatenate[str, ...], str] = cb  # E
     f3: CallbackWithInt[...] = cb  # OK


### PR DESCRIPTION
Updated conformance results for pyright 1.1.362, which fixed two non-conformance issues but introduced a regression in another conformance test.

Improved callables_annotation test to cover a few missing cases and make the test more resilient to differences in interpretation for `assert_type`.