### PR TITLE
Typo fix: Replace `TypeVar` with `TypeVarTuple` in a docs example

### DIFF
--- a/docs/spec/generics.rst
+++ b/docs/spec/generics.rst
@@ -1574,8 +1574,8 @@ First, type arguments to generic aliases can be variadic. For example, a
 
 ::
 
-    Ts1 = TypeVar('Ts1')
-    Ts2 = TypeVar('Ts2')
+    Ts1 = TypeVarTuple('Ts1')
+    Ts2 = TypeVarTuple('Ts2')
 
     IntTuple = tuple[int, *Ts1]
     IntFloatTuple = IntTuple[float, *Ts2]  # Valid


### PR DESCRIPTION
Current text from a subsection within 'TypeVarTuple':
```py
Ts1 = TypeVar('Ts1')
Ts2 = TypeVar('Ts2')

IntTuple = Tuple[int, *Ts1]
IntFloatTuple = IntTuple[float, *Ts2]  # Valid
```

It's a small thing, but those first two variables should `TypeVarTuple` instances, I think; the example doesn't really make sense otherwise. Seems to be a typo from the original PEP.

