### PR TITLE
Tweak the typing spec's module resolution to more closely emulate Python's runtime semantics

### DIFF
--- a/docs/spec/distributing.rst
+++ b/docs/spec/distributing.rst
@@ -252,7 +252,8 @@ resolve modules containing type information:
    stub files or inline in ``.py`` files).
 
 6. If the type checker chooses to additionally vendor any third-party stubs
-   from typeshed, these SHOULD come last in the module resolution order.
+   (from typeshed or elsewhere), these SHOULD come last in the module
+   resolution order.
 
 If typecheckers identify a stub-only namespace package without the desired module
 in step 4, they should continue to step 5/6. Typecheckers should identify namespace packages

--- a/docs/spec/distributing.rst
+++ b/docs/spec/distributing.rst
@@ -199,8 +199,9 @@ Partial Stub Packages
 Many stub packages will only have part of the type interface for libraries
 completed, especially initially. For the benefit of type checking and code
 editors, packages can be "partial". This means modules not found in the stub
-package SHOULD be searched for in part four of the module resolution
-order below, namely :term:`inline` packages.
+package SHOULD be searched for in parts five and six of the module resolution
+order below, namely :term:`inline` packages and any third-party stubs the type
+checker chooses to vendor.
 
 Type checkers should merge the stub package and runtime package
 directories. This can be thought of as the functional equivalent of copying the
@@ -235,19 +236,26 @@ resolve modules containing type information:
 
 2. User code - the files the type checker is running on.
 
-3. :term:`Stub <stub>` packages - these packages SHOULD supersede any installed inline
+3. Typeshed stubs for the standard library. These will usually be vendored by
+   type checkers, but type checkers SHOULD provide an option for users to
+   provide a path to a directory containing a custom or modified version of
+   typeshed; if this option is provided, type checkers SHOULD use this as the
+   canonical source for standard-library types in this step.
+
+4. :term:`Stub <stub>` packages - these packages SHOULD supersede any installed inline
    package. They can be found in directories named ``foopkg-stubs`` for
    package ``foopkg``.
 
-4. Packages with a ``py.typed`` marker file - if there is nothing overriding
+5. Packages with a ``py.typed`` marker file - if there is nothing overriding
    the installed package, *and* it opts into type checking, the types
    bundled with the package SHOULD be used (be they in ``.pyi`` type
    stub files or inline in ``.py`` files).
 
-5. Typeshed - only for modules in the standard library.
+6. If the type checker chooses to additionally vendor any third-party stubs
+   from typeshed, these SHOULD come last in the module resolution order.
 
 If typecheckers identify a stub-only namespace package without the desired module
-in step 3, they should continue to step 4/5. Typecheckers should identify namespace packages
+in step 4, they should continue to step 5/6. Typecheckers should identify namespace packages
 by the absence of ``__init__.pyi``.  This allows different subpackages to
 independently opt for inline vs stub-only.
 


### PR DESCRIPTION
This PR implements the changes to the typing spec's module resolution order that have been [proposed on Discourse](https://discuss.python.org/t/pep-561-s-module-resolution-order-seems-incorrect/55048/1). Three changes have been made:

1. Typeshed’s standard-library stubs have been moved higher in the resolution order, above any items that originate from site-packages.
2. With the change from point (1), it becomes more important that type checkers provide a clear and easy way for users to override the vendored copy of typeshed’s standard-library stubs with a custom directory of standard-library stubs if they want to. Most major type checkers already implement this (mypy provides the `--custom-typeshed-dir` option; pyright provides the `typeshedPath` configuration-file option; pyre provides the `--typeshed` option). This update to the spec formally specifies that doing so is highly encouraged.
3. The PR brings back an explicit mention in the typing spec of where vendored typeshed stubs for third-party packages (if there are any that the type checker has chosen to vendor) should come in the module resolution order (last!). This was specified in PEP 561, but the relevant language was removed from the typing spec in https://github.com/python/typing/pull/1571.

Please see [the Discourse topic](https://discuss.python.org/t/pep-561-s-module-resolution-order-seems-incorrect/55048/1) for a detailed rationale for these changes, and please post any substantive feedback on the proposed changes there rather than on this PR. (Suggestions for minor wording improvements are welcome here.)

As discussed on Discourse, the proposed new specification appears to already be implemented by mypy, but pyright's behaviour would have to change to become conformant with the new spec. (I have not surveyed pyre's and pytype's module resolution behaviour.)