### PR TITLE
Updated conformance results for mypy 1.13 and pyright 1.1.386

### DIFF
--- a/conformance/results/mypy/version.toml
+++ b/conformance/results/mypy/version.toml
@@ -1,2 +1,2 @@
-version = "mypy 1.12.0"
-test_duration = 1.7
+version = "mypy 1.13.0"
+test_duration = 1.5

--- a/conformance/results/pyre/version.toml
+++ b/conformance/results/pyre/version.toml
@@ -1,2 +1,2 @@
 version = "pyre 0.9.22"
-test_duration = 4.6
+test_duration = 4.4

--- a/conformance/results/pyright/callables_kwargs.toml
+++ b/conformance/results/pyright/callables_kwargs.toml
@@ -1,11 +1,7 @@
-conformant = "Partial"
-notes = """
-Incorrectly handles assert_type for unpacked TypedDict.
-"""
+conformant = "Pass"
 output = """
 callables_kwargs.py:28:5 - error: Could not access item in TypedDict
-  "v2" is not a required key in "*TD2", so access may result in runtime exception (reportTypedDictNotRequiredAccess)
-callables_kwargs.py:41:17 - error: "assert_type" mismatch: expected "TD1" but received "*TD1" (reportAssertTypeFailure)
+  "v2" is not a required key in "TD2", so access may result in runtime exception (reportTypedDictNotRequiredAccess)
 callables_kwargs.py:46:5 - error: Arguments missing for parameters "v1", "v3" (reportCallIssue)
 callables_kwargs.py:51:32 - error: No parameter named "v4" (reportCallIssue)
 callables_kwargs.py:52:11 - error: Expected 0 positional arguments (reportCallIssue)
@@ -32,7 +28,6 @@ callables_kwargs.py:103:19 - error: Type "(**kwargs: **TD2) -> None" is not assi
 callables_kwargs.py:111:30 - error: Typed dictionary overlaps with keyword parameter: v1 (reportGeneralTypeIssues)
 callables_kwargs.py:122:21 - error: Expected TypedDict type argument for Unpack (reportGeneralTypeIssues)
 """
-conformance_automated = "Fail"
+conformance_automated = "Pass"
 errors_diff = """
-Line 41: Unexpected errors ['callables_kwargs.py:41:17 - error: "assert_type" mismatch: expected "TD1" but received "*TD1" (reportAssertTypeFailure)']
 """

--- a/conformance/results/pyright/typeddicts_readonly_kwargs.toml
+++ b/conformance/results/pyright/typeddicts_readonly_kwargs.toml
@@ -1,7 +1,7 @@
 conformant = "Pass"
 output = """
 typeddicts_readonly_kwargs.py:33:5 - error: Could not assign item in TypedDict
-  "key1" is a read-only key in "*ReadOnlyArgs" (reportTypedDictNotRequiredAccess)
+  "key1" is a read-only key in "ReadOnlyArgs" (reportTypedDictNotRequiredAccess)
 """
 conformance_automated = "Pass"
 errors_diff = """

--- a/conformance/results/pyright/version.toml
+++ b/conformance/results/pyright/version.toml
@@ -1,2 +1,2 @@
-version = "pyright 1.1.385"
+version = "pyright 1.1.386"
 test_duration = 1.2

--- a/conformance/results/results.html
+++ b/conformance/results/results.html
@@ -158,14 +158,14 @@
         </header>
         <div class="table_container"><table><tbody>
 <tr><th class="col1">&nbsp;</th>
-<th class='tc-header'><div class='tc-name'>mypy 1.12.0</div>
-<div class='tc-time'>1.7sec</div>
+<th class='tc-header'><div class='tc-name'>mypy 1.13.0</div>
+<div class='tc-time'>1.5sec</div>
 </th>
-<th class='tc-header'><div class='tc-name'>pyright 1.1.385</div>
+<th class='tc-header'><div class='tc-name'>pyright 1.1.386</div>
 <div class='tc-time'>1.2sec</div>
 </th>
 <th class='tc-header'><div class='tc-name'>pyre 0.9.22</div>
-<div class='tc-time'>4.6sec</div>
+<div class='tc-time'>4.4sec</div>
 </th>
 <th class='tc-header'><div class='tc-name'>pytype 2024.10.11</div>
 <div class='tc-time'>33.1sec</div>
@@ -608,7 +608,7 @@
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;callables_kwargs</th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Incorrectly handles assert_type for unpacked TypedDict.</p></span></div></th>
+<th class="column col2 conformant">Pass</th>
 <th class="column col2 not-conformant"><div class="hover-text">Unsupported<span class="tooltip-text" id="bottom"><p>Does not understand Unpack in the context of **kwargs annotation.</p></span></div></th>
 <th class="column col2 not-conformant"><div class="hover-text">Unsupported<span class="tooltip-text" id="bottom"><p>Does not understand Unpack in the context of **kwargs annotation.</p></span></div></th>
 </tr>


### PR DESCRIPTION
Pyright fixed one conformance bug in callables_kwargs test. Mypy results did not change.