### PR TITLE
Turn Sphinx warnings into errors

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -10,7 +10,7 @@ PYTHON       = python3
 VENVDIR      = ./venv
 SPHINXBUILD  = PATH=$(VENVDIR)/bin:$$PATH sphinx-build
 
-ALLSPHINXOPTS = -b $(BUILDER) -d build/doctrees $(SPHINXOPTS) . build/$(BUILDER) $(SOURCES)
+ALLSPHINXOPTS = -W -b $(BUILDER) -d build/doctrees $(SPHINXOPTS) . build/$(BUILDER) $(SOURCES)
 
 .PHONY: help clean build html text venv Makefile
 

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -25,7 +25,7 @@ if errorlevel 9009 (
 	exit /b 1
 )
 
-%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+%SPHINXBUILD% -W -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
 goto end
 
 :help


### PR DESCRIPTION
This will – for example – prevent accidental "floating" documents that aren't part of the TOC structure.