### PR TITLE
Updated conformance results for pyright 1.1.364.

### DIFF
--- a/conformance/results/mypy/dataclasses_final.toml
+++ b/conformance/results/mypy/dataclasses_final.toml
@@ -6,13 +6,9 @@ Doesn't support Final nested inside ClassVar.
 conformance_automated = "Fail"
 errors_diff = """
 Line 27: Expected 1 errors
-Line 38: Expected 1 errors
-Line 41: Expected 1 errors
 Line 16: Unexpected errors ['dataclasses_final.py:16: error: Final name must be initialized with a value  [misc]']
 Line 18: Unexpected errors ['dataclasses_final.py:18: error: Final can be only used as an outermost qualifier in a variable annotation  [valid-type]']
 Line 24: Unexpected errors ['dataclasses_final.py:24: error: Expression is of type "Any", not "int"  [assert-type]']
-Line 37: Unexpected errors ['dataclasses_final.py:37: error: Cannot access final instance attribute "final_no_default" on class object  [misc]', 'dataclasses_final.py:37: error: Cannot assign to final attribute "final_no_default"  [misc]']
-Line 40: Unexpected errors ['dataclasses_final.py:40: error: Cannot assign to final attribute "final_with_default"  [misc]']
 """
 output = """
 dataclasses_final.py:16: error: Final name must be initialized with a value  [misc]
@@ -22,5 +18,5 @@ dataclasses_final.py:35: error: Cannot assign to final attribute "final_no_defau
 dataclasses_final.py:36: error: Cannot assign to final attribute "final_with_default"  [misc]
 dataclasses_final.py:37: error: Cannot access final instance attribute "final_no_default" on class object  [misc]
 dataclasses_final.py:37: error: Cannot assign to final attribute "final_no_default"  [misc]
-dataclasses_final.py:40: error: Cannot assign to final attribute "final_with_default"  [misc]
+dataclasses_final.py:38: error: Cannot assign to final attribute "final_with_default"  [misc]
 """

--- a/conformance/results/pyre/dataclasses_final.toml
+++ b/conformance/results/pyre/dataclasses_final.toml
@@ -4,12 +4,8 @@ Mis-handles Final nested inside ClassVar.
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 38: Expected 1 errors
-Line 41: Expected 1 errors
 Line 18: Unexpected errors ['dataclasses_final.py:18:4 Incompatible attribute type [8]: Attribute `final_classvar` declared in class `D` has type `Final[int]` but is used as type `int`.', 'dataclasses_final.py:18:4 Invalid type [31]: Expression `Final[int]` is not a valid type. Final cannot be nested.']
 Line 24: Unexpected errors ['dataclasses_final.py:24:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `Final[int]`.']
-Line 37: Unexpected errors ['dataclasses_final.py:37:0 Invalid assignment [41]: Cannot reassign final attribute `D.final_no_default`.']
-Line 40: Unexpected errors ['dataclasses_final.py:40:0 Invalid assignment [41]: Cannot reassign final attribute `D.final_with_default`.']
 """
 output = """
 dataclasses_final.py:18:4 Incompatible attribute type [8]: Attribute `final_classvar` declared in class `D` has type `Final[int]` but is used as type `int`.
@@ -19,5 +15,5 @@ dataclasses_final.py:27:0 Incompatible attribute type [8]: Attribute `final_clas
 dataclasses_final.py:35:0 Invalid assignment [41]: Cannot reassign final attribute `d.final_no_default`.
 dataclasses_final.py:36:0 Invalid assignment [41]: Cannot reassign final attribute `d.final_with_default`.
 dataclasses_final.py:37:0 Invalid assignment [41]: Cannot reassign final attribute `D.final_no_default`.
-dataclasses_final.py:40:0 Invalid assignment [41]: Cannot reassign final attribute `D.final_with_default`.
+dataclasses_final.py:38:0 Invalid assignment [41]: Cannot reassign final attribute `D.final_with_default`.
 """

--- a/conformance/results/pyright/callables_protocol.toml
+++ b/conformance/results/pyright/callables_protocol.toml
@@ -46,8 +46,9 @@ callables_protocol.py:197:16 - error: Cannot access attribute "other_attribute2"
   Attribute "other_attribute2" is unknown (reportAttributeAccessIssue)
 callables_protocol.py:238:8 - error: Expression of type "(x: int, y: str, /) -> Any" is incompatible with declared type "Proto11"
   Type "(x: int, y: str, /) -> Any" is incompatible with type "(x: int, /, y: str) -> Any"
-    Position-only parameter mismatch; parameter "y" is not position-only
-    Position-only parameter mismatch; expected 2 but received 1 (reportAssignmentType)
+    Keyword parameter "y" is missing in source
+      Position-only parameter mismatch; parameter "y" is not position-only
+      Position-only parameter mismatch; expected 2 but received 1 (reportAssignmentType)
 callables_protocol.py:260:8 - error: Expression of type "(*args: Any, kwarg0: Any) -> None" is incompatible with declared type "Proto12"
   Type "(*args: Any, kwarg0: Any) -> None" is incompatible with type "(*args: Any, kwarg0: Any, kwarg1: Any) -> None"
     Keyword parameter "kwarg1" is missing in source (reportAssignmentType)

--- a/conformance/results/pyright/callables_subtyping.toml
+++ b/conformance/results/pyright/callables_subtyping.toml
@@ -14,9 +14,11 @@ callables_subtyping.py:51:21 - error: Expression of type "PosOnly2" is incompati
   "PosOnly2" is incompatible with protocol "Standard2"
     "__call__" is an incompatible type
       Type "(b: int, a: int, /) -> None" is incompatible with type "(a: int, b: int) -> None"
-        Position-only parameter mismatch; parameter "a" is not position-only
-        Position-only parameter mismatch; parameter "b" is not position-only
-        Position-only parameter mismatch; expected 2 but received 0 (reportAssignmentType)
+        Keyword parameter "a" is missing in source
+        Keyword parameter "b" is missing in source
+          Position-only parameter mismatch; parameter "a" is not position-only
+          Position-only parameter mismatch; parameter "b" is not position-only
+          Position-only parameter mismatch; expected 2 but received 0 (reportAssignmentType)
 callables_subtyping.py:52:21 - error: Expression of type "KwOnly2" is incompatible with declared type "Standard2"
   "KwOnly2" is incompatible with protocol "Standard2"
     "__call__" is an incompatible type
@@ -94,13 +96,16 @@ callables_subtyping.py:125:22 - error: Expression of type "IntStrArgs4" is incom
   "IntStrArgs4" is incompatible with protocol "Standard4"
     "__call__" is an incompatible type
       Type "(*args: int | str) -> None" is incompatible with type "(a: int, b: str) -> None"
+        Keyword parameter "a" is missing in source
         Keyword parameter "b" is missing in source (reportAssignmentType)
 callables_subtyping.py:126:22 - error: Expression of type "StrArgs4" is incompatible with declared type "Standard4"
   "StrArgs4" is incompatible with protocol "Standard4"
     "__call__" is an incompatible type
       Type "(a: int, /, *args: str) -> None" is incompatible with type "(a: int, b: str) -> None"
-        Position-only parameter mismatch; parameter "a" is not position-only
-        Position-only parameter mismatch; expected 1 but received 0 (reportAssignmentType)
+        Keyword parameter "a" is missing in source
+        Keyword parameter "b" is missing in source
+          Position-only parameter mismatch; parameter "a" is not position-only
+          Position-only parameter mismatch; expected 1 but received 0 (reportAssignmentType)
 callables_subtyping.py:151:22 - error: Expression of type "NoKwargs5" is incompatible with declared type "IntKwargs5"
   "NoKwargs5" is incompatible with protocol "IntKwargs5"
     "__call__" is an incompatible type

--- a/conformance/results/pyright/dataclasses_final.toml
+++ b/conformance/results/pyright/dataclasses_final.toml
@@ -1,23 +1,11 @@
-conformant = "Partial"
-notes = """
-Doesn't support Final nested inside ClassVar.
-"""
-conformance_automated = "Fail"
+conformant = "Pass"
+conformance_automated = "Pass"
 errors_diff = """
-Line 38: Expected 1 errors
-Line 41: Expected 1 errors
-Line 18: Unexpected errors ['dataclasses_final.py:18:30 - error: "Final" is not allowed in this context', 'dataclasses_final.py:18:44 - error: Expression of type "Literal[4]" is incompatible with declared type "Final"']
-Line 24: Unexpected errors ['dataclasses_final.py:24:13 - error: "assert_type" mismatch: expected "int" but received "Final" (reportAssertTypeFailure)']
-Line 37: Unexpected errors ['dataclasses_final.py:37:3 - error: Cannot assign to attribute "final_no_default" for class "type[D]"']
-Line 40: Unexpected errors ['dataclasses_final.py:40:3 - error: Cannot assign to attribute "final_with_default" for class "type[D]"']
 """
 output = """
-dataclasses_final.py:18:30 - error: "Final" is not allowed in this context
-dataclasses_final.py:18:44 - error: Expression of type "Literal[4]" is incompatible with declared type "Final"
-  "Literal[4]" is incompatible with "Final" (reportAssignmentType)
-dataclasses_final.py:24:13 - error: "assert_type" mismatch: expected "int" but received "Final" (reportAssertTypeFailure)
-dataclasses_final.py:27:20 - error: Cannot assign to attribute "final_classvar" for class "type[D]"
-  "Literal[10]" is incompatible with "Final" (reportAttributeAccessIssue)
+dataclasses_final.py:27:3 - error: Cannot assign to attribute "final_classvar" for class "type[D]"
+  "final_classvar" is declared as Final and cannot be reassigned
+    Attribute "__set__" is unknown (reportAttributeAccessIssue)
 dataclasses_final.py:35:3 - error: Cannot assign to attribute "final_no_default" for class "D"
   "final_no_default" is declared as Final and cannot be reassigned
     Attribute "__set__" is unknown (reportAttributeAccessIssue)
@@ -27,7 +15,7 @@ dataclasses_final.py:36:3 - error: Cannot assign to attribute "final_with_defaul
 dataclasses_final.py:37:3 - error: Cannot assign to attribute "final_no_default" for class "type[D]"
   "final_no_default" is declared as Final and cannot be reassigned
     Attribute "__set__" is unknown (reportAttributeAccessIssue)
-dataclasses_final.py:40:3 - error: Cannot assign to attribute "final_with_default" for class "type[D]"
+dataclasses_final.py:38:3 - error: Cannot assign to attribute "final_with_default" for class "type[D]"
   "final_with_default" is declared as Final and cannot be reassigned
     Attribute "__set__" is unknown (reportAttributeAccessIssue)
 """

--- a/conformance/results/pyright/protocols_definition.toml
+++ b/conformance/results/pyright/protocols_definition.toml
@@ -72,9 +72,11 @@ protocols_definition.py:288:22 - error: Expression of type "Concrete5_Bad4" is i
   "Concrete5_Bad4" is incompatible with protocol "Template5"
     "method1" is an incompatible type
       Type "(a: int, b: int, /) -> float" is incompatible with type "(a: int, b: int) -> float"
-        Position-only parameter mismatch; parameter "a" is not position-only
-        Position-only parameter mismatch; parameter "b" is not position-only
-        Position-only parameter mismatch; expected 2 but received 0 (reportAssignmentType)
+        Keyword parameter "a" is missing in source
+        Keyword parameter "b" is missing in source
+          Position-only parameter mismatch; parameter "a" is not position-only
+          Position-only parameter mismatch; parameter "b" is not position-only
+          Position-only parameter mismatch; expected 2 but received 0 (reportAssignmentType)
 protocols_definition.py:289:22 - error: Expression of type "Concrete5_Bad5" is incompatible with declared type "Template5"
   "Concrete5_Bad5" is incompatible with protocol "Template5"
     "method1" is an incompatible type

--- a/conformance/results/pyright/qualifiers_annotated.toml
+++ b/conformance/results/pyright/qualifiers_annotated.toml
@@ -17,9 +17,9 @@ qualifiers_annotated.py:52:18 - error: Expected type expression but received "Li
 qualifiers_annotated.py:53:18 - error: Binary operator not allowed in type annotation (reportInvalidTypeForm)
 qualifiers_annotated.py:54:18 - error: Type annotations cannot use format string literals (f-strings) (reportGeneralTypeIssues)
 qualifiers_annotated.py:64:8 - error: Expected one type argument and one or more annotations for "Annotated"
-qualifiers_annotated.py:76:24 - error: Expression of type "type[int]" is incompatible with declared type "type[Any]" (reportAssignmentType)
+qualifiers_annotated.py:76:24 - error: Expression of type "type[Annotated]" is incompatible with declared type "type[Any]" (reportAssignmentType)
 qualifiers_annotated.py:77:24 - error: Expression of type "SmallInt" is incompatible with declared type "type[Any]" (reportAssignmentType)
-qualifiers_annotated.py:84:7 - error: Argument of type "type[str]" cannot be assigned to parameter "x" of type "type[T@func4]" in function "func4" (reportArgumentType)
+qualifiers_annotated.py:84:7 - error: Argument of type "type[Annotated]" cannot be assigned to parameter "x" of type "type[T@func4]" in function "func4" (reportArgumentType)
 qualifiers_annotated.py:85:7 - error: Argument of type "SmallInt" cannot be assigned to parameter "x" of type "type[T@func4]" in function "func4" (reportArgumentType)
 qualifiers_annotated.py:91:1 - error: "Annotated" cannot be instantiated (reportCallIssue)
 qualifiers_annotated.py:92:1 - error: Object of type "type[Annotated]" is not callable (reportCallIssue)

--- a/conformance/results/pyright/qualifiers_final_annotation.toml
+++ b/conformance/results/pyright/qualifiers_final_annotation.toml
@@ -25,8 +25,6 @@ qualifiers_final_annotation.py:81:8 - error: Cannot assign to attribute "DEFAULT
     Attribute "__set__" is unknown (reportAttributeAccessIssue)
 qualifiers_final_annotation.py:94:5 - error: "BORDER_WIDTH" cannot be redeclared because parent class "ClassC" declares it as Final (reportGeneralTypeIssues)
 qualifiers_final_annotation.py:107:22 - error: "Final" is not allowed in this context
-qualifiers_final_annotation.py:107:31 - error: Expression of type "Literal[1]" is incompatible with declared type "Final"
-  "Literal[1]" is incompatible with "Final" (reportAssignmentType)
 qualifiers_final_annotation.py:108:19 - error: "ClassVar" is not allowed in this context
 qualifiers_final_annotation.py:118:9 - error: "Final" is not allowed in this context
 qualifiers_final_annotation.py:121:14 - error: "Final" is not allowed in this context

--- a/conformance/results/pyright/version.toml
+++ b/conformance/results/pyright/version.toml
@@ -1,2 +1,2 @@
-version = "pyright 1.1.363"
+version = "pyright 1.1.364"
 test_duration = 1.4

--- a/conformance/results/pytype/dataclasses_final.toml
+++ b/conformance/results/pytype/dataclasses_final.toml
@@ -5,15 +5,13 @@ Doesn't handle Final nested inside ClassVar.
 errors_diff = """
 Line 27: Expected 1 errors
 Line 35: Expected 1 errors
-Line 38: Expected 1 errors
-Line 41: Expected 1 errors
+Line 37: Expected 1 errors
 Line 18: Unexpected errors ['File "dataclasses_final.py", line 18, in D: Invalid use of typing.Final [final-error]', 'File "dataclasses_final.py", line 18, in D: Invalid type annotation \\'ClassVar[Final[int]]\\'  [invalid-annotation]']
-Line 40: Unexpected errors ['File "dataclasses_final.py", line 40, in <module>: Assigning to attribute final_with_default, which was annotated with Final [final-error]']
 """
 output = """
 File "dataclasses_final.py", line 18, in D: Invalid use of typing.Final [final-error]
 File "dataclasses_final.py", line 18, in D: Invalid type annotation 'ClassVar[Final[int]]'  [invalid-annotation]
 File "dataclasses_final.py", line 36, in <module>: Assigning to attribute final_with_default, which was annotated with Final [final-error]
-File "dataclasses_final.py", line 40, in <module>: Assigning to attribute final_with_default, which was annotated with Final [final-error]
+File "dataclasses_final.py", line 38, in <module>: Assigning to attribute final_with_default, which was annotated with Final [final-error]
 """
 conformance_automated = "Fail"

--- a/conformance/results/results.html
+++ b/conformance/results/results.html
@@ -161,7 +161,7 @@
 <th class='tc-header'><div class='tc-name'>mypy 1.10.0</div>
 <div class='tc-time'>1.4sec</div>
 </th>
-<th class='tc-header'><div class='tc-name'>pyright 1.1.363</div>
+<th class='tc-header'><div class='tc-name'>pyright 1.1.364</div>
 <div class='tc-time'>1.4sec</div>
 </th>
 <th class='tc-header'><div class='tc-name'>pyre 0.9.21</div>
@@ -692,7 +692,7 @@
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dataclasses_final</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Wrongly requires a Final dataclass field to be initialized at class level.</p><p>Doesn't support Final nested inside ClassVar.</p></span></div></th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Doesn't support Final nested inside ClassVar.</p></span></div></th>
+<th class="column col2 conformant">Pass</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Mis-handles Final nested inside ClassVar.</p></span></div></th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Doesn't handle Final nested inside ClassVar.</p></span></div></th>
 </tr>

--- a/conformance/tests/dataclasses_final.py
+++ b/conformance/tests/dataclasses_final.py
@@ -34,9 +34,5 @@ assert_type(d.final_with_default, str)
 # ... but can't be assigned to (on the class or on an instance):
 d.final_no_default = 10  # E: can't assign to final attribute
 d.final_with_default = "baz"  # E: can't assign to final attribute
-D.final_no_default = (
-    10  # E: can't assign to final attribute / can't assign instance attr on class
-)
-D.final_with_default = (
-    "baz"  # E: can't assign to final attribute / can't assign instance attr on class
-)
+D.final_no_default = 10  # E: can't assign to final attribute
+D.final_with_default = "baz"  # E: can't assign to final attribute


### PR DESCRIPTION
This version of pyright fixes one conformance issue detected by the "dataclasses_final" test. It also rewords some existing error messages, which accounts for the other changes. Fixed a recent regression in the "dataclasses_final" test due to auto-formatting.