### PR TITLE
Updated conformance results for pyright 1.1.385.

### DIFF
--- a/conformance/results/pyright/constructors_call_type.toml
+++ b/conformance/results/pyright/constructors_call_type.toml
@@ -1,18 +1,15 @@
-conformant = "Partial"
-notes = """
-Fails to report error when passing incorrect arguments for metaclass __call__ method.
-"""
+conformant = "Pass"
 errors_diff = """
-Line 30: Expected 1 errors
-Line 72: Expected 1 errors
 """
 output = """
+constructors_call_type.py:30:5 - error: Arguments missing for parameters "x", "y" (reportCallIssue)
 constructors_call_type.py:40:5 - error: Arguments missing for parameters "x", "y" (reportCallIssue)
 constructors_call_type.py:50:5 - error: Arguments missing for parameters "x", "y" (reportCallIssue)
 constructors_call_type.py:59:9 - error: Expected 0 positional arguments (reportCallIssue)
 constructors_call_type.py:64:9 - error: Expected 0 positional arguments (reportCallIssue)
+constructors_call_type.py:72:5 - error: Arguments missing for parameters "x", "y" (reportCallIssue)
 constructors_call_type.py:81:5 - error: Argument missing for parameter "y" (reportCallIssue)
 constructors_call_type.py:82:12 - error: Argument of type "Literal[2]" cannot be assigned to parameter "y" of type "str" in function "__new__"
   "Literal[2]" is not assignable to "str" (reportArgumentType)
 """
-conformance_automated = "Fail"
+conformance_automated = "Pass"

--- a/conformance/results/pyright/generics_typevartuple_args.toml
+++ b/conformance/results/pyright/generics_typevartuple_args.toml
@@ -8,16 +8,15 @@ generics_typevartuple_args.py:48:10 - error: Argument of type "Literal['2']" can
   "Literal['2']" is not assignable to "int" (reportArgumentType)
 generics_typevartuple_args.py:57:10 - error: Argument of type "Literal[1]" cannot be assigned to parameter of type "str" in function "func2"
   "Literal[1]" is not assignable to "str" (reportArgumentType)
-generics_typevartuple_args.py:59:7 - error: Argument of type "Literal['']" cannot be assigned to parameter of type "int" in function "func2"
-  "Literal['']" is not assignable to "int" (reportArgumentType)
+generics_typevartuple_args.py:58:1 - error: Argument missing for parameter "args[2]" (reportCallIssue)
+generics_typevartuple_args.py:59:1 - error: Argument missing for parameter "args[2]" (reportCallIssue)
+generics_typevartuple_args.py:67:1 - error: Argument missing for parameter "args[1]" (reportCallIssue)
 generics_typevartuple_args.py:75:13 - error: Argument of type "tuple[Literal[1], Literal[2]]" cannot be assigned to parameter "args" of type "tuple[*Ts@func4]" in function "func4"
   "tuple[Literal[1], Literal[2]]" is not assignable to "tuple[int]"
     Tuple size mismatch; expected 1 but received 2 (reportArgumentType)
 generics_typevartuple_args.py:76:14 - error: Argument of type "tuple[Literal['1']]" cannot be assigned to parameter "args" of type "tuple[*Ts@func4]" in function "func4"
   "Literal['1']" is not assignable to "int" (reportArgumentType)
 """
-conformance_automated = "Fail"
+conformance_automated = "Pass"
 errors_diff = """
-Line 58: Expected 1 errors
-Line 67: Expected 1 errors
 """

--- a/conformance/results/pyright/version.toml
+++ b/conformance/results/pyright/version.toml
@@ -1,2 +1,2 @@
-version = "pyright 1.1.384"
-test_duration = 1.3
+version = "pyright 1.1.385"
+test_duration = 1.2

--- a/conformance/results/results.html
+++ b/conformance/results/results.html
@@ -161,8 +161,8 @@
 <th class='tc-header'><div class='tc-name'>mypy 1.12.0</div>
 <div class='tc-time'>1.7sec</div>
 </th>
-<th class='tc-header'><div class='tc-name'>pyright 1.1.384</div>
-<div class='tc-time'>1.3sec</div>
+<th class='tc-header'><div class='tc-name'>pyright 1.1.385</div>
+<div class='tc-time'>1.2sec</div>
 </th>
 <th class='tc-header'><div class='tc-name'>pyre 0.9.22</div>
 <div class='tc-time'>4.6sec</div>
@@ -647,7 +647,7 @@
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;constructors_call_type</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not validate call to custom metaclass __call__ method through type[T].</p></span></div></th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Fails to report error when passing incorrect arguments for metaclass __call__ method.</p></span></div></th>
+<th class="column col2 conformant">Pass</th>
 <th class="column col2 conformant">Pass</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not validate call to custom metaclass __call__ method through type[T].</p></span></div></th>
 </tr>


### PR DESCRIPTION
* Fixes regression caught by constructors_call_type test
* Fixes regression caught by generics_typevartuple_args test