### PR TITLE
Fix `A previous point` link

### DIFF
--- a/docs/spec/callables.rst
+++ b/docs/spec/callables.rst
@@ -333,7 +333,7 @@ return types should behave covariantly.
 Passing kwargs inside a function to another function
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-`A previous point <PEP 692 assignment dest no kwargs>`_
+:ref:`A previous point <PEP 692 assignment dest no kwargs>`
 mentions the problem of possibly passing additional keyword arguments by
 assigning a subclass instance to a variable that has a base class type. Let's
 consider the following example::


### PR DESCRIPTION
Thank you for the excellent documentation!
While reading this section, I noticed that this link was broken, so I fixed it. That's all :)

`A previous point` in https://typing.readthedocs.io/en/latest/spec/callables.html#passing-kwargs-inside-a-function-to-another-function

![image](https://github.com/python/typing/assets/51289448/78e905dd-5a81-45ee-bf7e-7a63f2ac5bba)