### PR TITLE
Suggest `pyupgrade` or `ruff` for modernizing superseded typing features

### DIFF
--- a/docs/guides/modernizing.rst
+++ b/docs/guides/modernizing.rst
@@ -24,6 +24,12 @@ Each section states the minimum Python version required to use the
 feature, whether it is available in typing-extensions, and whether it is
 available using quoting.
 
+.. tip::
+
+    Tools such as `pyupgrade <https://pypi.org/project/pyupgrade/>`__ or
+    `ruff <https://pypi.org/project/ruff/>`__ can automatically perform
+    these refactorings for you.
+
 .. note::
 
     The latest version of typing-extensions is available for all Python


### PR DESCRIPTION
Given the existence of automatic upgrade tools, I'd rather not do this by hand; and I think it's worth giving the tip that they exist for readers who don't know the ecosystem as well as many maintainers might.