### PR TITLE
Updated conformance results for pyright 1.1.374.

### DIFF
--- a/conformance/results/mypy/version.toml
+++ b/conformance/results/mypy/version.toml
@@ -1,2 +1,2 @@
-version = "mypy 1.11.0"
-test_duration = 1.2
+version = "mypy 1.11.1"
+test_duration = 1.0

--- a/conformance/results/pyre/version.toml
+++ b/conformance/results/pyre/version.toml
@@ -1,2 +1,2 @@
 version = "pyre 0.9.22"
-test_duration = 2.6
+test_duration = 1.4

--- a/conformance/results/pyright/constructors_call_init.toml
+++ b/conformance/results/pyright/constructors_call_init.toml
@@ -5,10 +5,10 @@ errors_diff = """
 output = """
 constructors_call_init.py:21:13 - error: Argument of type "float" cannot be assigned to parameter "x" of type "int" in function "__init__"
   "float" is incompatible with "int" (reportArgumentType)
-constructors_call_init.py:42:8 - error: Argument of type "Class2[int]" cannot be assigned to parameter "x" of type "Class3 | None" in function "__init__"
-  Type "Class2[int]" is incompatible with type "Class3 | None"
-    "Class2[int]" is incompatible with "Class3"
-    "Class2[int]" is incompatible with "None" (reportArgumentType)
+constructors_call_init.py:42:8 - error: Argument of type "Class2[Unknown]" cannot be assigned to parameter "x" of type "Class3 | None" in function "__init__"
+  Type "Class2[Unknown]" is incompatible with type "Class3 | None"
+    "Class2[Unknown]" is incompatible with "Class3"
+    "Class2[Unknown]" is incompatible with "None" (reportArgumentType)
 constructors_call_init.py:56:1 - error: 
   Could not bind method "__init__" because "Class4[str]" is not assignable to parameter "self"
     "Class4[str]" is incompatible with "Class4[int]"

--- a/conformance/results/pyright/dataclasses_usage.toml
+++ b/conformance/results/pyright/dataclasses_usage.toml
@@ -8,8 +8,8 @@ dataclasses_usage.py:61:5 - error: Fields without default values cannot appear a
 dataclasses_usage.py:67:5 - error: Fields without default values cannot appear after fields with default values (reportGeneralTypeIssues)
 dataclasses_usage.py:73:5 - error: Fields without default values cannot appear after fields with default values (reportGeneralTypeIssues)
 dataclasses_usage.py:83:13 - error: Expected 1 positional argument (reportCallIssue)
-dataclasses_usage.py:88:36 - error: Argument of type "type[str]" cannot be assigned to parameter "default_factory" of type "() -> _T@field" in function "field"
-  No overloaded function matches type "() -> int" (reportArgumentType)
+dataclasses_usage.py:88:14 - error: Expression of type "str" is incompatible with declared type "int"
+  "str" is incompatible with "int" (reportAssignmentType)
 dataclasses_usage.py:127:8 - error: Expected 1 positional argument (reportCallIssue)
 dataclasses_usage.py:130:1 - error: Argument missing for parameter "y" (reportCallIssue)
 dataclasses_usage.py:179:6 - error: Expected 0 positional arguments (reportCallIssue)

--- a/conformance/results/pyright/directives_deprecated.toml
+++ b/conformance/results/pyright/directives_deprecated.toml
@@ -1,12 +1,6 @@
-conformant = "Partial"
-notes = """
-Does not report error for deprecated magic methods.
-"""
-conformance_automated = "Fail"
+conformant = "Pass"
+conformance_automated = "Pass"
 errors_diff = """
-Line 41: Expected 1 errors
-Line 42: Expected 1 errors
-Line 48: Expected 1 errors
 """
 output = """
 directives_deprecated.py:18:44 - error: The class "Ham" is deprecated
@@ -19,9 +13,15 @@ directives_deprecated.py:30:9 - error: The function "foo" is deprecated
   Only str will be allowed (reportDeprecated)
 directives_deprecated.py:34:7 - error: The class "Ham" is deprecated
   Use Spam instead (reportDeprecated)
+directives_deprecated.py:41:5 - error: The method "__add__" in class "Spam" is deprecated
+  There is enough spam in the world (reportDeprecated)
+directives_deprecated.py:42:1 - error: The method "__add__" in class "Spam" is deprecated
+  There is enough spam in the world (reportDeprecated)
 directives_deprecated.py:44:6 - error: The getter for property "greasy" is deprecated
   All spam will be equally greasy (reportDeprecated)
 directives_deprecated.py:47:6 - error: The setter for property "shape" is deprecated
+  Shapes are becoming immutable (reportDeprecated)
+directives_deprecated.py:48:6 - error: The setter for property "shape" is deprecated
   Shapes are becoming immutable (reportDeprecated)
 directives_deprecated.py:58:1 - error: The function "invocable" is deprecated
   Deprecated (reportDeprecated)

--- a/conformance/results/pyright/generics_paramspec_components.toml
+++ b/conformance/results/pyright/generics_paramspec_components.toml
@@ -12,10 +12,10 @@ generics_paramspec_components.py:36:20 - error: "kwargs" attribute of ParamSpec 
 generics_paramspec_components.py:38:26 - error: "args" and "kwargs" attributes of ParamSpec must both appear within a function signature (reportGeneralTypeIssues)
 generics_paramspec_components.py:41:31 - error: "args" and "kwargs" attributes of ParamSpec must both appear within a function signature (reportGeneralTypeIssues)
 generics_paramspec_components.py:49:9 - error: Arguments for ParamSpec "P@decorator" are missing (reportCallIssue)
-generics_paramspec_components.py:51:11 - error: Arguments for ParamSpec "P@decorator" are missing (reportCallIssue)
+generics_paramspec_components.py:51:11 - error: Expected 0 positional arguments (reportCallIssue)
 generics_paramspec_components.py:60:28 - error: Keyword parameter "s" cannot appear in signature after ParamSpec args parameter (reportGeneralTypeIssues)
-generics_paramspec_components.py:70:12 - error: Expected 2 positional arguments (reportCallIssue)
-generics_paramspec_components.py:72:12 - error: Expected 2 positional arguments (reportCallIssue)
+generics_paramspec_components.py:70:12 - error: Expected 1 positional argument (reportCallIssue)
+generics_paramspec_components.py:72:12 - error: Expected 1 positional argument (reportCallIssue)
 generics_paramspec_components.py:83:19 - error: Expected 1 positional argument (reportCallIssue)
 generics_paramspec_components.py:98:20 - error: Argument of type "Literal['A']" cannot be assigned to parameter "a" of type "int"
   "Literal['A']" is incompatible with "int" (reportArgumentType)

--- a/conformance/results/pyright/generics_syntax_declarations.toml
+++ b/conformance/results/pyright/generics_syntax_declarations.toml
@@ -5,10 +5,12 @@ generics_syntax_declarations.py:27:20 - error: Type arguments are not allowed wi
 generics_syntax_declarations.py:34:11 - error: Cannot access attribute "is_integer" for class "str*"
   Attribute "is_integer" is unknown (reportAttributeAccessIssue)
 generics_syntax_declarations.py:46:21 - error: TypeVar constraint type cannot be generic (reportGeneralTypeIssues)
+generics_syntax_declarations.py:50:17 - error: List expression not allowed in type annotation
+  Use List[T] to indicate a list type or Union[T1, T2] to indicate a union type (reportInvalidTypeForm)
 generics_syntax_declarations.py:50:17 - error: Expected class but received "list[Unknown]" (reportGeneralTypeIssues)
 generics_syntax_declarations.py:62:17 - error: TypeVar must have at least two constrained types (reportGeneralTypeIssues)
 generics_syntax_declarations.py:66:17 - error: TypeVar must have at least two constrained types (reportGeneralTypeIssues)
-generics_syntax_declarations.py:73:17 - error: Expected class but received "tuple[type[bytes], type[str]]" (reportGeneralTypeIssues)
+generics_syntax_declarations.py:73:17 - error: Variable not allowed in type expression (reportInvalidTypeForm)
 generics_syntax_declarations.py:77:18 - error: Expected class but received "Literal[3]" (reportGeneralTypeIssues)
 generics_syntax_declarations.py:81:23 - error: "S" is not defined (reportUndefinedVariable)
 """

--- a/conformance/results/pyright/generics_typevartuple_basic.toml
+++ b/conformance/results/pyright/generics_typevartuple_basic.toml
@@ -1,12 +1,13 @@
 conformant = "Pass"
 output = """
 generics_typevartuple_basic.py:42:34 - error: Argument of type "Height" cannot be assigned to parameter "shape" of type "tuple[*Shape@Array]" in function "__init__"
-  "Height" is incompatible with "tuple[Height, Width]" (reportArgumentType)
-generics_typevartuple_basic.py:43:52 - error: Argument of type "tuple[Batch, Width]" cannot be assigned to parameter "shape" of type "tuple[*Shape@Array]" in function "__init__"
-  "Width" is incompatible with "Height" (reportArgumentType)
-generics_typevartuple_basic.py:45:5 - error: Argument of type "tuple[Time, Batch, Width, Height]" cannot be assigned to parameter "shape" of type "tuple[*Shape@Array]" in function "__init__"
-  "Width" is incompatible with "Height"
-  "Height" is incompatible with "Width" (reportArgumentType)
+  "Height" is incompatible with "tuple[*Shape@Array]" (reportArgumentType)
+generics_typevartuple_basic.py:43:35 - error: Expression of type "Array[Batch, Width]" is incompatible with declared type "Array[Batch, Height, Width]"
+  "Array[Batch, Width]" is incompatible with "Array[Batch, Height, Width]"
+    Type parameter "Shape@Array" is invariant, but "*tuple[Batch, Width]" is not the same as "*tuple[Batch, Height, Width]" (reportAssignmentType)
+generics_typevartuple_basic.py:44:41 - error: Expression of type "Array[Time, Batch, Width, Height]" is incompatible with declared type "Array[Time, Batch, Height, Width]"
+  "Array[Time, Batch, Width, Height]" is incompatible with "Array[Time, Batch, Height, Width]"
+    Type parameter "Shape@Array" is invariant, but "*tuple[Time, Batch, Width, Height]" is not the same as "*tuple[Time, Batch, Height, Width]" (reportAssignmentType)
 generics_typevartuple_basic.py:52:22 - error: Expected unpacked TypeVarTuple; use Unpack[Shape] or *Shape (reportInvalidTypeForm)
 generics_typevartuple_basic.py:53:37 - error: Expected unpacked TypeVarTuple; use Unpack[Shape] or *Shape (reportInvalidTypeForm)
 generics_typevartuple_basic.py:56:34 - error: Expected unpacked TypeVarTuple; use Unpack[Shape] or *Shape (reportInvalidTypeForm)

--- a/conformance/results/pyright/literals_literalstring.toml
+++ b/conformance/results/pyright/literals_literalstring.toml
@@ -14,7 +14,8 @@ literals_literalstring.py:120:22 - error: Argument of type "str" cannot be assig
   Type "str" is incompatible with type "LiteralString"
     "str" is incompatible with "LiteralString" (reportArgumentType)
 literals_literalstring.py:134:51 - error: Argument of type "str" cannot be assigned to parameter "value" of type "T@Container" in function "__init__"
-  "str" is incompatible with "LiteralString" (reportArgumentType)
+  Type "str" is incompatible with type "LiteralString"
+    "str" is incompatible with "LiteralString" (reportArgumentType)
 literals_literalstring.py:171:21 - error: Expression of type "list[LiteralString]" is incompatible with declared type "list[str]"
   "list[LiteralString]" is incompatible with "list[str]"
     Type parameter "_T@list" is invariant, but "LiteralString" is not the same as "str"

--- a/conformance/results/pyright/protocols_generic.toml
+++ b/conformance/results/pyright/protocols_generic.toml
@@ -36,7 +36,7 @@ protocols_generic.py:147:25 - error: Expression of type "ConcreteHasProperty4" i
     "m" is an incompatible type
       Type "(item: str, callback: (int) -> str) -> str" is incompatible with type "(item: T@m, callback: (T@m) -> str) -> str"
         Parameter 2: type "(T@m) -> str" is incompatible with type "(int) -> str"
-          Type "(T@m) -> str" is incompatible with type "(int) -> str" (reportAssignmentType)
+          Type "(str) -> str" is incompatible with type "(int) -> str" (reportAssignmentType)
 """
 conformance_automated = "Pass"
 errors_diff = """

--- a/conformance/results/pyright/version.toml
+++ b/conformance/results/pyright/version.toml
@@ -1,2 +1,2 @@
-version = "pyright 1.1.373"
+version = "pyright 1.1.374"
 test_duration = 1.4

--- a/conformance/results/pytype/version.toml
+++ b/conformance/results/pytype/version.toml
@@ -1,2 +1,2 @@
 version = "pytype 2024.04.11"
-test_duration = 34.1
+test_duration = 31.4

--- a/conformance/results/results.html
+++ b/conformance/results/results.html
@@ -158,17 +158,17 @@
         </header>
         <div class="table_container"><table><tbody>
 <tr><th class="col1">&nbsp;</th>
-<th class='tc-header'><div class='tc-name'>mypy 1.11.0</div>
-<div class='tc-time'>1.2sec</div>
+<th class='tc-header'><div class='tc-name'>mypy 1.11.1</div>
+<div class='tc-time'>1.0sec</div>
 </th>
-<th class='tc-header'><div class='tc-name'>pyright 1.1.373</div>
+<th class='tc-header'><div class='tc-name'>pyright 1.1.374</div>
 <div class='tc-time'>1.4sec</div>
 </th>
 <th class='tc-header'><div class='tc-name'>pyre 0.9.22</div>
-<div class='tc-time'>2.6sec</div>
+<div class='tc-time'>1.4sec</div>
 </th>
 <th class='tc-header'><div class='tc-name'>pytype 2024.04.11</div>
-<div class='tc-time'>34.1sec</div>
+<div class='tc-time'>31.4sec</div>
 </th>
 </tr>
 <tr><th class="column" colspan="5">
@@ -974,7 +974,7 @@
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;directives_deprecated</th>
 <th class="column col2 not-conformant"><div class="hover-text">Unsupported<span class="tooltip-text" id="bottom"><p>Does not support @deprecated.</p></span></div></th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not report error for deprecated magic methods.</p></span></div></th>
+<th class="column col2 conformant">Pass</th>
 <th class="column col2 not-conformant"><div class="hover-text">Unsupported<span class="tooltip-text" id="bottom"><p>Does not support @deprecated.</p></span></div></th>
 <th class="column col2 not-conformant"><div class="hover-text">Unsupported<span class="tooltip-text" id="bottom"><p>Does not support @deprecated.</p></span></div></th>
 </tr>


### PR DESCRIPTION
This release included a fix for a conformance issue in the `deprecated` test. All other output changes are due to updates to error messages and do not affect conformance results.