### PR TITLE
Add PEP 712 converters to the `dataclasses` spec

### DIFF
--- a/docs/spec/dataclasses.rst
+++ b/docs/spec/dataclasses.rst
@@ -541,10 +541,8 @@ conversion and validation during object initialization and attribute assignment.
 
 Converter behavior:
 
-* For non-frozen dataclasses, the converter is used for all attribute assignment, including assignment
+* The converter is used for all attribute assignment, including: assignment
   of default values and direct attribute setting (e.g., ``obj.attr = value``).
-* For frozen dataclasses, the converter is only used inside a ``dataclass``-synthesized ``__init__``
-  when setting the attribute.
 * The converter is not used when reading attributes, as the attributes should already have been converted.
 
 Typing rules for converters:
@@ -556,9 +554,9 @@ Typing rules for converters:
 
 When used with ``default`` or ``default_factory``:
 
-* If a ``converter`` is provided alongside ``default`` or ``default_factory``, the type of the default
-  value should be assignable to the the ``converter`` parameter.
-* Default values are unconditionally converted using the ``converter`` if provided.
+* If a ``converter`` is provided alongside ``default`` or ``default_factory``, 
+  default values are converted using the ``converter``.
+* The type of the default value should be assignable to the single-parameter of the ``converter``
 
 Example usage:
 
@@ -567,11 +565,11 @@ Example usage:
     def str_or_none(x: Any) -> str | None:
         return str(x) if x is not None else None
 
-    @dataclasses.dataclass
+    @custom_dataclass
     class Example:
-        int_field: int = dataclasses.field(converter=int)
-        str_field: str | None = dataclasses.field(converter=str_or_none)
-        path_field: pathlib.Path = dataclasses.field(
+        int_field: int = field(converter=int)
+        str_field: str | None = field(converter=str_or_none)
+        path_field: pathlib.Path = field(
             converter=pathlib.Path,
             default="default/path.txt"
         )

--- a/docs/spec/dataclasses.rst
+++ b/docs/spec/dataclasses.rst
@@ -534,7 +534,7 @@ Converters
 
 The ``converter`` parameter can be specified in a field definition to provide a callable
 used to convert values when assigning to the associated attribute. This feature allows for automatic type
-conversion and validation attribute assignment.
+conversion and validation during attribute assignment.
 
 Converter behavior:
 

--- a/docs/spec/dataclasses.rst
+++ b/docs/spec/dataclasses.rst
@@ -365,12 +365,9 @@ positional and may use other names.
 * ``alias`` is an optional str parameter that provides an alternative
   name for the field. This alternative name is used in the synthesized
   ``__init__`` method.
-* ``converter`` is an optional parameter that specifies a single-parameter
-* ``converter`` is an optional parameter that specifies a single-parameter
-  attribute (including the assignment in ``__init__``). The type
-  of this argument provides the type of the synthesized
-  ``__init__`` parameter associated with the field. The return type of
-  the callable must be assignable to the field's declared type.
+* ``converter`` is an optional parameter that specifies a
+  callable used to convert values when assigning to the associated
+  attribute.
 
 It is an error to specify more than one of ``default``,
 ``default_factory`` and ``factory``.
@@ -535,26 +532,26 @@ This includes, but is not limited to, the following semantics:
 Converters
 ^^^^^^^^^^
 
-The ``converter`` parameter can be specified in a field definition to provide a single-parameter callable
+The ``converter`` parameter can be specified in a field definition to provide a callable
 used to convert values when assigning to the associated attribute. This feature allows for automatic type
-conversion and validation during object initialization and attribute assignment.
+conversion and validation attribute assignment.
 
 Converter behavior:
 
-* The converter is used for all attribute assignment, including: assignment
-  of default values and direct attribute setting (e.g., ``obj.attr = value``).
+* The converter is used for all attribute assignment, including assignment
+  of default values, assignment in synthesized ``__init__`` methods
+  and direct attribute setting (e.g., ``obj.attr = value``).
 * The converter is not used when reading attributes, as the attributes should already have been converted.
-* If a ``converter`` is provided alongside ``default`` or ``default_factory``,
-  default values are converted using the ``converter``.
 
 Typing rules for converters:
 
-* The ``converter`` must be a callable that accepts a single positional argument.
-* The parameter type of the parameter provides the type of the synthesized ``__init__`` parameter
+* The ``converter`` must be a callable that must accept a single positional argument 
+  (but may optionally accept other arguments, which are ignored for typing purposes).
+* The type of the first positional parameter provides the type of the synthesized ``__init__`` parameter
   associated with the field.
 * The return type of the callable must be assignable to the field's declared type.
 * If ``default`` or ``default_factory`` are provided, the type of the default value should be
-  assignable to the single-parameter of the ``converter``
+  assignable to the first positional parameter of the ``converter``
 
 Example usage:
 

--- a/docs/spec/dataclasses.rst
+++ b/docs/spec/dataclasses.rst
@@ -367,10 +367,10 @@ positional and may use other names.
   ``__init__`` method.
 * ``converter`` is an optional parameter that specifies a single-argument
   callable used to convert values when assigning to the associated
-  attribute (Including the assignment in in ``__init__``). The parameter
+  attribute (Including the assignment in ``__init__``). The parameter
   type of this single argument provides the type of the synthesized
   ``__init__`` parameter associated with the field. The return type of
-  the callable must be compatible with the field's declared type.
+  the callable must be assignable to the field's declared type.
 
 It is an error to specify more than one of ``default``,
 ``default_factory`` and ``factory``.
@@ -552,12 +552,12 @@ Typing rules for converters:
 * The ``converter`` must be a callable that accepts a single positional argument.
 * The parameter type of this single argument provides the type of the synthesized ``__init__`` parameter
   associated with the field.
-* The return type of the callable must be compatible with the field's declared type.
+* The return type of the callable must be assignable to the field's declared type.
 
 When used with ``default`` or ``default_factory``:
 
 * If a ``converter`` is provided alongside ``default`` or ``default_factory``, the type of the default
-  value should be compatible with the type of the single argument to the ``converter`` callable.
+  value should be assignable to the type of the single argument to the ``converter`` callable.
 * Default values are unconditionally converted using the ``converter`` if provided.
 
 Example usage:

--- a/docs/spec/dataclasses.rst
+++ b/docs/spec/dataclasses.rst
@@ -551,7 +551,7 @@ Typing rules for converters:
   associated with the field.
 * The return type of the callable must be assignable to the field's declared type.
 * If ``default`` or ``default_factory`` are provided, the type of the default value should be
-  assignable to the first positional parameter of the ``converter``
+  assignable to the first positional parameter of the ``converter``.
 
 Example usage:
 

--- a/docs/spec/dataclasses.rst
+++ b/docs/spec/dataclasses.rst
@@ -366,8 +366,7 @@ positional and may use other names.
   name for the field. This alternative name is used in the synthesized
   ``__init__`` method.
 * ``converter`` is an optional parameter that specifies a
-  callable used to convert values when assigning to the associated
-  attribute.
+  callable used to convert values when assigning to the field.
 
 It is an error to specify more than one of ``default``,
 ``default_factory`` and ``factory``.
@@ -546,9 +545,9 @@ Converter behavior:
 Typing rules for converters:
 
 * The ``converter`` must be a callable that must accept a single positional argument
-  (but may optionally accept other arguments, which are ignored for typing purposes).
+  (but may accept other optional arguments, which are ignored for typing purposes).
 * The type of the first positional parameter provides the type of the synthesized ``__init__`` parameter
-  associated with the field.
+  for the field.
 * The return type of the callable must be assignable to the field's declared type.
 * If ``default`` or ``default_factory`` are provided, the type of the default value should be
   assignable to the first positional parameter of the ``converter``.

--- a/docs/spec/dataclasses.rst
+++ b/docs/spec/dataclasses.rst
@@ -553,7 +553,7 @@ Typing rules for converters:
 * The parameter type of the parameter provides the type of the synthesized ``__init__`` parameter
   associated with the field.
 * The return type of the callable must be assignable to the field's declared type.
-* If ``default`` or ``default_factory`` are provided, the type of the default value should be 
+* If ``default`` or ``default_factory`` are provided, the type of the default value should be
   assignable to the single-parameter of the ``converter``
 
 Example usage:

--- a/docs/spec/dataclasses.rst
+++ b/docs/spec/dataclasses.rst
@@ -554,7 +554,7 @@ Typing rules for converters:
 
 When used with ``default`` or ``default_factory``:
 
-* If a ``converter`` is provided alongside ``default`` or ``default_factory``, 
+* If a ``converter`` is provided alongside ``default`` or ``default_factory``,
   default values are converted using the ``converter``.
 * The type of the default value should be assignable to the single-parameter of the ``converter``
 

--- a/docs/spec/dataclasses.rst
+++ b/docs/spec/dataclasses.rst
@@ -365,10 +365,10 @@ positional and may use other names.
 * ``alias`` is an optional str parameter that provides an alternative
   name for the field. This alternative name is used in the synthesized
   ``__init__`` method.
-* ``converter`` is an optional parameter that specifies a single-argument
-  callable used to convert values when assigning to the associated
-  attribute (Including the assignment in ``__init__``). The parameter
-  type of this single argument provides the type of the synthesized
+* ``converter`` is an optional parameter that specifies a single-parameter
+* ``converter`` is an optional parameter that specifies a single-parameter
+  attribute (including the assignment in ``__init__``). The type
+  of this argument provides the type of the synthesized
   ``__init__`` parameter associated with the field. The return type of
   the callable must be assignable to the field's declared type.
 
@@ -535,7 +535,7 @@ This includes, but is not limited to, the following semantics:
 Converters
 ^^^^^^^^^^
 
-The ``converter`` parameter can be specified in a field definition to provide a single-argument callable
+The ``converter`` parameter can be specified in a field definition to provide a single-parameter callable
 used to convert values when assigning to the associated attribute. This feature allows for automatic type
 conversion and validation during object initialization and attribute assignment.
 
@@ -550,14 +550,14 @@ Converter behavior:
 Typing rules for converters:
 
 * The ``converter`` must be a callable that accepts a single positional argument.
-* The parameter type of this single argument provides the type of the synthesized ``__init__`` parameter
+* The parameter type of the parameter provides the type of the synthesized ``__init__`` parameter
   associated with the field.
 * The return type of the callable must be assignable to the field's declared type.
 
 When used with ``default`` or ``default_factory``:
 
 * If a ``converter`` is provided alongside ``default`` or ``default_factory``, the type of the default
-  value should be assignable to the type of the single argument to the ``converter`` callable.
+  value should be assignable to the the ``converter`` parameter.
 * Default values are unconditionally converted using the ``converter`` if provided.
 
 Example usage:

--- a/docs/spec/dataclasses.rst
+++ b/docs/spec/dataclasses.rst
@@ -562,9 +562,9 @@ Example usage:
 
     @custom_dataclass
     class Example:
-        int_field: int = field(converter=int)
-        str_field: str | None = field(converter=str_or_none)
-        path_field: pathlib.Path = field(
+        int_field: int = custom_field(converter=int)
+        str_field: str | None = custom_field(converter=str_or_none)
+        path_field: pathlib.Path = custom_field(
             converter=pathlib.Path,
             default="default/path.txt"
         )

--- a/docs/spec/dataclasses.rst
+++ b/docs/spec/dataclasses.rst
@@ -544,6 +544,8 @@ Converter behavior:
 * The converter is used for all attribute assignment, including: assignment
   of default values and direct attribute setting (e.g., ``obj.attr = value``).
 * The converter is not used when reading attributes, as the attributes should already have been converted.
+* If a ``converter`` is provided alongside ``default`` or ``default_factory``,
+  default values are converted using the ``converter``.
 
 Typing rules for converters:
 
@@ -551,12 +553,8 @@ Typing rules for converters:
 * The parameter type of the parameter provides the type of the synthesized ``__init__`` parameter
   associated with the field.
 * The return type of the callable must be assignable to the field's declared type.
-
-When used with ``default`` or ``default_factory``:
-
-* If a ``converter`` is provided alongside ``default`` or ``default_factory``,
-  default values are converted using the ``converter``.
-* The type of the default value should be assignable to the single-parameter of the ``converter``
+* If ``default`` or ``default_factory`` are provided, the type of the default value should be 
+  assignable to the single-parameter of the ``converter``
 
 Example usage:
 

--- a/docs/spec/dataclasses.rst
+++ b/docs/spec/dataclasses.rst
@@ -545,7 +545,7 @@ Converter behavior:
 
 Typing rules for converters:
 
-* The ``converter`` must be a callable that must accept a single positional argument 
+* The ``converter`` must be a callable that must accept a single positional argument
   (but may optionally accept other arguments, which are ignored for typing purposes).
 * The type of the first positional parameter provides the type of the synthesized ``__init__`` parameter
   associated with the field.

--- a/docs/spec/dataclasses.rst
+++ b/docs/spec/dataclasses.rst
@@ -365,11 +365,11 @@ positional and may use other names.
 * ``alias`` is an optional str parameter that provides an alternative
   name for the field. This alternative name is used in the synthesized
   ``__init__`` method.
-* ``converter`` is an optional parameter that specifies a single-argument 
-  callable used to convert values when assigning to the associated 
-  attribute (Including the assignment in in ``__init__``). The parameter 
-  type of this single argument provides the type of the synthesized 
-  ``__init__`` parameter associated with the field. The return type of 
+* ``converter`` is an optional parameter that specifies a single-argument
+  callable used to convert values when assigning to the associated
+  attribute (Including the assignment in in ``__init__``). The parameter
+  type of this single argument provides the type of the synthesized
+  ``__init__`` parameter associated with the field. The return type of
   the callable must be compatible with the field's declared type.
 
 It is an error to specify more than one of ``default``,
@@ -535,28 +535,28 @@ This includes, but is not limited to, the following semantics:
 Converters
 ^^^^^^^^^^
 
-The ``converter`` parameter can be specified in a field definition to provide a single-argument callable 
-used to convert values when assigning to the associated attribute. This feature allows for automatic type 
+The ``converter`` parameter can be specified in a field definition to provide a single-argument callable
+used to convert values when assigning to the associated attribute. This feature allows for automatic type
 conversion and validation during object initialization and attribute assignment.
 
 Converter behavior:
 
 * For non-frozen dataclasses, the converter is used for all attribute assignment, including assignment
   of default values and direct attribute setting (e.g., ``obj.attr = value``).
-* For frozen dataclasses, the converter is only used inside a ``dataclass``-synthesized ``__init__`` 
+* For frozen dataclasses, the converter is only used inside a ``dataclass``-synthesized ``__init__``
   when setting the attribute.
 * The converter is not used when reading attributes, as the attributes should already have been converted.
 
 Typing rules for converters:
 
 * The ``converter`` must be a callable that accepts a single positional argument.
-* The parameter type of this single argument provides the type of the synthesized ``__init__`` parameter 
+* The parameter type of this single argument provides the type of the synthesized ``__init__`` parameter
   associated with the field.
 * The return type of the callable must be compatible with the field's declared type.
 
 When used with ``default`` or ``default_factory``:
 
-* If a ``converter`` is provided alongside ``default`` or ``default_factory``, the type of the default 
+* If a ``converter`` is provided alongside ``default`` or ``default_factory``, the type of the default
   value should be compatible with the type of the single argument to the ``converter`` callable.
 * Default values are unconditionally converted using the ``converter`` if provided.
 


### PR DESCRIPTION
Picking up from https://discuss.python.org/t/would-adding-converter-to-dataclass-transform-even-need-a-pep/55125

Which stems from https://discuss.python.org/t/pep-712-adding-a-converter-parameter-to-dataclasses-field/26126 (already discussed) this PR adds `converter` as another field specifier parameter.