### PR TITLE
Adds links to Python Discourse and ruff to typing.readthedocs.io.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,7 +54,8 @@ Discussions and Support
 
 * `User help forum <https://github.com/python/typing/discussions>`_
 * `User chat on Gitter <http://gitter.im/python/typing>`_
-* `Developer mailing list <https://mail.python.org/archives/list/typing-sig@python.org/>`_
+* `Developer forum <https://discuss.python.org/c/typing/32>`_
+* `Developer mailing list (archived) <https://mail.python.org/archives/list/typing-sig@python.org/>`_
 
 Typing-related Tools
 ====================
@@ -64,12 +65,12 @@ Type Checkers
 
 * `mypy <http://mypy-lang.org/>`_, the reference implementation for type
   checkers.
-* `pyre <https://pyre-check.org/>`_, written in OCaml and optimized for
-  performance.
+* `pyre <https://pyre-check.org/>`_, a type checker written in OCaml and
+  optimized for performance.
 * `pyright <https://github.com/microsoft/pyright>`_, a type checker that
   emphasizes speed.
-* `pytype <https://google.github.io/pytype/>`_, checks and infers types for
-  unannotated code.
+* `pytype <https://google.github.io/pytype/>`_, a type checker that
+  checks and infers types for unannotated code.
 
 Development Environments
 ------------------------
@@ -89,13 +90,19 @@ Linters and Formatters
 * `flake8-pyi <https://github.com/ambv/flake8-pyi>`_, a plugin for the
   `flake8 <https://flake8.pycqa.org/>`_ linter that adds support for type
   stubs.
+* `ruff <https://astral.sh/ruff>`_, a linter built for speed, with support for
+  most of the ``flake8-pyi`` rules.
 
 Type-Hint and Stub Integration
 ------------------------------
 
-* `autotyping <https://github.com/JelleZijlstra/autotyping>`_, a tool which infers simple types from their context and inserts them as inline type-hints.
-* `merge_pyi <https://google.github.io/pytype/developers/tools.html#merge_pyi>`_, integrates .pyi signatures as inline type-hints in Python source code.
-  This is a thin wrapper around ``ApplyTypeAnnotationsVisitor`` from `libCST <https://libcst.readthedocs.io/en/latest/>`_.
+* `autotyping <https://github.com/JelleZijlstra/autotyping>`_, a tool which
+  infers simple types from their context and inserts them as inline type-hints.
+* `merge-pyi
+  <https://google.github.io/pytype/developers/tools.html#merge_pyi>`_,
+  a thin wrapper around ``ApplyTypeAnnotationsVisitor`` from
+  `libCST <https://libcst.readthedocs.io/en/latest/>`_ that integrates .pyi
+  signatures as inline type-hints in Python source code.
 
 Typing PEPs
 ===========


### PR DESCRIPTION
I noticed that the "Discussions and Support" section still linked to the typing-sig mailing list. While touching this page, I figured I might as well add ruff, which is used by typeshed, to the list of linters, and make the items in each list grammatically consistent.