### PR TITLE
add ellipsis to incomplete class __getattr__

### DIFF
--- a/docs/source/stubs.rst
+++ b/docs/source/stubs.rst
@@ -616,7 +616,7 @@ annotated function ``bar()``::
     def __getattr__(name: str) -> Any: ...  # incomplete
 
     class Foo:
-        def __getattr__(self, name: str) -> Any:  # incomplete
+        def __getattr__(self, name: str) -> Any: ... # incomplete
         x: int
         y: str
 


### PR DESCRIPTION
I'm fairly certain this is required, because I tried to follow this documentation by omitting it, just now, and got a syntax error.