### PR TITLE
Did a pass on the new deprecated tests to make them stylistically more consistent with existing tests.

### DIFF
--- a/conformance/results/mypy/directives_deprecated.toml
+++ b/conformance/results/mypy/directives_deprecated.toml
@@ -4,17 +4,18 @@ Does not support @deprecated.
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 15: Expected 1 errors
-Line 23: Expected 1 errors
+Line 18: Expected 1 errors
 Line 24: Expected 1 errors
-Line 29: Expected 1 errors
-Line 40: Expected 1 errors
+Line 25: Expected 1 errors
+Line 30: Expected 1 errors
 Line 41: Expected 1 errors
-Line 43: Expected 1 errors
-Line 46: Expected 1 errors
+Line 42: Expected 1 errors
+Line 44: Expected 1 errors
 Line 47: Expected 1 errors
-Line 57: Expected 1 errors
-Line 87: Expected 1 errors
+Line 48: Expected 1 errors
+Line 58: Expected 1 errors
+Line 69: Expected 1 errors
+Line 98: Expected 1 errors
 """
 output = """
 """

--- a/conformance/results/mypy/version.toml
+++ b/conformance/results/mypy/version.toml
@@ -1,2 +1,2 @@
 version = "mypy 1.11.0"
-test_duration = 1.4
+test_duration = 1.2

--- a/conformance/results/pyre/directives_deprecated.toml
+++ b/conformance/results/pyre/directives_deprecated.toml
@@ -4,17 +4,18 @@ Does not support @deprecated.
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 15: Expected 1 errors
-Line 23: Expected 1 errors
+Line 18: Expected 1 errors
 Line 24: Expected 1 errors
-Line 29: Expected 1 errors
-Line 40: Expected 1 errors
+Line 25: Expected 1 errors
+Line 30: Expected 1 errors
 Line 41: Expected 1 errors
-Line 43: Expected 1 errors
-Line 46: Expected 1 errors
+Line 42: Expected 1 errors
+Line 44: Expected 1 errors
 Line 47: Expected 1 errors
-Line 57: Expected 1 errors
-Line 87: Expected 1 errors
+Line 48: Expected 1 errors
+Line 58: Expected 1 errors
+Line 69: Expected 1 errors
+Line 98: Expected 1 errors
 """
 output = """
 """

--- a/conformance/results/pyre/version.toml
+++ b/conformance/results/pyre/version.toml
@@ -1,2 +1,2 @@
 version = "pyre 0.9.22"
-test_duration = 1.8
+test_duration = 2.6

--- a/conformance/results/pyright/directives_deprecated.toml
+++ b/conformance/results/pyright/directives_deprecated.toml
@@ -4,28 +4,29 @@ Does not report error for deprecated magic methods.
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 40: Expected 1 errors
 Line 41: Expected 1 errors
-Line 47: Expected 1 errors
-Line 33: Unexpected errors ['directives_deprecated.py:33:7 - error: The class "Ham" is deprecated']
+Line 42: Expected 1 errors
+Line 48: Expected 1 errors
 """
 output = """
-directives_deprecated.py:15:44 - error: The class "Ham" is deprecated
+directives_deprecated.py:18:44 - error: The class "Ham" is deprecated
   Use Spam instead (reportDeprecated)
-directives_deprecated.py:23:9 - error: The function "norwegian_blue" is deprecated
-  It is pining for the fiords (reportDeprecated)
-directives_deprecated.py:24:13 - error: The function "norwegian_blue" is deprecated
-  It is pining for the fiords (reportDeprecated)
-directives_deprecated.py:29:9 - error: The function "foo" is deprecated
+directives_deprecated.py:24:9 - error: The function "norwegian_blue" is deprecated
+  It is pining for the fjords (reportDeprecated)
+directives_deprecated.py:25:13 - error: The function "norwegian_blue" is deprecated
+  It is pining for the fjords (reportDeprecated)
+directives_deprecated.py:30:9 - error: The function "foo" is deprecated
   Only str will be allowed (reportDeprecated)
-directives_deprecated.py:33:7 - error: The class "Ham" is deprecated
+directives_deprecated.py:34:7 - error: The class "Ham" is deprecated
   Use Spam instead (reportDeprecated)
-directives_deprecated.py:43:6 - error: The getter for property "greasy" is deprecated
+directives_deprecated.py:44:6 - error: The getter for property "greasy" is deprecated
   All spam will be equally greasy (reportDeprecated)
-directives_deprecated.py:46:6 - error: The setter for property "shape" is deprecated
+directives_deprecated.py:47:6 - error: The setter for property "shape" is deprecated
   Shapes are becoming immutable (reportDeprecated)
-directives_deprecated.py:57:9 - error: The function "lorem" is deprecated
+directives_deprecated.py:58:1 - error: The function "invocable" is deprecated
   Deprecated (reportDeprecated)
-directives_deprecated.py:87:13 - error: The method "foo" in class "Fooable" is deprecated
+directives_deprecated.py:69:1 - error: The function "lorem" is deprecated
+  Deprecated (reportDeprecated)
+directives_deprecated.py:98:7 - error: The method "foo" in class "SupportsFoo1" is deprecated
   Deprecated (reportDeprecated)
 """

--- a/conformance/results/pyright/version.toml
+++ b/conformance/results/pyright/version.toml
@@ -1,2 +1,2 @@
 version = "pyright 1.1.373"
-test_duration = 1.2
+test_duration = 1.4

--- a/conformance/results/pytype/directives_deprecated.toml
+++ b/conformance/results/pytype/directives_deprecated.toml
@@ -4,23 +4,24 @@ Does not support @deprecated.
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 23: Expected 1 errors
 Line 24: Expected 1 errors
-Line 29: Expected 1 errors
-Line 40: Expected 1 errors
+Line 25: Expected 1 errors
+Line 30: Expected 1 errors
 Line 41: Expected 1 errors
-Line 43: Expected 1 errors
-Line 46: Expected 1 errors
+Line 42: Expected 1 errors
+Line 44: Expected 1 errors
 Line 47: Expected 1 errors
-Line 57: Expected 1 errors
-Line 87: Expected 1 errors
-Line 16: Unexpected errors ['File "directives_deprecated.py", line 16, in <module>: Can\\'t find module \\'_directives_deprecated_library\\'. [import-error]']
-Line 18: Unexpected errors ['File "directives_deprecated.py", line 18, in <module>: typing_extensions.deprecated not supported yet [not-supported-yet]']
-Line 66: Unexpected errors ['File "directives_deprecated.py", line 66, in <module>: typing.override not supported yet [not-supported-yet]']
+Line 48: Expected 1 errors
+Line 58: Expected 1 errors
+Line 69: Expected 1 errors
+Line 98: Expected 1 errors
+Line 10: Unexpected errors ['File "directives_deprecated.py", line 10, in <module>: typing.override not supported yet [not-supported-yet]']
+Line 11: Unexpected errors ['File "directives_deprecated.py", line 11, in <module>: typing_extensions.deprecated not supported yet [not-supported-yet]']
+Line 19: Unexpected errors ['File "directives_deprecated.py", line 19, in <module>: Can\\'t find module \\'_directives_deprecated_library\\'. [import-error]']
 """
 output = """
-File "directives_deprecated.py", line 15, in <module>: Can't find module '_directives_deprecated_library'. [import-error]
-File "directives_deprecated.py", line 16, in <module>: Can't find module '_directives_deprecated_library'. [import-error]
-File "directives_deprecated.py", line 18, in <module>: typing_extensions.deprecated not supported yet [not-supported-yet]
-File "directives_deprecated.py", line 66, in <module>: typing.override not supported yet [not-supported-yet]
+File "directives_deprecated.py", line 10, in <module>: typing.override not supported yet [not-supported-yet]
+File "directives_deprecated.py", line 11, in <module>: typing_extensions.deprecated not supported yet [not-supported-yet]
+File "directives_deprecated.py", line 18, in <module>: Can't find module '_directives_deprecated_library'. [import-error]
+File "directives_deprecated.py", line 19, in <module>: Can't find module '_directives_deprecated_library'. [import-error]
 """

--- a/conformance/results/pytype/version.toml
+++ b/conformance/results/pytype/version.toml
@@ -1,2 +1,2 @@
 version = "pytype 2024.04.11"
-test_duration = 30.0
+test_duration = 34.1

--- a/conformance/results/results.html
+++ b/conformance/results/results.html
@@ -159,16 +159,16 @@
         <div class="table_container"><table><tbody>
 <tr><th class="col1">&nbsp;</th>
 <th class='tc-header'><div class='tc-name'>mypy 1.11.0</div>
-<div class='tc-time'>1.4sec</div>
-</th>
-<th class='tc-header'><div class='tc-name'>pyright 1.1.373</div>
 <div class='tc-time'>1.2sec</div>
 </th>
+<th class='tc-header'><div class='tc-name'>pyright 1.1.373</div>
+<div class='tc-time'>1.4sec</div>
+</th>
 <th class='tc-header'><div class='tc-name'>pyre 0.9.22</div>
-<div class='tc-time'>1.8sec</div>
+<div class='tc-time'>2.6sec</div>
 </th>
 <th class='tc-header'><div class='tc-name'>pytype 2024.04.11</div>
-<div class='tc-time'>30.0sec</div>
+<div class='tc-time'>34.1sec</div>
 </th>
 </tr>
 <tr><th class="column" colspan="5">
@@ -987,7 +987,7 @@
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;directives_reveal_type</th>
 <th class="column col2 conformant">Pass</th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>"</p><p>Produces errors rather than warnings on `reveal_type`.</p></span></div></th>
+<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Produces errors rather than warnings on `reveal_type`.</p></span></div></th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not reject call to reveal_type with zero arguments.</p><p>Does not reject call to reveal_type with too many arguments.</p></span></div></th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;directives_type_checking</th>

--- a/conformance/tests/_directives_deprecated_library.py
+++ b/conformance/tests/_directives_deprecated_library.py
@@ -3,42 +3,49 @@ Support module for directive_deprecated.
 """
 
 from typing import Self, overload
-
 from typing_extensions import deprecated
 
 
 @deprecated("Use Spam instead")
-class Ham: ...
+class Ham:
+    ...
 
 
-@deprecated("It is pining for the fiords")
-def norwegian_blue(x: int) -> int: ...
+@deprecated("It is pining for the fjords")
+def norwegian_blue(x: int) -> int:
+    ...
 
 
 @overload
 @deprecated("Only str will be allowed")
-def foo(x: int) -> str: ...
+def foo(x: int) -> str:
+    ...
 
 
 @overload
-def foo(x: str) -> str: ...
+def foo(x: str) -> str:
+    ...
 
 
-def foo(x: int | str) -> str: ...
+def foo(x: int | str) -> str:
+    ...
 
 
 class Spam:
-
     @deprecated("There is enough spam in the world")
-    def __add__(self, other: object) -> Self: ...
+    def __add__(self, other: object) -> Self:
+        ...
 
     @property
     @deprecated("All spam will be equally greasy")
-    def greasy(self) -> float: ...
+    def greasy(self) -> float:
+        ...
 
     @property
-    def shape(self) -> str: ...
+    def shape(self) -> str:
+        ...
 
     @shape.setter
     @deprecated("Shapes are becoming immutable")
-    def shape(self, value: str) -> None: ...
+    def shape(self, value: str) -> None:
+        ...

--- a/conformance/tests/directives_deprecated.py
+++ b/conformance/tests/directives_deprecated.py
@@ -7,6 +7,9 @@ Tests the warnings.deprecated function.
 # Specification: https://typing.readthedocs.io/en/latest/spec/directives.html#deprecated
 # See also https://peps.python.org/pep-0702/
 
+from typing import Protocol, override
+from typing_extensions import deprecated
+
 # > Type checkers should produce a diagnostic whenever they encounter a usage of an object
 # > marked as deprecated. [...] For deprecated classes and functions, this includes:
 
@@ -14,8 +17,6 @@ Tests the warnings.deprecated function.
 
 from _directives_deprecated_library import Ham  # E: Use of deprecated class Ham
 import _directives_deprecated_library as library
-
-from typing_extensions import deprecated
 
 
 # > * References through module, class, or instance attributes
@@ -30,7 +31,7 @@ library.foo(1)  # E: Use of deprecated overload for foo
 library.foo("x")  # OK
 
 
-ham = Ham()  # OK (already reported above)
+ham = Ham()  # E?: OK (already reported above)
 
 
 # > * Any syntax that indirectly triggers a call to the function.
@@ -48,9 +49,10 @@ spam.shape += "cube"  # E: Use of deprecated property setter Spam.shape
 
 
 class Invocable:
-
     @deprecated("Deprecated")
-    def __call__(self) -> None: ...
+    def __call__(self) -> None:
+        ...
+
 
 invocable = Invocable()
 invocable()  # E: Use of deprecated method __call__
@@ -58,11 +60,13 @@ invocable()  # E: Use of deprecated method __call__
 
 # > * Any usage of deprecated objects in their defining module
 
+
 @deprecated("Deprecated")
-def lorem() -> None: ...
+def lorem() -> None:
+    ...
 
 
-ipsum = lorem()  # E: Use of deprecated function lorem
+lorem()  # E: Use of deprecated function lorem
 
 
 # > There are additional scenarios where deprecations could come into play.
@@ -71,46 +75,46 @@ ipsum = lorem()  # E: Use of deprecated function lorem
 # > As scenarios such as this one appear complex and relatively unlikely to come up in practice,
 # > this PEP does not mandate that type checkers detect them.
 
-from typing import Protocol, override
 
-
-class Fooable(Protocol):
-
+class SupportsFoo1(Protocol):
     @deprecated("Deprecated")
-    def foo(self) -> None: ...
+    def foo(self) -> None:
+        ...
 
-    def bar(self) -> None: ...
+    def bar(self) -> None:
+        ...
 
 
-class Fooer(Fooable):
-
+class FooConcrete1(SupportsFoo1):
     @override
     def foo(self) -> None:  # E?: Implementation of deprecated method foo
         ...
 
-    def bar(self) -> None: ...
+    def bar(self) -> None:
+        ...
 
 
-def foo_it(fooable: Fooable) -> None:
-    fooable.foo()  # E: Use of deprecated method foo
-    fooable.bar()
+def foo_it(f: SupportsFoo1) -> None:
+    f.foo()  # E: Use of deprecated method foo
+    f.bar()
 
 
-# https://github.com/python/typing/pull/1822#discussion_r1693991644
-
-class Fooable2(Protocol):
-
-    def foo(self) -> None: ...
+class SupportsFoo2(Protocol):
+    def foo(self) -> None:
+        ...
 
 
-class Concrete:
-
+class FooConcrete2:
     @deprecated("Deprecated")
-    def foo(self) -> None: ...
+    def foo(self) -> None:
+        ...
 
 
-def take_fooable(f: Fooable2) -> None: ...
+def takes_foo(f: SupportsFoo2) -> None:
+    ...
 
 
-def caller(c: Concrete) -> None:
-    take_fooable(c)  # E?: Concrete is a Fooable2, but only because of a deprecated method
+def caller(c: FooConcrete2) -> None:
+    takes_foo(
+        c
+    )  # E?: FooConcrete2 is a SupportsFoo2, but only because of a deprecated method


### PR DESCRIPTION
* Ran code formatter
* Moved import statements to top of module
* Fixed spelling issues so code passes spell checking
* Marked usage of imported deprecated symbol as an optional error