### PR TITLE
Modernizing guide: also mention `com2ann`

### DIFF
--- a/docs/guides/modernizing.rst
+++ b/docs/guides/modernizing.rst
@@ -26,8 +26,9 @@ available using quoting.
 
 .. tip::
 
-    Tools such as `pyupgrade <https://pypi.org/project/pyupgrade/>`__ or
-    `ruff <https://pypi.org/project/ruff/>`__ can automatically perform
+    Tools such as `pyupgrade <https://pypi.org/project/pyupgrade/>`__,
+    `ruff <https://pypi.org/project/ruff/>`__ and/or
+    `com2ann <https://pypi.org/project/com2ann/>`__ can automatically perform
     these refactorings for you.
 
 .. note::


### PR DESCRIPTION
Small followup to #1868

This guide mentions type comments as one of the older typing features that you might like to modernize; as far as I know, `com2ann` is still the best tool for auto-converting these to Python-3 type annotations.