### PR TITLE
List pip as an explicit dependency for the conformance tests

### DIFF
--- a/conformance/requirements.txt
+++ b/conformance/requirements.txt
@@ -3,5 +3,6 @@ tomlkit
 tqdm
 pyright
 mypy
+pip
 pyre-check
 pytype; platform_system != "Windows"


### PR DESCRIPTION
I created a virtual environment using `uv`, which meant that `pip` wasn't automatically installed into my environment, causing all tests to be skipped due to things like this:

https://github.com/python/typing/blob/a79b87fadb0185d8032211dc81638f4acb5bc122/conformance/src/type_checker.py#L76-L84