### PR TITLE
Add missing code block marker in `generics.rst`

### DIFF
--- a/docs/spec/generics.rst
+++ b/docs/spec/generics.rst
@@ -1918,6 +1918,8 @@ Scoping Rules
 
 Using a type parameter from an outer scope as a default is not supported.
 
+::
+
    class Foo(Generic[T1]):
        class Bar(Generic[T2]): ...   # Type Error
 


### PR DESCRIPTION
Currently the block is rendered as:

![](https://github.com/python/typing/assets/122007197/d396a2b7-aa99-46b8-a0ca-801d23823fab)
