### PR TITLE
Ignore reveal_type errors when parsing Pyre output

### DIFF
--- a/conformance/results/mypy/version.toml
+++ b/conformance/results/mypy/version.toml
@@ -1,2 +1,2 @@
 version = "mypy 1.11.1"
-test_duration = 1.0
+test_duration = 13.2

--- a/conformance/results/pyre/constructors_callable.toml
+++ b/conformance/results/pyre/constructors_callable.toml
@@ -11,26 +11,16 @@ Line 127: Expected 1 errors
 Line 144: Expected 1 errors
 Line 184: Expected 1 errors
 Line 195: Expected 1 errors
-Line 36: Unexpected errors ['constructors_callable.py:36:0 Revealed type [-1]: Revealed type for `r1` is `typing.Callable[[Named(x, int)], Class1]`.']
-Line 49: Unexpected errors ['constructors_callable.py:49:0 Revealed type [-1]: Revealed type for `r2` is `typing.Callable[[], Class2]`.']
-Line 63: Unexpected errors ['constructors_callable.py:63:0 Revealed type [-1]: Revealed type for `r3` is `typing.Callable[[Named(x, int)], Class3]`.']
-Line 77: Unexpected errors ['constructors_callable.py:77:0 Revealed type [-1]: Revealed type for `r4` is `typing.Callable[[Named(x, int)], Class4]`.']
 Line 78: Unexpected errors ['constructors_callable.py:78:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `Class4`.']
-Line 97: Unexpected errors ['constructors_callable.py:97:0 Revealed type [-1]: Revealed type for `r5` is `typing.Callable[[Variable(typing.Any), Keywords(typing.Any)], NoReturn]`.']
-Line 125: Unexpected errors ['constructors_callable.py:125:0 Revealed type [-1]: Revealed type for `r6` is `typing.Callable[[Named(x, int)], Class6]`.']
 Line 126: Unexpected errors ['constructors_callable.py:126:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Class6Proxy` but got `Class6`.', 'constructors_callable.py:126:12 Missing argument [20]: PositionalOnly call expects argument `x`.']
-Line 142: Unexpected errors ['constructors_callable.py:142:0 Revealed type [-1]: Revealed type for `r6_any` is `typing.Callable[[Named(x, int)], Class6Any]`.']
 Line 143: Unexpected errors ['constructors_callable.py:143:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `typing.Any` but got `Class6Any`.', 'constructors_callable.py:143:12 Missing argument [20]: PositionalOnly call expects argument `x`.']
 Line 153: Unexpected errors ['constructors_callable.py:153:4 Incompatible overload [43]: The implementation of `Class7.__init__` does not accept all possible arguments of overload defined on line `153`.']
 Line 155: Unexpected errors ['constructors_callable.py:155:4 Incompatible overload [43]: The implementation of `Class7.__init__` does not accept all possible arguments of overload defined on line `155`.']
-Line 161: Unexpected errors ['constructors_callable.py:161:0 Revealed type [-1]: Revealed type for `r7` is `typing.Callable[[Named(x, int)], Class7[typing.Any]]`.']
 Line 164: Unexpected errors ['constructors_callable.py:164:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Class7[int]` but got `Class7[typing.Any]`.']
 Line 165: Unexpected errors ['constructors_callable.py:165:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Class7[str]` but got `Class7[typing.Any]`.', 'constructors_callable.py:165:15 Incompatible parameter type [6]: In anonymous call, for 1st positional argument, expected `int` but got `str`.']
 Line 181: Unexpected errors ['constructors_callable.py:181:22 Incompatible parameter type [6]: In call `accepts_callable`, for 1st positional argument, expected `typing.Callable[constructors_callable.P, Variable[R]]` but got `Type[Class8]`.']
-Line 182: Unexpected errors ['constructors_callable.py:182:0 Revealed type [-1]: Revealed type for `r8` is `typing.Callable[..., typing.Any]`.']
 Line 183: Unexpected errors ['constructors_callable.py:183:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Class8[str]` but got `typing.Any`.']
 Line 192: Unexpected errors ['constructors_callable.py:192:22 Incompatible parameter type [6]: In call `accepts_callable`, for 1st positional argument, expected `typing.Callable[constructors_callable.P, Variable[R]]` but got `Type[Class9]`.']
-Line 193: Unexpected errors ['constructors_callable.py:193:0 Revealed type [-1]: Revealed type for `r9` is `typing.Callable[..., typing.Any]`.']
 Line 194: Unexpected errors ['constructors_callable.py:194:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Class9` but got `typing.Any`.']
 """
 output = """

--- a/conformance/results/pyre/directives_reveal_type.toml
+++ b/conformance/results/pyre/directives_reveal_type.toml
@@ -12,8 +12,5 @@ directives_reveal_type.py:20:4 Revealed type [-1]: Revealed type for `a` is `typ
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 14: Unexpected errors ['directives_reveal_type.py:14:4 Revealed type [-1]: Revealed type for `a` is `typing.Union[int, str]`.']
-Line 15: Unexpected errors ['directives_reveal_type.py:15:4 Revealed type [-1]: Revealed type for `b` is `typing.List[int]`.']
-Line 16: Unexpected errors ['directives_reveal_type.py:16:4 Revealed type [-1]: Revealed type for `c` is `typing.Any`.']
-Line 17: Unexpected errors ['directives_reveal_type.py:17:4 Revealed type [-1]: Revealed type for `d` is `ForwardReference`.']
+Line 20: Expected 1 errors
 """

--- a/conformance/results/pyre/enums_members.toml
+++ b/conformance/results/pyre/enums_members.toml
@@ -22,7 +22,6 @@ Line 35: Unexpected errors ['enums_members.py:35:0 Incompatible parameter type [
 Line 36: Unexpected errors ['enums_members.py:36:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `str` but got `Pet2`.']
 Line 100: Unexpected errors ['enums_members.py:100:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `typing_extensions.Literal[TrafficLight.YELLOW]` but got `typing_extensions.Literal[TrafficLight.AMBER]`.']
 Line 117: Unexpected errors ['enums_members.py:117:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `typing_extensions.Literal[Example.c]` but got `member[typing.Callable(Example.c)[[Named(self, Example)], None]]`.']
-Line 128: Unexpected errors ['enums_members.py:128:8 Revealed type [-1]: Revealed type for `enums_members.Example2._Example2__B` is `typing_extensions.Literal[Example2._Example2__B]` (final).']
 Line 139: Unexpected errors ['enums_members.py:139:4 Inconsistent override [15]: `_ignore_` overrides attribute defined in `Enum` inconsistently. Type `Pet5` is not a subtype of the overridden attribute `typing.Union[typing.List[str], str]`.']
 """
 output = """

--- a/conformance/results/pyre/version.toml
+++ b/conformance/results/pyre/version.toml
@@ -1,2 +1,2 @@
 version = "pyre 0.9.22"
-test_duration = 1.4
+test_duration = 5.4

--- a/conformance/results/pyright/version.toml
+++ b/conformance/results/pyright/version.toml
@@ -1,2 +1,2 @@
 version = "pyright 1.1.374"
-test_duration = 1.4
+test_duration = 1.5

--- a/conformance/results/pytype/version.toml
+++ b/conformance/results/pytype/version.toml
@@ -1,2 +1,2 @@
 version = "pytype 2024.04.11"
-test_duration = 31.4
+test_duration = 35.2

--- a/conformance/results/results.html
+++ b/conformance/results/results.html
@@ -159,16 +159,16 @@
         <div class="table_container"><table><tbody>
 <tr><th class="col1">&nbsp;</th>
 <th class='tc-header'><div class='tc-name'>mypy 1.11.1</div>
-<div class='tc-time'>1.0sec</div>
+<div class='tc-time'>13.2sec</div>
 </th>
 <th class='tc-header'><div class='tc-name'>pyright 1.1.374</div>
-<div class='tc-time'>1.4sec</div>
+<div class='tc-time'>1.5sec</div>
 </th>
 <th class='tc-header'><div class='tc-name'>pyre 0.9.22</div>
-<div class='tc-time'>1.4sec</div>
+<div class='tc-time'>5.4sec</div>
 </th>
 <th class='tc-header'><div class='tc-name'>pytype 2024.04.11</div>
-<div class='tc-time'>31.4sec</div>
+<div class='tc-time'>35.2sec</div>
 </th>
 </tr>
 <tr><th class="column" colspan="5">

--- a/conformance/src/type_checker.py
+++ b/conformance/src/type_checker.py
@@ -254,6 +254,9 @@ class PyreTypeChecker(TypeChecker):
             # Ignore multi-line errors
             if ".py:" not in line:
                 continue
+            # Ignore reveal_type errors
+            if "Revealed type [-1]" in line:
+                continue
             assert line.count(":") >= 2, f"Failed to parse line: {line!r}"
             _, lineno, _ = line.split(":", maxsplit=2)
             line_to_errors.setdefault(int(lineno), []).append(line)


### PR DESCRIPTION
Pyre generates diagnostics for `reveal_type` like any other type error, since it doesn't distinguish between errors and warnings in the output. 

The mypy and pyright `reveal_type` diagnostics are prefixed with `note` and `info`, which get filtered out when parsing the output. This PR updates Pyre's output parsing to ignore `reveal_type` errors. They'll still show up in the output, but they will no longer cause "unexpected error" conformance mismatches that need to be manually checked.