### PR TITLE
Specify that `type[]` distributes over unions

### DIFF
--- a/docs/spec/special-types.rst
+++ b/docs/spec/special-types.rst
@@ -176,7 +176,7 @@ Note that it is legal to use a union of classes as the parameter for
       ...
 
 ``type[]`` distributes over unions:
-``type[A | B]`` is the same as ``type[A] | type[B]``.
+``type[A | B]`` is consistent with ``type[A] | type[B]``.
 
 However, the actual argument passed in at runtime must still be a
 concrete class object, e.g. in the above example::

--- a/docs/spec/special-types.rst
+++ b/docs/spec/special-types.rst
@@ -176,7 +176,7 @@ Note that it is legal to use a union of classes as the parameter for
       ...
 
 ``type[]`` distributes over unions:
-``type[A | B]`` is equivalent to ``type[A] | type[B]``.
+``type[A | B]`` is :term:`equivalent` to ``type[A] | type[B]``.
 
 However, the actual argument passed in at runtime must still be a
 concrete class object, e.g. in the above example::

--- a/docs/spec/special-types.rst
+++ b/docs/spec/special-types.rst
@@ -176,7 +176,7 @@ Note that it is legal to use a union of classes as the parameter for
       ...
 
 ``type[]`` distributes over unions:
-``type[A | B]`` is consistent with ``type[A] | type[B]``.
+``type[A | B]`` is equivalent to ``type[A] | type[B]``.
 
 However, the actual argument passed in at runtime must still be a
 concrete class object, e.g. in the above example::

--- a/docs/spec/special-types.rst
+++ b/docs/spec/special-types.rst
@@ -175,7 +175,10 @@ Note that it is legal to use a union of classes as the parameter for
       user = new_user(user_class)
       ...
 
-However the actual argument passed in at runtime must still be a
+``type[]`` distributes over unions:
+``type[A | B]`` is the same as ``type[A] | type[B]``.
+
+However, the actual argument passed in at runtime must still be a
 concrete class object, e.g. in the above example::
 
   new_non_team_user(ProUser)  # OK


### PR DESCRIPTION
I think this much can be inferred, since the specs already said that:

* `type[A | B]` is supported, and
* `B` the class is a valid value for `type[A | B]`
