### PR TITLE
Fixed a bug in the conformance test for `ClassVar` qualifier

### DIFF
--- a/conformance/results/mypy/classes_classvar.toml
+++ b/conformance/results/mypy/classes_classvar.toml
@@ -7,32 +7,32 @@ Does not reject use of ClassVar in TypeAlias definition.
 Does not infer type of ClassVar from assignment if no type is provided.
 """
 output = """
-classes_classvar.py:36: error: ClassVar[...] must have at most one type argument  [valid-type]
-classes_classvar.py:37: error: Invalid type: try using Literal[3] instead?  [valid-type]
-classes_classvar.py:38: error: Name "var" is not defined  [name-defined]
-classes_classvar.py:43: error: ClassVar cannot contain type variables  [misc]
+classes_classvar.py:37: error: ClassVar[...] must have at most one type argument  [valid-type]
+classes_classvar.py:38: error: Invalid type: try using Literal[3] instead?  [valid-type]
+classes_classvar.py:39: error: Name "var" is not defined  [name-defined]
 classes_classvar.py:44: error: ClassVar cannot contain type variables  [misc]
-classes_classvar.py:50: error: Incompatible types in assignment (expression has type "dict[Never, Never]", variable has type "list[str]")  [assignment]
-classes_classvar.py:52: error: Name "Final" is not defined  [name-defined]
-classes_classvar.py:53: error: Invalid type: ClassVar nested inside other type  [valid-type]
-classes_classvar.py:59: error: Invalid type: ClassVar nested inside other type  [valid-type]
-classes_classvar.py:61: error: ClassVar can only be used for assignments in class body  [misc]
+classes_classvar.py:45: error: ClassVar cannot contain type variables  [misc]
+classes_classvar.py:51: error: Incompatible types in assignment (expression has type "dict[Never, Never]", variable has type "list[str]")  [assignment]
+classes_classvar.py:53: error: Variable should not be annotated with both ClassVar and Final  [misc]
+classes_classvar.py:54: error: Invalid type: ClassVar nested inside other type  [valid-type]
+classes_classvar.py:60: error: Invalid type: ClassVar nested inside other type  [valid-type]
 classes_classvar.py:62: error: ClassVar can only be used for assignments in class body  [misc]
 classes_classvar.py:63: error: ClassVar can only be used for assignments in class body  [misc]
-classes_classvar.py:65: error: ClassVar can only be used for assignments in class body  [misc]
-classes_classvar.py:69: error: ClassVar can only be used for assignments in class body  [misc]
-classes_classvar.py:76: error: Expression is of type "Any", not "float"  [assert-type]
-classes_classvar.py:100: error: Cannot assign to class variable "stats" via instance  [misc]
-classes_classvar.py:129: error: Incompatible types in assignment (expression has type "ProtoAImpl", variable has type "ProtoA")  [assignment]
-classes_classvar.py:129: note: "ProtoAImpl" is missing following "ProtoA" protocol member:
-classes_classvar.py:129: note:     z
-classes_classvar.py:129: note: Protocol member ProtoA.x expected class variable, got instance variable
-classes_classvar.py:129: note: Protocol member ProtoA.y expected class variable, got instance variable
+classes_classvar.py:64: error: ClassVar can only be used for assignments in class body  [misc]
+classes_classvar.py:66: error: ClassVar can only be used for assignments in class body  [misc]
+classes_classvar.py:70: error: ClassVar can only be used for assignments in class body  [misc]
+classes_classvar.py:77: error: Expression is of type "Any", not "float"  [assert-type]
+classes_classvar.py:101: error: Cannot assign to class variable "stats" via instance  [misc]
+classes_classvar.py:130: error: Incompatible types in assignment (expression has type "ProtoAImpl", variable has type "ProtoA")  [assignment]
+classes_classvar.py:130: note: "ProtoAImpl" is missing following "ProtoA" protocol member:
+classes_classvar.py:130: note:     z
+classes_classvar.py:130: note: Protocol member ProtoA.x expected class variable, got instance variable
+classes_classvar.py:130: note: Protocol member ProtoA.y expected class variable, got instance variable
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 45: Expected 1 errors
-Line 70: Expected 1 errors
-Line 59: Unexpected errors ['classes_classvar.py:59: error: Invalid type: ClassVar nested inside other type  [valid-type]']
-Line 76: Unexpected errors ['classes_classvar.py:76: error: Expression is of type "Any", not "float"  [assert-type]']
+Line 46: Expected 1 errors
+Line 71: Expected 1 errors
+Line 60: Unexpected errors ['classes_classvar.py:60: error: Invalid type: ClassVar nested inside other type  [valid-type]']
+Line 77: Unexpected errors ['classes_classvar.py:77: error: Expression is of type "Any", not "float"  [assert-type]']
 """

--- a/conformance/results/mypy/dataclasses_final.toml
+++ b/conformance/results/mypy/dataclasses_final.toml
@@ -5,18 +5,22 @@ Doesn't support Final nested inside ClassVar.
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 16: Expected 1 errors
-Line 6: Unexpected errors ['dataclasses_final.py:6: error: Final name must be initialized with a value  [misc]']
-Line 8: Unexpected errors ['dataclasses_final.py:8: error: Final can be only used as an outermost qualifier in a variable annotation  [valid-type]']
-Line 13: Unexpected errors ['dataclasses_final.py:13: error: Expression is of type "Any", not "int"  [assert-type]']
+Line 27: Expected 1 errors
+Line 38: Expected 1 errors
+Line 41: Expected 1 errors
+Line 16: Unexpected errors ['dataclasses_final.py:16: error: Final name must be initialized with a value  [misc]']
+Line 18: Unexpected errors ['dataclasses_final.py:18: error: Final can be only used as an outermost qualifier in a variable annotation  [valid-type]']
+Line 24: Unexpected errors ['dataclasses_final.py:24: error: Expression is of type "Any", not "int"  [assert-type]']
+Line 37: Unexpected errors ['dataclasses_final.py:37: error: Cannot access final instance attribute "final_no_default" on class object  [misc]', 'dataclasses_final.py:37: error: Cannot assign to final attribute "final_no_default"  [misc]']
+Line 40: Unexpected errors ['dataclasses_final.py:40: error: Cannot assign to final attribute "final_with_default"  [misc]']
 """
 output = """
-dataclasses_final.py:6: error: Final name must be initialized with a value  [misc]
-dataclasses_final.py:8: error: Final can be only used as an outermost qualifier in a variable annotation  [valid-type]
-dataclasses_final.py:13: error: Expression is of type "Any", not "int"  [assert-type]
-dataclasses_final.py:24: error: Cannot assign to final attribute "final_no_default"  [misc]
-dataclasses_final.py:25: error: Cannot assign to final attribute "final_with_default"  [misc]
-dataclasses_final.py:26: error: Cannot access final instance attribute "final_no_default" on class object  [misc]
-dataclasses_final.py:26: error: Cannot assign to final attribute "final_no_default"  [misc]
-dataclasses_final.py:27: error: Cannot assign to final attribute "final_with_default"  [misc]
+dataclasses_final.py:16: error: Final name must be initialized with a value  [misc]
+dataclasses_final.py:18: error: Final can be only used as an outermost qualifier in a variable annotation  [valid-type]
+dataclasses_final.py:24: error: Expression is of type "Any", not "int"  [assert-type]
+dataclasses_final.py:35: error: Cannot assign to final attribute "final_no_default"  [misc]
+dataclasses_final.py:36: error: Cannot assign to final attribute "final_with_default"  [misc]
+dataclasses_final.py:37: error: Cannot access final instance attribute "final_no_default" on class object  [misc]
+dataclasses_final.py:37: error: Cannot assign to final attribute "final_no_default"  [misc]
+dataclasses_final.py:40: error: Cannot assign to final attribute "final_with_default"  [misc]
 """

--- a/conformance/results/mypy/version.toml
+++ b/conformance/results/mypy/version.toml
@@ -1,2 +1,2 @@
 version = "mypy 1.10.0"
-test_duration = 1.0
+test_duration = 1.4

--- a/conformance/results/pyre/classes_classvar.toml
+++ b/conformance/results/pyre/classes_classvar.toml
@@ -11,35 +11,35 @@ Does not reject use of ClassVar in type alias definition.
 Does not infer type from initialization for bare ClassVar.
 """
 output = """
-classes_classvar.py:33:0 Uninitialized attribute [13]: Attribute `bad1` is declared in class `ClassA` to have type `typing.Any` but is never initialized.
-classes_classvar.py:33:0 Uninitialized attribute [13]: Attribute `bad4` is declared in class `ClassA` to have type `Variable[T]` but is never initialized.
-classes_classvar.py:33:0 Uninitialized attribute [13]: Attribute `bad5` is declared in class `ClassA` to have type `typing.List[Variable[T]]` but is never initialized.
-classes_classvar.py:33:0 Uninitialized attribute [13]: Attribute `bad6` is declared in class `ClassA` to have type `typing.Callable[classes_classvar.P, typing.Any]` but is never initialized.
-classes_classvar.py:36:10 Invalid type parameters [24]: Generic type `CV` expects 1 type parameter, received 2.
-classes_classvar.py:37:10 Invalid type [31]: Expression `typing.ClassVar[3]` is not a valid type.
-classes_classvar.py:38:13 Unbound name [10]: Name `var` is used but not defined in the current scope.
-classes_classvar.py:50:4 Incompatible attribute type [8]: Attribute `bad8` declared in class `ClassA` has type `List[str]` but is used as type `Dict[Variable[_KT], Variable[_VT]]`.
-classes_classvar.py:52:10 Unbound name [10]: Name `Final` is used but not defined in the current scope.
-classes_classvar.py:63:8 Undefined attribute [16]: `ClassA` has no attribute `xx`.
-classes_classvar.py:66:8 Incompatible return type [7]: Expected `CV[int]` but got `int`.
-classes_classvar.py:76:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `float` but got `typing.Any`.
-classes_classvar.py:79:0 Uninitialized attribute [13]: Attribute `damage` is declared in class `BasicStarship` to have type `int` but is never initialized.
-classes_classvar.py:100:0 Invalid assignment [41]: Assigning to class variable through instance, did you mean to assign to `Starship.stats` instead?
-classes_classvar.py:129:0 Incompatible variable type [9]: a is declared to have type `ProtoA` but is used as type `ProtoAImpl`.
+classes_classvar.py:34:0 Uninitialized attribute [13]: Attribute `bad1` is declared in class `ClassA` to have type `typing.Any` but is never initialized.
+classes_classvar.py:34:0 Uninitialized attribute [13]: Attribute `bad4` is declared in class `ClassA` to have type `Variable[T]` but is never initialized.
+classes_classvar.py:34:0 Uninitialized attribute [13]: Attribute `bad5` is declared in class `ClassA` to have type `typing.List[Variable[T]]` but is never initialized.
+classes_classvar.py:34:0 Uninitialized attribute [13]: Attribute `bad6` is declared in class `ClassA` to have type `typing.Callable[classes_classvar.P, typing.Any]` but is never initialized.
+classes_classvar.py:37:10 Invalid type parameters [24]: Generic type `CV` expects 1 type parameter, received 2.
+classes_classvar.py:38:10 Invalid type [31]: Expression `typing.ClassVar[3]` is not a valid type.
+classes_classvar.py:39:13 Unbound name [10]: Name `var` is used but not defined in the current scope.
+classes_classvar.py:51:4 Incompatible attribute type [8]: Attribute `bad8` declared in class `ClassA` has type `List[str]` but is used as type `Dict[Variable[_KT], Variable[_VT]]`.
+classes_classvar.py:64:8 Undefined attribute [16]: `ClassA` has no attribute `xx`.
+classes_classvar.py:67:8 Incompatible return type [7]: Expected `CV[int]` but got `int`.
+classes_classvar.py:77:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `float` but got `typing.Any`.
+classes_classvar.py:80:0 Uninitialized attribute [13]: Attribute `damage` is declared in class `BasicStarship` to have type `int` but is never initialized.
+classes_classvar.py:101:0 Invalid assignment [41]: Assigning to class variable through instance, did you mean to assign to `Starship.stats` instead?
+classes_classvar.py:130:0 Incompatible variable type [9]: a is declared to have type `ProtoA` but is used as type `ProtoAImpl`.
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 43: Expected 1 errors
 Line 44: Expected 1 errors
 Line 45: Expected 1 errors
+Line 46: Expected 1 errors
 Line 53: Expected 1 errors
-Line 61: Expected 1 errors
+Line 54: Expected 1 errors
 Line 62: Expected 1 errors
-Line 65: Expected 1 errors
-Line 69: Expected 1 errors
+Line 63: Expected 1 errors
+Line 66: Expected 1 errors
 Line 70: Expected 1 errors
-Line 33: Unexpected errors ['classes_classvar.py:33:0 Uninitialized attribute [13]: Attribute `bad1` is declared in class `ClassA` to have type `typing.Any` but is never initialized.', 'classes_classvar.py:33:0 Uninitialized attribute [13]: Attribute `bad4` is declared in class `ClassA` to have type `Variable[T]` but is never initialized.', 'classes_classvar.py:33:0 Uninitialized attribute [13]: Attribute `bad5` is declared in class `ClassA` to have type `typing.List[Variable[T]]` but is never initialized.', 'classes_classvar.py:33:0 Uninitialized attribute [13]: Attribute `bad6` is declared in class `ClassA` to have type `typing.Callable[classes_classvar.P, typing.Any]` but is never initialized.']
-Line 66: Unexpected errors ['classes_classvar.py:66:8 Incompatible return type [7]: Expected `CV[int]` but got `int`.']
-Line 76: Unexpected errors ['classes_classvar.py:76:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `float` but got `typing.Any`.']
-Line 79: Unexpected errors ['classes_classvar.py:79:0 Uninitialized attribute [13]: Attribute `damage` is declared in class `BasicStarship` to have type `int` but is never initialized.']
+Line 71: Expected 1 errors
+Line 34: Unexpected errors ['classes_classvar.py:34:0 Uninitialized attribute [13]: Attribute `bad1` is declared in class `ClassA` to have type `typing.Any` but is never initialized.', 'classes_classvar.py:34:0 Uninitialized attribute [13]: Attribute `bad4` is declared in class `ClassA` to have type `Variable[T]` but is never initialized.', 'classes_classvar.py:34:0 Uninitialized attribute [13]: Attribute `bad5` is declared in class `ClassA` to have type `typing.List[Variable[T]]` but is never initialized.', 'classes_classvar.py:34:0 Uninitialized attribute [13]: Attribute `bad6` is declared in class `ClassA` to have type `typing.Callable[classes_classvar.P, typing.Any]` but is never initialized.']
+Line 67: Unexpected errors ['classes_classvar.py:67:8 Incompatible return type [7]: Expected `CV[int]` but got `int`.']
+Line 77: Unexpected errors ['classes_classvar.py:77:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `float` but got `typing.Any`.']
+Line 80: Unexpected errors ['classes_classvar.py:80:0 Uninitialized attribute [13]: Attribute `damage` is declared in class `BasicStarship` to have type `int` but is never initialized.']
 """

--- a/conformance/results/pyre/dataclasses_final.toml
+++ b/conformance/results/pyre/dataclasses_final.toml
@@ -4,16 +4,20 @@ Mis-handles Final nested inside ClassVar.
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 8: Unexpected errors ['dataclasses_final.py:8:4 Incompatible attribute type [8]: Attribute `final_classvar` declared in class `D` has type `Final[int]` but is used as type `int`.', 'dataclasses_final.py:8:4 Invalid type [31]: Expression `Final[int]` is not a valid type. Final cannot be nested.']
-Line 13: Unexpected errors ['dataclasses_final.py:13:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `Final[int]`.']
+Line 38: Expected 1 errors
+Line 41: Expected 1 errors
+Line 18: Unexpected errors ['dataclasses_final.py:18:4 Incompatible attribute type [8]: Attribute `final_classvar` declared in class `D` has type `Final[int]` but is used as type `int`.', 'dataclasses_final.py:18:4 Invalid type [31]: Expression `Final[int]` is not a valid type. Final cannot be nested.']
+Line 24: Unexpected errors ['dataclasses_final.py:24:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `Final[int]`.']
+Line 37: Unexpected errors ['dataclasses_final.py:37:0 Invalid assignment [41]: Cannot reassign final attribute `D.final_no_default`.']
+Line 40: Unexpected errors ['dataclasses_final.py:40:0 Invalid assignment [41]: Cannot reassign final attribute `D.final_with_default`.']
 """
 output = """
-dataclasses_final.py:8:4 Incompatible attribute type [8]: Attribute `final_classvar` declared in class `D` has type `Final[int]` but is used as type `int`.
-dataclasses_final.py:8:4 Invalid type [31]: Expression `Final[int]` is not a valid type. Final cannot be nested.
-dataclasses_final.py:13:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `Final[int]`.
-dataclasses_final.py:16:0 Incompatible attribute type [8]: Attribute `final_classvar` declared in class `D` has type `Final[int]` but is used as type `int`.
-dataclasses_final.py:24:0 Invalid assignment [41]: Cannot reassign final attribute `d.final_no_default`.
-dataclasses_final.py:25:0 Invalid assignment [41]: Cannot reassign final attribute `d.final_with_default`.
-dataclasses_final.py:26:0 Invalid assignment [41]: Cannot reassign final attribute `D.final_no_default`.
-dataclasses_final.py:27:0 Invalid assignment [41]: Cannot reassign final attribute `D.final_with_default`.
+dataclasses_final.py:18:4 Incompatible attribute type [8]: Attribute `final_classvar` declared in class `D` has type `Final[int]` but is used as type `int`.
+dataclasses_final.py:18:4 Invalid type [31]: Expression `Final[int]` is not a valid type. Final cannot be nested.
+dataclasses_final.py:24:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `Final[int]`.
+dataclasses_final.py:27:0 Incompatible attribute type [8]: Attribute `final_classvar` declared in class `D` has type `Final[int]` but is used as type `int`.
+dataclasses_final.py:35:0 Invalid assignment [41]: Cannot reassign final attribute `d.final_no_default`.
+dataclasses_final.py:36:0 Invalid assignment [41]: Cannot reassign final attribute `d.final_with_default`.
+dataclasses_final.py:37:0 Invalid assignment [41]: Cannot reassign final attribute `D.final_no_default`.
+dataclasses_final.py:40:0 Invalid assignment [41]: Cannot reassign final attribute `D.final_with_default`.
 """

--- a/conformance/results/pyre/version.toml
+++ b/conformance/results/pyre/version.toml
@@ -1,2 +1,2 @@
 version = "pyre 0.9.21"
-test_duration = 1.9
+test_duration = 3.4

--- a/conformance/results/pyright/classes_classvar.toml
+++ b/conformance/results/pyright/classes_classvar.toml
@@ -1,24 +1,24 @@
 conformant = "Pass"
 output = """
-classes_classvar.py:36:25 - error: Expected only one type argument after "ClassVar"
-classes_classvar.py:37:14 - error: Expected type expression but received "Literal[3]" (reportGeneralTypeIssues)
-classes_classvar.py:38:14 - error: "var" is not defined (reportUndefinedVariable)
-classes_classvar.py:43:20 - error: "ClassVar" type cannot include type variables (reportGeneralTypeIssues)
+classes_classvar.py:37:25 - error: Expected only one type argument after "ClassVar"
+classes_classvar.py:38:14 - error: Expected type expression but received "Literal[3]" (reportGeneralTypeIssues)
+classes_classvar.py:39:14 - error: "var" is not defined (reportUndefinedVariable)
 classes_classvar.py:44:20 - error: "ClassVar" type cannot include type variables (reportGeneralTypeIssues)
 classes_classvar.py:45:20 - error: "ClassVar" type cannot include type variables (reportGeneralTypeIssues)
-classes_classvar.py:50:33 - error: Expression of type "dict[Any, Any]" is incompatible with declared type "list[str]" (reportAssignmentType)
-classes_classvar.py:52:11 - error: "Final" is not defined (reportUndefinedVariable)
+classes_classvar.py:46:20 - error: "ClassVar" type cannot include type variables (reportGeneralTypeIssues)
+classes_classvar.py:51:33 - error: Expression of type "dict[Any, Any]" is incompatible with declared type "list[str]" (reportAssignmentType)
 classes_classvar.py:53:17 - error: "ClassVar" is not allowed in this context
-classes_classvar.py:61:26 - error: "ClassVar" is not allowed in this context
-classes_classvar.py:62:12 - error: "ClassVar" is not allowed in this context
-classes_classvar.py:63:18 - error: "ClassVar" is not allowed in this context
-classes_classvar.py:65:26 - error: "ClassVar" is not allowed in this context
-classes_classvar.py:69:8 - error: "ClassVar" is not allowed in this context
-classes_classvar.py:70:20 - error: "ClassVar" is not allowed in this context
-classes_classvar.py:100:14 - error: Cannot assign to attribute "stats" for class "Starship"
+classes_classvar.py:54:17 - error: "ClassVar" is not allowed in this context
+classes_classvar.py:62:26 - error: "ClassVar" is not allowed in this context
+classes_classvar.py:63:12 - error: "ClassVar" is not allowed in this context
+classes_classvar.py:64:18 - error: "ClassVar" is not allowed in this context
+classes_classvar.py:66:26 - error: "ClassVar" is not allowed in this context
+classes_classvar.py:70:8 - error: "ClassVar" is not allowed in this context
+classes_classvar.py:71:20 - error: "ClassVar" is not allowed in this context
+classes_classvar.py:101:14 - error: Cannot assign to attribute "stats" for class "Starship"
   Attribute "stats" cannot be assigned through a class instance because it is a ClassVar
     Attribute "__set__" is unknown (reportAttributeAccessIssue)
-classes_classvar.py:129:13 - error: Expression of type "ProtoAImpl" is incompatible with declared type "ProtoA"
+classes_classvar.py:130:13 - error: Expression of type "ProtoAImpl" is incompatible with declared type "ProtoA"
   "ProtoAImpl" is incompatible with protocol "ProtoA"
     "x" is defined as a ClassVar in protocol
     "y" is defined as a ClassVar in protocol (reportAssignmentType)

--- a/conformance/results/pyright/dataclasses_final.toml
+++ b/conformance/results/pyright/dataclasses_final.toml
@@ -4,26 +4,30 @@ Doesn't support Final nested inside ClassVar.
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 8: Unexpected errors ['dataclasses_final.py:8:30 - error: "Final" is not allowed in this context', 'dataclasses_final.py:8:44 - error: Expression of type "Literal[4]" is incompatible with declared type "Final"']
-Line 13: Unexpected errors ['dataclasses_final.py:13:13 - error: "assert_type" mismatch: expected "int" but received "Final" (reportAssertTypeFailure)']
+Line 38: Expected 1 errors
+Line 41: Expected 1 errors
+Line 18: Unexpected errors ['dataclasses_final.py:18:30 - error: "Final" is not allowed in this context', 'dataclasses_final.py:18:44 - error: Expression of type "Literal[4]" is incompatible with declared type "Final"']
+Line 24: Unexpected errors ['dataclasses_final.py:24:13 - error: "assert_type" mismatch: expected "int" but received "Final" (reportAssertTypeFailure)']
+Line 37: Unexpected errors ['dataclasses_final.py:37:3 - error: Cannot assign to attribute "final_no_default" for class "type[D]"']
+Line 40: Unexpected errors ['dataclasses_final.py:40:3 - error: Cannot assign to attribute "final_with_default" for class "type[D]"']
 """
 output = """
-dataclasses_final.py:8:30 - error: "Final" is not allowed in this context
-dataclasses_final.py:8:44 - error: Expression of type "Literal[4]" is incompatible with declared type "Final"
+dataclasses_final.py:18:30 - error: "Final" is not allowed in this context
+dataclasses_final.py:18:44 - error: Expression of type "Literal[4]" is incompatible with declared type "Final"
   "Literal[4]" is incompatible with "Final" (reportAssignmentType)
-dataclasses_final.py:13:13 - error: "assert_type" mismatch: expected "int" but received "Final" (reportAssertTypeFailure)
-dataclasses_final.py:16:20 - error: Cannot assign to attribute "final_classvar" for class "type[D]"
+dataclasses_final.py:24:13 - error: "assert_type" mismatch: expected "int" but received "Final" (reportAssertTypeFailure)
+dataclasses_final.py:27:20 - error: Cannot assign to attribute "final_classvar" for class "type[D]"
   "Literal[10]" is incompatible with "Final" (reportAttributeAccessIssue)
-dataclasses_final.py:24:3 - error: Cannot assign to attribute "final_no_default" for class "D"
+dataclasses_final.py:35:3 - error: Cannot assign to attribute "final_no_default" for class "D"
   "final_no_default" is declared as Final and cannot be reassigned
     Attribute "__set__" is unknown (reportAttributeAccessIssue)
-dataclasses_final.py:25:3 - error: Cannot assign to attribute "final_with_default" for class "D"
+dataclasses_final.py:36:3 - error: Cannot assign to attribute "final_with_default" for class "D"
   "final_with_default" is declared as Final and cannot be reassigned
     Attribute "__set__" is unknown (reportAttributeAccessIssue)
-dataclasses_final.py:26:3 - error: Cannot assign to attribute "final_no_default" for class "type[D]"
+dataclasses_final.py:37:3 - error: Cannot assign to attribute "final_no_default" for class "type[D]"
   "final_no_default" is declared as Final and cannot be reassigned
     Attribute "__set__" is unknown (reportAttributeAccessIssue)
-dataclasses_final.py:27:3 - error: Cannot assign to attribute "final_with_default" for class "type[D]"
+dataclasses_final.py:40:3 - error: Cannot assign to attribute "final_with_default" for class "type[D]"
   "final_with_default" is declared as Final and cannot be reassigned
     Attribute "__set__" is unknown (reportAttributeAccessIssue)
 """

--- a/conformance/results/pyright/version.toml
+++ b/conformance/results/pyright/version.toml
@@ -1,2 +1,2 @@
 version = "pyright 1.1.363"
-test_duration = 1.7
+test_duration = 1.4

--- a/conformance/results/pytype/classes_classvar.toml
+++ b/conformance/results/pytype/classes_classvar.toml
@@ -13,35 +13,35 @@ Does not reject assignment of ClassVar through instance of class.
 """
 output = """
 File "classes_classvar.py", line 7, in <module>: typing.TypeVarTuple not supported yet [not-supported-yet]
-File "classes_classvar.py", line 27, in <module>: Function TypeVarTuple.__init__ expects 1 arg(s), got 2 [wrong-arg-count]
-File "classes_classvar.py", line 36, in ClassA: Invalid type annotation 'ClassVar[int, str]'  [invalid-annotation]
-File "classes_classvar.py", line 37, in ClassA: class ClassVar is not indexable [not-indexable]
-File "classes_classvar.py", line 38, in ClassA: Name 'var' is not defined [name-error]
-File "classes_classvar.py", line 50, in ClassA: Type annotation for bad8 does not match type of assignment [annotation-type-mismatch]
-File "classes_classvar.py", line 52, in ClassA: Name 'Final' is not defined [name-error]
-File "classes_classvar.py", line 58, in ClassA: Type annotation for good4 does not match type of assignment [annotation-type-mismatch]
-File "classes_classvar.py", line 66, in method2: bad return type [bad-return-type]
-File "classes_classvar.py", line 76, in <module>: ClassVar [assert-type]
-File "classes_classvar.py", line 119, in ProtoA: Type annotation for z does not match type of assignment [annotation-type-mismatch]
-File "classes_classvar.py", line 129, in <module>: Type annotation for a does not match type of assignment [annotation-type-mismatch]
+File "classes_classvar.py", line 28, in <module>: Function TypeVarTuple.__init__ expects 1 arg(s), got 2 [wrong-arg-count]
+File "classes_classvar.py", line 37, in ClassA: Invalid type annotation 'ClassVar[int, str]'  [invalid-annotation]
+File "classes_classvar.py", line 38, in ClassA: class ClassVar is not indexable [not-indexable]
+File "classes_classvar.py", line 39, in ClassA: Name 'var' is not defined [name-error]
+File "classes_classvar.py", line 51, in ClassA: Type annotation for bad8 does not match type of assignment [annotation-type-mismatch]
+File "classes_classvar.py", line 59, in ClassA: Type annotation for good4 does not match type of assignment [annotation-type-mismatch]
+File "classes_classvar.py", line 67, in method2: bad return type [bad-return-type]
+File "classes_classvar.py", line 77, in <module>: ClassVar [assert-type]
+File "classes_classvar.py", line 120, in ProtoA: Type annotation for z does not match type of assignment [annotation-type-mismatch]
+File "classes_classvar.py", line 130, in <module>: Type annotation for a does not match type of assignment [annotation-type-mismatch]
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 43: Expected 1 errors
 Line 44: Expected 1 errors
 Line 45: Expected 1 errors
+Line 46: Expected 1 errors
 Line 53: Expected 1 errors
-Line 61: Expected 1 errors
+Line 54: Expected 1 errors
 Line 62: Expected 1 errors
 Line 63: Expected 1 errors
-Line 65: Expected 1 errors
-Line 69: Expected 1 errors
+Line 64: Expected 1 errors
+Line 66: Expected 1 errors
 Line 70: Expected 1 errors
-Line 100: Expected 1 errors
+Line 71: Expected 1 errors
+Line 101: Expected 1 errors
 Line 7: Unexpected errors ['File "classes_classvar.py", line 7, in <module>: typing.TypeVarTuple not supported yet [not-supported-yet]']
-Line 27: Unexpected errors ['File "classes_classvar.py", line 27, in <module>: Function TypeVarTuple.__init__ expects 1 arg(s), got 2 [wrong-arg-count]']
-Line 58: Unexpected errors ['File "classes_classvar.py", line 58, in ClassA: Type annotation for good4 does not match type of assignment [annotation-type-mismatch]']
-Line 66: Unexpected errors ['File "classes_classvar.py", line 66, in method2: bad return type [bad-return-type]']
-Line 76: Unexpected errors ['File "classes_classvar.py", line 76, in <module>: ClassVar [assert-type]']
-Line 119: Unexpected errors ['File "classes_classvar.py", line 119, in ProtoA: Type annotation for z does not match type of assignment [annotation-type-mismatch]']
+Line 28: Unexpected errors ['File "classes_classvar.py", line 28, in <module>: Function TypeVarTuple.__init__ expects 1 arg(s), got 2 [wrong-arg-count]']
+Line 59: Unexpected errors ['File "classes_classvar.py", line 59, in ClassA: Type annotation for good4 does not match type of assignment [annotation-type-mismatch]']
+Line 67: Unexpected errors ['File "classes_classvar.py", line 67, in method2: bad return type [bad-return-type]']
+Line 77: Unexpected errors ['File "classes_classvar.py", line 77, in <module>: ClassVar [assert-type]']
+Line 120: Unexpected errors ['File "classes_classvar.py", line 120, in ProtoA: Type annotation for z does not match type of assignment [annotation-type-mismatch]']
 """

--- a/conformance/results/pytype/dataclasses_final.toml
+++ b/conformance/results/pytype/dataclasses_final.toml
@@ -3,15 +3,17 @@ notes = """
 Doesn't handle Final nested inside ClassVar.
 """
 errors_diff = """
-Line 16: Expected 1 errors
-Line 24: Expected 1 errors
-Line 26: Expected 1 errors
-Line 8: Unexpected errors ['File "dataclasses_final.py", line 8, in D: Invalid use of typing.Final [final-error]', 'File "dataclasses_final.py", line 8, in D: Invalid type annotation \\'ClassVar[Final[int]]\\'  [invalid-annotation]']
+Line 27: Expected 1 errors
+Line 35: Expected 1 errors
+Line 38: Expected 1 errors
+Line 41: Expected 1 errors
+Line 18: Unexpected errors ['File "dataclasses_final.py", line 18, in D: Invalid use of typing.Final [final-error]', 'File "dataclasses_final.py", line 18, in D: Invalid type annotation \\'ClassVar[Final[int]]\\'  [invalid-annotation]']
+Line 40: Unexpected errors ['File "dataclasses_final.py", line 40, in <module>: Assigning to attribute final_with_default, which was annotated with Final [final-error]']
 """
 output = """
-File "dataclasses_final.py", line 8, in D: Invalid use of typing.Final [final-error]
-File "dataclasses_final.py", line 8, in D: Invalid type annotation 'ClassVar[Final[int]]'  [invalid-annotation]
-File "dataclasses_final.py", line 25, in <module>: Assigning to attribute final_with_default, which was annotated with Final [final-error]
-File "dataclasses_final.py", line 27, in <module>: Assigning to attribute final_with_default, which was annotated with Final [final-error]
+File "dataclasses_final.py", line 18, in D: Invalid use of typing.Final [final-error]
+File "dataclasses_final.py", line 18, in D: Invalid type annotation 'ClassVar[Final[int]]'  [invalid-annotation]
+File "dataclasses_final.py", line 36, in <module>: Assigning to attribute final_with_default, which was annotated with Final [final-error]
+File "dataclasses_final.py", line 40, in <module>: Assigning to attribute final_with_default, which was annotated with Final [final-error]
 """
 conformance_automated = "Fail"

--- a/conformance/results/pytype/version.toml
+++ b/conformance/results/pytype/version.toml
@@ -1,2 +1,2 @@
 version = "pytype 2024.04.11"
-test_duration = 28.3
+test_duration = 30.1

--- a/conformance/results/results.html
+++ b/conformance/results/results.html
@@ -159,16 +159,16 @@
         <div class="table_container"><table><tbody>
 <tr><th class="col1">&nbsp;</th>
 <th class='tc-header'><div class='tc-name'>mypy 1.10.0</div>
-<div class='tc-time'>1.0sec</div>
+<div class='tc-time'>1.4sec</div>
 </th>
 <th class='tc-header'><div class='tc-name'>pyright 1.1.363</div>
-<div class='tc-time'>1.7sec</div>
+<div class='tc-time'>1.4sec</div>
 </th>
 <th class='tc-header'><div class='tc-name'>pyre 0.9.21</div>
-<div class='tc-time'>1.9sec</div>
+<div class='tc-time'>3.4sec</div>
 </th>
 <th class='tc-header'><div class='tc-name'>pytype 2024.04.11</div>
-<div class='tc-time'>28.3sec</div>
+<div class='tc-time'>30.1sec</div>
 </th>
 </tr>
 <tr><th class="column" colspan="5">

--- a/conformance/tests/classes_classvar.py
+++ b/conformance/tests/classes_classvar.py
@@ -9,6 +9,7 @@ from typing import (
     Any,
     Callable,
     ClassVar,
+    Final,
     Generic,
     ParamSpec,
     Protocol,

--- a/conformance/tests/dataclasses_final.py
+++ b/conformance/tests/dataclasses_final.py
@@ -1,5 +1,15 @@
+"""
+Tests the handling of ClassVar and Final in dataclasses.
+"""
+
 from dataclasses import dataclass
 from typing import assert_type, ClassVar, Final
+
+# Specification: https://typing.readthedocs.io/en/latest/spec/dataclasses.html#dataclass-semantics
+
+# > A final class variable on a dataclass must be explicitly annotated as
+# e.g. x: ClassVar[Final[int]] = 3.
+
 
 @dataclass
 class D:
@@ -8,6 +18,7 @@ class D:
     final_classvar: ClassVar[Final[int]] = 4
     # we don't require support for Final[ClassVar[...]] because the dataclasses
     # runtime implementation won't recognize it as a ClassVar either
+
 
 # An explicitly marked ClassVar can be accessed on the class:
 assert_type(D.final_classvar, int)
@@ -23,5 +34,9 @@ assert_type(d.final_with_default, str)
 # ... but can't be assigned to (on the class or on an instance):
 d.final_no_default = 10  # E: can't assign to final attribute
 d.final_with_default = "baz"  # E: can't assign to final attribute
-D.final_no_default  = 10  # E: can't assign to final attribute / can't assign instance attr on class
-D.final_with_default  = "baz"  # E: can't assign to final attribute / can't assign instance attr on class
+D.final_no_default = (
+    10  # E: can't assign to final attribute / can't assign instance attr on class
+)
+D.final_with_default = (
+    "baz"  # E: can't assign to final attribute / can't assign instance attr on class
+)


### PR DESCRIPTION
Fixed a bug in the conformance test for `ClassVar` qualifier. The test was not importing `Final`, so it was not really testing what it intended.

Also added some additional comments to the recently-added test for `dataclasses_final` for consistency with other tests.