### PR TITLE
Updated conformance test results for pyright 1.1.365.

### DIFF
--- a/conformance/results/mypy/version.toml
+++ b/conformance/results/mypy/version.toml
@@ -1,2 +1,2 @@
 version = "mypy 1.10.0"
-test_duration = 1.4
+test_duration = 1.5

--- a/conformance/results/pyre/version.toml
+++ b/conformance/results/pyre/version.toml
@@ -1,2 +1,2 @@
 version = "pyre 0.9.21"
-test_duration = 3.4
+test_duration = 4.1

--- a/conformance/results/pyright/aliases_explicit.toml
+++ b/conformance/results/pyright/aliases_explicit.toml
@@ -22,7 +22,8 @@ aliases_explicit.py:82:21 - error: Expected type expression but received "list[t
 aliases_explicit.py:83:21 - error: Invalid expression form for type alias definition (reportInvalidTypeForm)
 aliases_explicit.py:83:21 - error: Dictionary expression not allowed in type annotation
   Use Dict[T1, T2] to indicate a dictionary type (reportInvalidTypeForm)
-aliases_explicit.py:83:21 - error: Expected type expression but received "dict[str, str]" (reportGeneralTypeIssues)
+aliases_explicit.py:83:21 - error: Expected type expression but received "dict[str, Unknown]" (reportGeneralTypeIssues)
+aliases_explicit.py:83:28 - error: "b" is not defined (reportUndefinedVariable)
 aliases_explicit.py:84:21 - error: Invalid expression form for type alias definition (reportInvalidTypeForm)
 aliases_explicit.py:84:21 - error: Call expression not allowed in type expression (reportInvalidTypeForm)
 aliases_explicit.py:85:21 - error: Invalid expression form for type alias definition (reportInvalidTypeForm)

--- a/conformance/results/pyright/aliases_recursive.toml
+++ b/conformance/results/pyright/aliases_recursive.toml
@@ -18,11 +18,11 @@ aliases_recursive.py:20:16 - error: Expression of type "list[int | complex]" is 
     "complex" is incompatible with "float"
     "complex" is incompatible with "list[Json]"
     "complex" is incompatible with "dict[str, Json]" (reportAssignmentType)
-aliases_recursive.py:38:22 - error: Expression of type "tuple[Literal[1], tuple[Literal['1'], Literal[1]], tuple[Literal[1], tuple[Literal[1], list[int]]]]" is incompatible with declared type "RecursiveTuple"
-  Type "tuple[Literal[1], tuple[Literal['1'], Literal[1]], tuple[Literal[1], tuple[Literal[1], list[int]]]]" is incompatible with type "RecursiveTuple"
-    "tuple[Literal[1], tuple[Literal['1'], Literal[1]], tuple[Literal[1], tuple[Literal[1], list[int]]]]" is incompatible with "str"
-    "tuple[Literal[1], tuple[Literal['1'], Literal[1]], tuple[Literal[1], tuple[Literal[1], list[int]]]]" is incompatible with "int"
-    "tuple[Literal[1], tuple[Literal['1'], Literal[1]], tuple[Literal[1], tuple[Literal[1], list[int]]]]" is incompatible with "tuple[RecursiveTuple, ...]"
+aliases_recursive.py:38:22 - error: Expression of type "tuple[Literal[1], tuple[str, int], tuple[int, tuple[int, list[int]]]]" is incompatible with declared type "RecursiveTuple"
+  Type "tuple[Literal[1], tuple[str, int], tuple[int, tuple[int, list[int]]]]" is incompatible with type "RecursiveTuple"
+    "tuple[Literal[1], tuple[str, int], tuple[int, tuple[int, list[int]]]]" is incompatible with "str"
+    "tuple[Literal[1], tuple[str, int], tuple[int, tuple[int, list[int]]]]" is incompatible with "int"
+    "tuple[Literal[1], tuple[str, int], tuple[int, tuple[int, list[int]]]]" is incompatible with "tuple[RecursiveTuple, ...]"
       Tuple entry 1 is incorrect type (reportAssignmentType)
 aliases_recursive.py:39:22 - error: Expression of type "tuple[Literal[1], list[int]]" is incompatible with declared type "RecursiveTuple"
   Type "tuple[Literal[1], list[int]]" is incompatible with type "RecursiveTuple"

--- a/conformance/results/pyright/aliases_type_statement.toml
+++ b/conformance/results/pyright/aliases_type_statement.toml
@@ -24,7 +24,8 @@ aliases_type_statement.py:40:22 - error: List expression not allowed in type ann
 aliases_type_statement.py:40:22 - error: Expected type expression but received "list[type[int]]" (reportGeneralTypeIssues)
 aliases_type_statement.py:41:22 - error: Dictionary expression not allowed in type annotation
   Use Dict[T1, T2] to indicate a dictionary type (reportInvalidTypeForm)
-aliases_type_statement.py:41:22 - error: Expected type expression but received "dict[str, str]" (reportGeneralTypeIssues)
+aliases_type_statement.py:41:22 - error: Expected type expression but received "dict[str, Unknown]" (reportGeneralTypeIssues)
+aliases_type_statement.py:41:29 - error: "b" is not defined (reportUndefinedVariable)
 aliases_type_statement.py:42:22 - error: Call expression not allowed in type expression (reportInvalidTypeForm)
 aliases_type_statement.py:43:22 - error: List expression not allowed in type annotation
   Use List[T] to indicate a list type or Union[T1, T2] to indicate a union type (reportInvalidTypeForm)

--- a/conformance/results/pyright/aliases_typealiastype.toml
+++ b/conformance/results/pyright/aliases_typealiastype.toml
@@ -15,7 +15,8 @@ aliases_typealiastype.py:52:40 - error: Call expression not allowed in type expr
 aliases_typealiastype.py:53:40 - error: Expected type expression but received "list[Unknown]" (reportGeneralTypeIssues)
 aliases_typealiastype.py:54:42 - error: Expected type expression but received "tuple[tuple[type[int], type[str]]]" (reportGeneralTypeIssues)
 aliases_typealiastype.py:55:42 - error: Expected type expression but received "list[type[int]]" (reportGeneralTypeIssues)
-aliases_typealiastype.py:56:42 - error: Expected type expression but received "dict[str, str]" (reportGeneralTypeIssues)
+aliases_typealiastype.py:56:42 - error: Expected type expression but received "dict[str, Unknown]" (reportGeneralTypeIssues)
+aliases_typealiastype.py:56:49 - error: "b" is not defined (reportUndefinedVariable)
 aliases_typealiastype.py:57:42 - error: Call expression not allowed in type expression (reportInvalidTypeForm)
 aliases_typealiastype.py:58:42 - error: List expression not allowed in type annotation
   Use List[T] to indicate a list type or Union[T1, T2] to indicate a union type (reportInvalidTypeForm)

--- a/conformance/results/pyright/callables_kwargs.toml
+++ b/conformance/results/pyright/callables_kwargs.toml
@@ -19,12 +19,12 @@ callables_kwargs.py:101:19 - error: Expression of type "(**kwargs: **TD2) -> Non
       "int" is incompatible with "str" (reportAssignmentType)
 callables_kwargs.py:102:19 - error: Expression of type "(**kwargs: **TD2) -> None" is incompatible with declared type "TDProtocol4"
   Type "(**kwargs: **TD2) -> None" is incompatible with type "(*, v1: int) -> None"
-    Keyword parameter "v3" is missing in destination (reportAssignmentType)
+    Extra parameter "v3" (reportAssignmentType)
 callables_kwargs.py:103:19 - error: Expression of type "(**kwargs: **TD2) -> None" is incompatible with declared type "TDProtocol5"
   Type "(**kwargs: **TD2) -> None" is incompatible with type "(v1: int, v3: str) -> None"
     Function accepts too many positional parameters; expected 0 but received 2
-      Keyword parameter "v1" is missing in destination
-      Keyword parameter "v3" is missing in destination (reportAssignmentType)
+      Extra parameter "v1"
+      Extra parameter "v3" (reportAssignmentType)
 callables_kwargs.py:111:30 - error: Typed dictionary overlaps with keyword parameter: v1 (reportGeneralTypeIssues)
 callables_kwargs.py:122:21 - error: Expected TypedDict type argument for Unpack (reportGeneralTypeIssues)
 """

--- a/conformance/results/pyright/callables_protocol.toml
+++ b/conformance/results/pyright/callables_protocol.toml
@@ -2,11 +2,11 @@ conformant = "Pass"
 output = """
 callables_protocol.py:35:7 - error: Expression of type "(*vals: bytes, max_items: int | None) -> list[bytes]" is incompatible with declared type "Proto1"
   Type "(*vals: bytes, max_items: int | None) -> list[bytes]" is incompatible with type "(*vals: bytes, max_len: int | None = None) -> list[bytes]"
-    Keyword parameter "max_items" is missing in destination
-    Keyword parameter "max_len" is missing in source (reportAssignmentType)
+    Extra parameter "max_items"
+    Missing keyword parameter "max_len" (reportAssignmentType)
 callables_protocol.py:36:7 - error: Expression of type "(*vals: bytes) -> list[bytes]" is incompatible with declared type "Proto1"
   Type "(*vals: bytes) -> list[bytes]" is incompatible with type "(*vals: bytes, max_len: int | None = None) -> list[bytes]"
-    Keyword parameter "max_len" is missing in source (reportAssignmentType)
+    Missing keyword parameter "max_len" (reportAssignmentType)
 callables_protocol.py:37:7 - error: Expression of type "(*vals: bytes, max_len: str | None) -> list[bytes]" is incompatible with declared type "Proto1"
   Type "(*vals: bytes, max_len: str | None) -> list[bytes]" is incompatible with type "(*vals: bytes, max_len: int | None = None) -> list[bytes]"
     Keyword parameter "max_len" of type "int | None" is incompatible with type "str | None"
@@ -46,12 +46,12 @@ callables_protocol.py:197:16 - error: Cannot access attribute "other_attribute2"
   Attribute "other_attribute2" is unknown (reportAttributeAccessIssue)
 callables_protocol.py:238:8 - error: Expression of type "(x: int, y: str, /) -> Any" is incompatible with declared type "Proto11"
   Type "(x: int, y: str, /) -> Any" is incompatible with type "(x: int, /, y: str) -> Any"
-    Keyword parameter "y" is missing in source
+    Missing keyword parameter "y"
       Position-only parameter mismatch; parameter "y" is not position-only
       Position-only parameter mismatch; expected 2 but received 1 (reportAssignmentType)
 callables_protocol.py:260:8 - error: Expression of type "(*args: Any, kwarg0: Any) -> None" is incompatible with declared type "Proto12"
   Type "(*args: Any, kwarg0: Any) -> None" is incompatible with type "(*args: Any, kwarg0: Any, kwarg1: Any) -> None"
-    Keyword parameter "kwarg1" is missing in source (reportAssignmentType)
+    Missing keyword parameter "kwarg1" (reportAssignmentType)
 callables_protocol.py:284:27 - error: Expression of type "(path: str) -> str" is incompatible with declared type "Proto13_Default"
   Type "(path: str) -> str" is incompatible with type "(path: str = ...) -> str"
     Parameter "path" is missing default argument (reportAssignmentType)

--- a/conformance/results/pyright/callables_subtyping.toml
+++ b/conformance/results/pyright/callables_subtyping.toml
@@ -14,8 +14,8 @@ callables_subtyping.py:51:21 - error: Expression of type "PosOnly2" is incompati
   "PosOnly2" is incompatible with protocol "Standard2"
     "__call__" is an incompatible type
       Type "(b: int, a: int, /) -> None" is incompatible with type "(a: int, b: int) -> None"
-        Keyword parameter "a" is missing in source
-        Keyword parameter "b" is missing in source
+        Missing keyword parameter "a"
+        Missing keyword parameter "b"
           Position-only parameter mismatch; parameter "a" is not position-only
           Position-only parameter mismatch; parameter "b" is not position-only
           Position-only parameter mismatch; expected 2 but received 0 (reportAssignmentType)
@@ -24,22 +24,23 @@ callables_subtyping.py:52:21 - error: Expression of type "KwOnly2" is incompatib
     "__call__" is an incompatible type
       Type "(*, b: int, a: int) -> None" is incompatible with type "(a: int, b: int) -> None"
         Function accepts too many positional parameters; expected 0 but received 2
-          Keyword parameter "b" is missing in destination
-          Keyword parameter "a" is missing in destination (reportAssignmentType)
+          Extra parameter "b"
+          Extra parameter "a" (reportAssignmentType)
 callables_subtyping.py:55:20 - error: Expression of type "KwOnly2" is incompatible with declared type "PosOnly2"
   "KwOnly2" is incompatible with protocol "PosOnly2"
     "__call__" is an incompatible type
       Type "(*, b: int, a: int) -> None" is incompatible with type "(b: int, a: int, /) -> None"
         Function accepts too many positional parameters; expected 0 but received 2
-          Keyword parameter "b" is missing in destination
-          Keyword parameter "a" is missing in destination (reportAssignmentType)
+          Extra parameter "b"
+          Extra parameter "a" (reportAssignmentType)
 callables_subtyping.py:58:19 - error: Expression of type "PosOnly2" is incompatible with declared type "KwOnly2"
   "PosOnly2" is incompatible with protocol "KwOnly2"
     "__call__" is an incompatible type
       Type "(b: int, a: int, /) -> None" is incompatible with type "(*, b: int, a: int) -> None"
         Position-only parameter mismatch; expected 2 but received 0
-        Keyword parameter "b" is missing in source
-        Keyword parameter "a" is missing in source (reportAssignmentType)
+        Function accepts too few positional parameters; expected 2 but received 0
+        Missing keyword parameter "b"
+        Missing keyword parameter "a" (reportAssignmentType)
 callables_subtyping.py:82:20 - error: Expression of type "NoArgs3" is incompatible with declared type "IntArgs3"
   "NoArgs3" is incompatible with protocol "IntArgs3"
     "__call__" is an incompatible type
@@ -96,14 +97,14 @@ callables_subtyping.py:125:22 - error: Expression of type "IntStrArgs4" is incom
   "IntStrArgs4" is incompatible with protocol "Standard4"
     "__call__" is an incompatible type
       Type "(*args: int | str) -> None" is incompatible with type "(a: int, b: str) -> None"
-        Keyword parameter "a" is missing in source
-        Keyword parameter "b" is missing in source (reportAssignmentType)
+        Missing keyword parameter "a"
+        Missing keyword parameter "b" (reportAssignmentType)
 callables_subtyping.py:126:22 - error: Expression of type "StrArgs4" is incompatible with declared type "Standard4"
   "StrArgs4" is incompatible with protocol "Standard4"
     "__call__" is an incompatible type
       Type "(a: int, /, *args: str) -> None" is incompatible with type "(a: int, b: str) -> None"
-        Keyword parameter "a" is missing in source
-        Keyword parameter "b" is missing in source
+        Missing keyword parameter "a"
+        Missing keyword parameter "b"
           Position-only parameter mismatch; parameter "a" is not position-only
           Position-only parameter mismatch; expected 1 but received 0 (reportAssignmentType)
 callables_subtyping.py:151:22 - error: Expression of type "NoKwargs5" is incompatible with declared type "IntKwargs5"
@@ -164,7 +165,7 @@ callables_subtyping.py:197:22 - error: Expression of type "StrKwargs6" is incomp
     "__call__" is an incompatible type
       Type "(*, a: int, **kwargs: str) -> None" is incompatible with type "(a: int, b: str) -> None"
         Function accepts too many positional parameters; expected 0 but received 2
-          Keyword parameter "a" is missing in destination (reportAssignmentType)
+          Extra parameter "a" (reportAssignmentType)
 callables_subtyping.py:236:23 - error: Expression of type "NoDefaultArg8" is incompatible with declared type "DefaultArg8"
   "NoDefaultArg8" is incompatible with protocol "DefaultArg8"
     "__call__" is an incompatible type
@@ -183,7 +184,8 @@ callables_subtyping.py:240:25 - error: Expression of type "NoX8" is incompatible
 callables_subtyping.py:243:16 - error: Expression of type "NoDefaultArg8" is incompatible with declared type "NoX8"
   "NoDefaultArg8" is incompatible with protocol "NoX8"
     "__call__" is an incompatible type
-      Type "(x: int) -> None" is incompatible with type "() -> None" (reportAssignmentType)
+      Type "(x: int) -> None" is incompatible with type "() -> None"
+        Extra parameter "x" (reportAssignmentType)
 callables_subtyping.py:273:21 - error: Expression of type "Overloaded9" is incompatible with declared type "FloatArg9"
   "Overloaded9" is incompatible with protocol "FloatArg9"
     "__call__" is an incompatible type

--- a/conformance/results/pyright/generics_paramspec_semantics.toml
+++ b/conformance/results/pyright/generics_paramspec_semantics.toml
@@ -12,8 +12,8 @@ generics_paramspec_semantics.py:46:17 - error: Argument of type "(y: int, x: str
     Parameter name mismatch: "y" versus "x" (reportArgumentType)
 generics_paramspec_semantics.py:61:23 - error: Argument of type "(*, y: int) -> int" cannot be assigned to parameter "y" of type "(**P@func1) -> int" in function "func1"
   Type "(*, y: int) -> int" is incompatible with type "(*, x: int) -> int"
-    Keyword parameter "y" is missing in destination
-    Keyword parameter "x" is missing in source (reportArgumentType)
+    Extra parameter "y"
+    Missing keyword parameter "x" (reportArgumentType)
 generics_paramspec_semantics.py:97:4 - error: Argument of type "Literal[1]" cannot be assigned to parameter of type "str"
   "Literal[1]" is incompatible with "str" (reportArgumentType)
 generics_paramspec_semantics.py:107:4 - error: Argument of type "Literal[1]" cannot be assigned to parameter "args" of type "bool"

--- a/conformance/results/pyright/protocols_class_objects.toml
+++ b/conformance/results/pyright/protocols_class_objects.toml
@@ -11,7 +11,8 @@ protocols_class_objects.py:58:16 - error: Expression of type "type[ConcreteA]" i
     Type "(self: ConcreteA, x: int) -> int" is incompatible with type "(x: int) -> int"
       Parameter name mismatch: "x" versus "self"
       Parameter 1: type "int" is incompatible with type "ConcreteA"
-        "int" is incompatible with "ConcreteA" (reportAssignmentType)
+        "int" is incompatible with "ConcreteA"
+      Extra parameter "x" (reportAssignmentType)
 protocols_class_objects.py:74:16 - error: Expression of type "type[ConcreteB]" is incompatible with declared type "ProtoB1"
   "prop1" is an incompatible type
     "property" is incompatible with "int" (reportAssignmentType)

--- a/conformance/results/pyright/protocols_definition.toml
+++ b/conformance/results/pyright/protocols_definition.toml
@@ -66,14 +66,14 @@ protocols_definition.py:287:22 - error: Expression of type "Concrete5_Bad3" is i
     "method1" is an incompatible type
       Type "(*, a: int, b: int) -> float" is incompatible with type "(a: int, b: int) -> float"
         Function accepts too many positional parameters; expected 0 but received 2
-          Keyword parameter "a" is missing in destination
-          Keyword parameter "b" is missing in destination (reportAssignmentType)
+          Extra parameter "a"
+          Extra parameter "b" (reportAssignmentType)
 protocols_definition.py:288:22 - error: Expression of type "Concrete5_Bad4" is incompatible with declared type "Template5"
   "Concrete5_Bad4" is incompatible with protocol "Template5"
     "method1" is an incompatible type
       Type "(a: int, b: int, /) -> float" is incompatible with type "(a: int, b: int) -> float"
-        Keyword parameter "a" is missing in source
-        Keyword parameter "b" is missing in source
+        Missing keyword parameter "a"
+        Missing keyword parameter "b"
           Position-only parameter mismatch; parameter "a" is not position-only
           Position-only parameter mismatch; parameter "b" is not position-only
           Position-only parameter mismatch; expected 2 but received 0 (reportAssignmentType)
@@ -82,7 +82,8 @@ protocols_definition.py:289:22 - error: Expression of type "Concrete5_Bad5" is i
     "method1" is an incompatible type
       Type "(self: Unknown, a: int, b: int) -> float" is incompatible with type "(a: int, b: int) -> float"
         Parameter name mismatch: "a" versus "self"
-        Parameter name mismatch: "b" versus "a" (reportAssignmentType)
+        Parameter name mismatch: "b" versus "a"
+        Extra parameter "b" (reportAssignmentType)
 protocols_definition.py:339:22 - error: Expression of type "Concrete6_Bad1" is incompatible with declared type "Template6"
   "Concrete6_Bad1" is incompatible with protocol "Template6"
     "val1" is an incompatible type

--- a/conformance/results/pyright/qualifiers_annotated.toml
+++ b/conformance/results/pyright/qualifiers_annotated.toml
@@ -4,8 +4,9 @@ qualifiers_annotated.py:43:17 - error: List expression not allowed for this type
 qualifiers_annotated.py:44:17 - error: Expected type expression but received "tuple[tuple[type[int], type[str]]]" (reportGeneralTypeIssues)
 qualifiers_annotated.py:45:17 - error: List expression not allowed for this type argument
 qualifiers_annotated.py:45:18 - error: Expected type expression but received "Generator[type[int], None, None]" (reportGeneralTypeIssues)
-qualifiers_annotated.py:46:17 - error: Expected type expression but received "dict[str, str]" (reportGeneralTypeIssues)
+qualifiers_annotated.py:46:17 - error: Expected type expression but received "dict[str, Unknown]" (reportGeneralTypeIssues)
 qualifiers_annotated.py:46:17 - error: Dictionary expression not allowed in type annotation
+qualifiers_annotated.py:46:24 - error: "b" is not defined (reportUndefinedVariable)
 qualifiers_annotated.py:47:17 - error: Call expression not allowed in type expression (reportInvalidTypeForm)
 qualifiers_annotated.py:48:17 - error: List expression not allowed in type annotation
   Use List[T] to indicate a list type or Union[T1, T2] to indicate a union type (reportInvalidTypeForm)

--- a/conformance/results/pyright/qualifiers_final_annotation.toml
+++ b/conformance/results/pyright/qualifiers_final_annotation.toml
@@ -6,6 +6,7 @@ qualifiers_final_annotation.py:34:5 - error: "ID2" is declared Final, but value 
 qualifiers_final_annotation.py:38:5 - error: "ID3" is declared Final, but value is not assigned (reportGeneralTypeIssues)
 qualifiers_final_annotation.py:54:14 - error: Cannot assign to attribute "ID5" for class "ClassA*"
   Attribute "ID5" cannot be assigned through a class instance because it is a ClassVar
+  "ID5" is declared as Final and cannot be reassigned
     Attribute "__set__" is unknown (reportAttributeAccessIssue)
 qualifiers_final_annotation.py:62:19 - error: "Final" is not allowed in this context
 qualifiers_final_annotation.py:63:19 - error: "Final" is not allowed in this context

--- a/conformance/results/pyright/version.toml
+++ b/conformance/results/pyright/version.toml
@@ -1,2 +1,2 @@
-version = "pyright 1.1.364"
+version = "pyright 1.1.365"
 test_duration = 1.4

--- a/conformance/results/pytype/version.toml
+++ b/conformance/results/pytype/version.toml
@@ -1,2 +1,2 @@
 version = "pytype 2024.04.11"
-test_duration = 30.1
+test_duration = 29.7

--- a/conformance/results/results.html
+++ b/conformance/results/results.html
@@ -159,16 +159,16 @@
         <div class="table_container"><table><tbody>
 <tr><th class="col1">&nbsp;</th>
 <th class='tc-header'><div class='tc-name'>mypy 1.10.0</div>
-<div class='tc-time'>1.4sec</div>
+<div class='tc-time'>1.5sec</div>
 </th>
-<th class='tc-header'><div class='tc-name'>pyright 1.1.364</div>
+<th class='tc-header'><div class='tc-name'>pyright 1.1.365</div>
 <div class='tc-time'>1.4sec</div>
 </th>
 <th class='tc-header'><div class='tc-name'>pyre 0.9.21</div>
-<div class='tc-time'>3.4sec</div>
+<div class='tc-time'>4.1sec</div>
 </th>
 <th class='tc-header'><div class='tc-name'>pytype 2024.04.11</div>
-<div class='tc-time'>30.1sec</div>
+<div class='tc-time'>29.7sec</div>
 </th>
 </tr>
 <tr><th class="column" colspan="5">


### PR DESCRIPTION
There are no changes to the top-level conformance results, but some of pyright's error messages changed (for improved clarity), and this results in changes to the diffs from previous versions.