### PR TITLE
Docs: Add reference to TypeIs to use via InterSphinx

### DIFF
--- a/docs/spec/narrowing.rst
+++ b/docs/spec/narrowing.rst
@@ -110,6 +110,8 @@ is not narrowed in the negative case.
             reveal_type(val)  # tuple[str, str]
             ...
 
+.. _`typeis`:
+
 TypeIs
 ------
 


### PR DESCRIPTION
To help https://github.com/python/peps/pull/3929 so it doesn't need to link like [python/peps@`5141ffd` (#3929)](https://github.com/python/peps/pull/3929/commits/5141ffdc40966bc90c5fb7b4fc17cec1730d23a8).