### PR TITLE
Change int to Any in unpacking unbounded tuple types

### DIFF
--- a/docs/spec/generics.rst
+++ b/docs/spec/generics.rst
@@ -1262,7 +1262,7 @@ unnecessary ``TypeVarTuple``:
     process_batch_channels(z)  # Error: Expected Channels.
 
 
-We can also pass a ``*tuple[int, ...]`` wherever a ``*Ts`` is
+We can also pass a ``*tuple[Any, ...]`` wherever a ``*Ts`` is
 expected. This is useful when we have particularly dynamic code and
 cannot state the precise number of dimensions or the precise types for
 each of the dimensions. In those cases, we can smoothly fall back to


### PR DESCRIPTION
It looks like there should be `Any` instead of `int`, because the documentation says the following:
"""
We can also pass a `*tuple[int, ...]` wherever a `*Ts` is expected. This is useful when we have particularly dynamic code and cannot state the precise number of dimensions **or the precise types** for each of the dimensions.
"""
