### PR TITLE
Fix type annotation with two string literals

### DIFF
--- a/conformance/tests/annotations_forward_refs.py
+++ b/conformance/tests/annotations_forward_refs.py
@@ -38,7 +38,7 @@ var1 = 1
 # The following should all generate errors because they are not legal type
 # expressions, despite being enclosed in quotes.
 def invalid_annotations(
-    p1: "eval(" ".join(map(chr, [105, 110, 116])))",  # E
+    p1: "eval(' '.join(map(chr, [105, 110, 116])))",  # E
     p2: "[int, str]",  # E
     p3: "(int, str)",  # E
     p4: "[int for i in range(1)]",  # E

--- a/conformance/tests/annotations_forward_refs.py
+++ b/conformance/tests/annotations_forward_refs.py
@@ -38,7 +38,7 @@ var1 = 1
 # The following should all generate errors because they are not legal type
 # expressions, despite being enclosed in quotes.
 def invalid_annotations(
-    p1: "eval(' '.join(map(chr, [105, 110, 116])))",  # E
+    p1: "eval(''.join(map(chr, [105, 110, 116])))",  # E
     p2: "[int, str]",  # E
     p3: "(int, str)",  # E
     p4: "[int for i in range(1)]",  # E


### PR DESCRIPTION
I noticed there are two strings as type annotation and I thought this is not intended because if I understand correctly forward annotations cannot consist of two string literals.

Although this is syntactically correct because the strings can be concatenated. But testing it out on pyright for example this does not pass:
```
a: "int" "| string" = 1  # error: Expected type but received a string literal (reportGeneralTypeIssues)
```