### PR TITLE
Mention use of cast in enum type stub example

### DIFF
--- a/docs/spec/enums.rst
+++ b/docs/spec/enums.rst
@@ -124,7 +124,7 @@ statically in cases where dynamic values are used.
         species: str  # Non-member attribute
 
         CAT = 1  # Member attribute with known value and type
-        DOG = cast(str, ...)  # Member attribute with unknown value and known type
+        DOG = cast(int, ...)  # Member attribute with unknown value and known type
         BIRD = ...  # Member attribute with unknown value and type
 
 * Members defined within an enum class should not include explicit type

--- a/docs/spec/enums.rst
+++ b/docs/spec/enums.rst
@@ -123,8 +123,9 @@ statically in cases where dynamic values are used.
         genus: str  # Non-member attribute
         species: str  # Non-member attribute
 
-        CAT = ...  # Member attribute
-        DOG = ...  # Member attribute
+        CAT = 1  # Member attribute with known value and type
+        DOG = cast(str, ...)  # Member attribute with unknown value and known type
+        BIRD = ...  # Member attribute with unknown value and type
 
 * Members defined within an enum class should not include explicit type
   annotations. Type checkers should infer a literal type for all members.


### PR DESCRIPTION
In case people gloss over the text, it's good for the example to recommend the thing with the most static information