### PR TITLE
Update conformance results after new pyre release

### DIFF
--- a/conformance/results/mypy/version.toml
+++ b/conformance/results/mypy/version.toml
@@ -1,2 +1,2 @@
 version = "mypy 1.13.0"
-test_duration = 1.5
+test_duration = 2.7

--- a/conformance/results/pyre/aliases_explicit.toml
+++ b/conformance/results/pyre/aliases_explicit.toml
@@ -15,6 +15,8 @@ aliases_explicit.py:26:0 Incompatible variable type [9]: GoodTypeAlias12 is decl
 aliases_explicit.py:26:31 Incompatible parameter type [6]: In call `typing.GenericMeta.__getitem__`, for 1st positional argument, expected `Tuple[typing.Any, Type[Variable[$synthetic_attribute_resolution_variable]]]` but got `Tuple[ParamSpec, None]`.
 aliases_explicit.py:41:8 Undefined or invalid type [11]: Annotation `GoodTypeAlias9` is not defined as a type.
 aliases_explicit.py:44:9 Undefined or invalid type [11]: Annotation `GoodTypeAlias12` is not defined as a type.
+aliases_explicit.py:57:4 Assert type [70]: Expected `typing.Callable[[int, str, str], None]` but got `unknown`.
+aliases_explicit.py:60:4 Assert type [70]: Expected `typing.Callable[..., None]` but got `unknown`.
 aliases_explicit.py:80:0 Incompatible variable type [9]: BadTypeAlias2 is declared to have type `TA` but is used as type `List[Type[Union[int, str]]]`.
 aliases_explicit.py:81:0 Incompatible variable type [9]: BadTypeAlias3 is declared to have type `TA` but is used as type `Tuple[Tuple[Type[int], Type[str]]]`.
 aliases_explicit.py:82:0 Incompatible variable type [9]: BadTypeAlias4 is declared to have type `TA` but is used as type `List[Type[int]]`.
@@ -44,5 +46,7 @@ Line 23: Unexpected errors ['aliases_explicit.py:23:0 Incompatible variable type
 Line 26: Unexpected errors ['aliases_explicit.py:26:0 Incompatible variable type [9]: GoodTypeAlias12 is declared to have type `TA` but is used as type `Type[typing.Callable[..., Variable[$synthetic_attribute_resolution_variable]]]`.', 'aliases_explicit.py:26:31 Incompatible parameter type [6]: In call `typing.GenericMeta.__getitem__`, for 1st positional argument, expected `Tuple[typing.Any, Type[Variable[$synthetic_attribute_resolution_variable]]]` but got `Tuple[ParamSpec, None]`.']
 Line 41: Unexpected errors ['aliases_explicit.py:41:8 Undefined or invalid type [11]: Annotation `GoodTypeAlias9` is not defined as a type.']
 Line 44: Unexpected errors ['aliases_explicit.py:44:9 Undefined or invalid type [11]: Annotation `GoodTypeAlias12` is not defined as a type.']
+Line 57: Unexpected errors ['aliases_explicit.py:57:4 Assert type [70]: Expected `typing.Callable[[int, str, str], None]` but got `unknown`.']
+Line 60: Unexpected errors ['aliases_explicit.py:60:4 Assert type [70]: Expected `typing.Callable[..., None]` but got `unknown`.']
 Line 97: Unexpected errors ['aliases_explicit.py:97:16 Call error [29]: `TA` is not a function.']
 """

--- a/conformance/results/pyre/aliases_implicit.toml
+++ b/conformance/results/pyre/aliases_implicit.toml
@@ -12,6 +12,8 @@ aliases_implicit.py:38:26 Incompatible parameter type [6]: In call `typing.Gener
 aliases_implicit.py:42:27 Incompatible parameter type [6]: In call `typing.GenericMeta.__getitem__`, for 1st positional argument, expected `Tuple[typing.Any, Type[Variable[$synthetic_attribute_resolution_variable]]]` but got `Tuple[ParamSpec, None]`.
 aliases_implicit.py:54:8 Undefined or invalid type [11]: Annotation `GoodTypeAlias9` is not defined as a type.
 aliases_implicit.py:58:9 Undefined or invalid type [11]: Annotation `GoodTypeAlias13` is not defined as a type.
+aliases_implicit.py:68:4 Assert type [70]: Expected `typing.Callable[[int, str, str], None]` but got `unknown`.
+aliases_implicit.py:72:4 Assert type [70]: Expected `typing.Callable[..., None]` but got `unknown`.
 aliases_implicit.py:106:8 Undefined or invalid type [11]: Annotation `BadTypeAlias1` is not defined as a type.
 aliases_implicit.py:107:8 Undefined or invalid type [11]: Annotation `BadTypeAlias2` is not defined as a type.
 aliases_implicit.py:108:8 Undefined or invalid type [11]: Annotation `BadTypeAlias3` is not defined as a type.
@@ -26,7 +28,7 @@ aliases_implicit.py:116:9 Undefined or invalid type [11]: Annotation `BadTypeAli
 aliases_implicit.py:117:9 Undefined or invalid type [11]: Annotation `BadTypeAlias12` is not defined as a type.
 aliases_implicit.py:118:9 Undefined or invalid type [11]: Annotation `BadTypeAlias13` is not defined as a type.
 aliases_implicit.py:119:9 Undefined or invalid type [11]: Annotation `BadTypeAlias14` is not defined as a type.
-aliases_implicit.py:131:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `List[int]` but got `typing.Any`.
+aliases_implicit.py:131:0 Assert type [70]: Expected `List[int]` but got `typing.Any`.
 """
 conformance_automated = "Fail"
 errors_diff = """
@@ -42,5 +44,7 @@ Line 38: Unexpected errors ['aliases_implicit.py:38:26 Incompatible parameter ty
 Line 42: Unexpected errors ['aliases_implicit.py:42:27 Incompatible parameter type [6]: In call `typing.GenericMeta.__getitem__`, for 1st positional argument, expected `Tuple[typing.Any, Type[Variable[$synthetic_attribute_resolution_variable]]]` but got `Tuple[ParamSpec, None]`.']
 Line 54: Unexpected errors ['aliases_implicit.py:54:8 Undefined or invalid type [11]: Annotation `GoodTypeAlias9` is not defined as a type.']
 Line 58: Unexpected errors ['aliases_implicit.py:58:9 Undefined or invalid type [11]: Annotation `GoodTypeAlias13` is not defined as a type.']
-Line 131: Unexpected errors ['aliases_implicit.py:131:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `List[int]` but got `typing.Any`.']
+Line 68: Unexpected errors ['aliases_implicit.py:68:4 Assert type [70]: Expected `typing.Callable[[int, str, str], None]` but got `unknown`.']
+Line 72: Unexpected errors ['aliases_implicit.py:72:4 Assert type [70]: Expected `typing.Callable[..., None]` but got `unknown`.']
+Line 131: Unexpected errors ['aliases_implicit.py:131:0 Assert type [70]: Expected `List[int]` but got `typing.Any`.']
 """

--- a/conformance/results/pyre/aliases_newtype.toml
+++ b/conformance/results/pyre/aliases_newtype.toml
@@ -15,7 +15,6 @@ aliases_newtype.py:38:5 Invalid type parameters [24]: Non-generic type `GoodNewT
 aliases_newtype.py:44:37 Invalid inheritance [39]: `typing.Union[int, str]` is not a valid parent class.
 aliases_newtype.py:51:37 Invalid inheritance [39]: `typing_extensions.Literal[7]` is not a valid parent class.
 aliases_newtype.py:60:14 Too many arguments [19]: Call `NewType.__init__` expects 2 positional arguments, 3 were provided.
-aliases_newtype.py:62:37 Invalid inheritance [39]: `typing.Any` is not a valid parent class.
 """
 conformance_automated = "Fail"
 errors_diff = """
@@ -25,4 +24,5 @@ Line 32: Expected 1 errors
 Line 47: Expected 1 errors
 Line 49: Expected 1 errors
 Line 58: Expected 1 errors
+Line 62: Expected 1 errors
 """

--- a/conformance/results/pyre/aliases_recursive.toml
+++ b/conformance/results/pyre/aliases_recursive.toml
@@ -8,7 +8,7 @@ aliases_recursive.py:19:0 Incompatible variable type [9]: j4 is declared to have
 aliases_recursive.py:20:0 Incompatible variable type [9]: j5 is declared to have type `aliases_recursive.Json (resolves to Union[None, Dict[str, Json], List[Json], float, int, str])` but is used as type `List[complex]`.
 aliases_recursive.py:30:29 Undefined attribute [16]: `tuple` has no attribute `__getitem__`.
 aliases_recursive.py:33:4 Undefined or invalid type [11]: Annotation `RecursiveTuple` is not defined as a type.
-aliases_recursive.py:42:39 Incompatible parameter type [6]: In call `typing.GenericMeta.__getitem__`, for 1st positional argument, expected `Tuple[Type[Variable[_KT]], Type[Variable[_VT_co](covariant)]]` but got `Tuple[Type[str], str]`.
+aliases_recursive.py:42:39 Incompatible parameter type [6]: In call `typing.GenericMeta.__getitem__`, for 1st positional argument, expected `Tuple[Type[Variable[_KT]], Type[Variable[_VT_co]]]` but got `Tuple[Type[str], str]`.
 aliases_recursive.py:44:4 Undefined or invalid type [11]: Annotation `RecursiveMapping` is not defined as a type.
 aliases_recursive.py:58:20 Undefined attribute [16]: `list` has no attribute `__getitem__`.
 aliases_recursive.py:61:4 Undefined or invalid type [11]: Annotation `SpecializedTypeAlias1` is not defined as a type.
@@ -29,7 +29,7 @@ Line 63: Expected 1 errors
 Line 69: Expected 1 errors
 Line 30: Unexpected errors ['aliases_recursive.py:30:29 Undefined attribute [16]: `tuple` has no attribute `__getitem__`.']
 Line 33: Unexpected errors ['aliases_recursive.py:33:4 Undefined or invalid type [11]: Annotation `RecursiveTuple` is not defined as a type.']
-Line 42: Unexpected errors ['aliases_recursive.py:42:39 Incompatible parameter type [6]: In call `typing.GenericMeta.__getitem__`, for 1st positional argument, expected `Tuple[Type[Variable[_KT]], Type[Variable[_VT_co](covariant)]]` but got `Tuple[Type[str], str]`.']
+Line 42: Unexpected errors ['aliases_recursive.py:42:39 Incompatible parameter type [6]: In call `typing.GenericMeta.__getitem__`, for 1st positional argument, expected `Tuple[Type[Variable[_KT]], Type[Variable[_VT_co]]]` but got `Tuple[Type[str], str]`.']
 Line 44: Unexpected errors ['aliases_recursive.py:44:4 Undefined or invalid type [11]: Annotation `RecursiveMapping` is not defined as a type.']
 Line 58: Unexpected errors ['aliases_recursive.py:58:20 Undefined attribute [16]: `list` has no attribute `__getitem__`.']
 Line 61: Unexpected errors ['aliases_recursive.py:61:4 Undefined or invalid type [11]: Annotation `SpecializedTypeAlias1` is not defined as a type.']

--- a/conformance/results/pyre/aliases_type_statement.toml
+++ b/conformance/results/pyre/aliases_type_statement.toml
@@ -1,9 +1,36 @@
-conformant = "Unsupported"
+conformant = "Partial"
 notes = """
-Does not support `type` statement.
+Does not complain when a type alias cannot be used as a base class.
+Does not complain when a type alias cannot be used as a function.
+Does not complain when a type statement definition combines new and old TypeVars.
+Does not complain when a type statement definition uses old TypeVars.
+Does not properly support recursive aliases.
 """
 output = """
-aliases_type_statement.py:8:6 Parsing failure [404]: invalid syntax
+aliases_type_statement.py:37:0 Invalid type [31]: Expression `eval("".join(map(chr, [105, 110, 116])))` is not a valid type.
+aliases_type_statement.py:38:0 Invalid type [31]: Expression `[int, str]` is not a valid type.
+aliases_type_statement.py:39:0 Invalid type [31]: Expression `((int, str))` is not a valid type.
+aliases_type_statement.py:40:0 Invalid type [31]: Expression `comprehension(int for generators(generator(i in range(1) if )))` is not a valid type.
+aliases_type_statement.py:41:0 Invalid type [31]: Expression `{ "a":"b" }` is not a valid type.
+aliases_type_statement.py:42:0 Invalid type [31]: Expression `lambda () (int)()` is not a valid type.
+aliases_type_statement.py:43:0 Invalid type [31]: Expression `[int][0]` is not a valid type.
+aliases_type_statement.py:44:0 Invalid type [31]: Expression `int if 1 < 3 else str` is not a valid type.
+aliases_type_statement.py:45:0 Undefined or invalid type [11]: Annotation `var1` is not defined as a type.
+aliases_type_statement.py:46:0 Invalid type [31]: Expression `True` is not a valid type.
+aliases_type_statement.py:47:0 Invalid type [31]: Expression `1` is not a valid type.
+aliases_type_statement.py:48:0 Invalid type [31]: Expression `list or set` is not a valid type.
+aliases_type_statement.py:49:0 Invalid type [31]: Expression `f"{"int"}"` is not a valid type.
+aliases_type_statement.py:72:0 Incompatible variable type [9]: r1_1 is declared to have type `aliases_type_statement.RecursiveTypeAlias1 (resolves to Union[List[aliases_type_statement.RecursiveTypeAlias1 (resolves to Union[List[RecursiveTypeAlias1], T])], T])` but is used as type `int`.
+aliases_type_statement.py:73:0 Incompatible variable type [9]: r1_2 is declared to have type `aliases_type_statement.RecursiveTypeAlias1 (resolves to Union[List[aliases_type_statement.RecursiveTypeAlias1 (resolves to Union[List[RecursiveTypeAlias1], T])], T])` but is used as type `List[Union[List[int], int]]`.
+aliases_type_statement.py:77:6 Invalid type [31]: Expression `RecursiveTypeAlias2[(str, str, ...)]` is not a valid type.
+aliases_type_statement.py:78:6 Invalid type [31]: Expression `RecursiveTypeAlias2[(int, str, ...)]` is not a valid type.
+aliases_type_statement.py:79:6 Invalid type [31]: Expression `RecursiveTypeAlias2[(int, int, ...)]` is not a valid type.
+aliases_type_statement.py:80:6 Invalid type [31]: Expression `RecursiveTypeAlias2[(int, str, [int, str])]` is not a valid type.
+aliases_type_statement.py:82:0 Undefined or invalid type [11]: Annotation `RecursiveTypeAlias3` is not defined as a type.
+aliases_type_statement.py:84:0 Invalid type parameters [24]: Non-generic type `RecursiveTypeAlias4` cannot take parameters.
+aliases_type_statement.py:84:0 Undefined or invalid type [11]: Annotation `RecursiveTypeAlias4` is not defined as a type.
+aliases_type_statement.py:88:0 Undefined or invalid type [11]: Annotation `RecursiveTypeAlias7` is not defined as a type.
+aliases_type_statement.py:89:0 Undefined or invalid type [11]: Annotation `RecursiveTypeAlias6` is not defined as a type.
 """
 conformance_automated = "Fail"
 errors_diff = """
@@ -12,27 +39,12 @@ Line 19: Expected 1 errors
 Line 23: Expected 1 errors
 Line 26: Expected 1 errors
 Line 31: Expected 1 errors
-Line 37: Expected 1 errors
-Line 38: Expected 1 errors
-Line 39: Expected 1 errors
-Line 40: Expected 1 errors
-Line 41: Expected 1 errors
-Line 42: Expected 1 errors
-Line 43: Expected 1 errors
-Line 44: Expected 1 errors
-Line 45: Expected 1 errors
-Line 46: Expected 1 errors
-Line 47: Expected 1 errors
-Line 48: Expected 1 errors
-Line 49: Expected 1 errors
 Line 56: Expected 1 errors
 Line 62: Expected 1 errors
 Line 67: Expected 1 errors
-Line 77: Expected 1 errors
-Line 79: Expected 1 errors
-Line 82: Expected 1 errors
-Line 84: Expected 1 errors
 Lines 51, 52: Expected error (tag 'TA14')
-Lines 88, 89: Expected error (tag 'RTA6')
-Line 8: Unexpected errors ['aliases_type_statement.py:8:6 Parsing failure [404]: invalid syntax']
+Line 72: Unexpected errors ['aliases_type_statement.py:72:0 Incompatible variable type [9]: r1_1 is declared to have type `aliases_type_statement.RecursiveTypeAlias1 (resolves to Union[List[aliases_type_statement.RecursiveTypeAlias1 (resolves to Union[List[RecursiveTypeAlias1], T])], T])` but is used as type `int`.']
+Line 73: Unexpected errors ['aliases_type_statement.py:73:0 Incompatible variable type [9]: r1_2 is declared to have type `aliases_type_statement.RecursiveTypeAlias1 (resolves to Union[List[aliases_type_statement.RecursiveTypeAlias1 (resolves to Union[List[RecursiveTypeAlias1], T])], T])` but is used as type `List[Union[List[int], int]]`.']
+Line 78: Unexpected errors ['aliases_type_statement.py:78:6 Invalid type [31]: Expression `RecursiveTypeAlias2[(int, str, ...)]` is not a valid type.']
+Line 80: Unexpected errors ['aliases_type_statement.py:80:6 Invalid type [31]: Expression `RecursiveTypeAlias2[(int, str, [int, str])]` is not a valid type.']
 """

--- a/conformance/results/pyre/aliases_typealiastype.toml
+++ b/conformance/results/pyre/aliases_typealiastype.toml
@@ -6,11 +6,9 @@ output = """
 aliases_typealiastype.py:17:41 Undefined attribute [16]: `list` has no attribute `__getitem__`.
 aliases_typealiastype.py:22:13 Incompatible parameter type [6]: In call `typing.GenericMeta.__getitem__`, for 1st positional argument, expected `Tuple[typing.Any, Type[Variable[$synthetic_attribute_resolution_variable]]]` but got `Tuple[ParamSpec, TypeVar]`.
 aliases_typealiastype.py:22:65 Undefined attribute [16]: `tuple` has no attribute `__getitem__`.
-aliases_typealiastype.py:27:45 Undefined attribute [16]: `list` has no attribute `__getitem__`.
 aliases_typealiastype.py:32:6 Undefined attribute [16]: `TypeAliasType` has no attribute `other_attrib`.
 aliases_typealiastype.py:35:4 Undefined or invalid type [11]: Annotation `GoodAlias4` is not defined as a type.
 aliases_typealiastype.py:37:4 Undefined or invalid type [11]: Annotation `GoodAlias5` is not defined as a type.
-aliases_typealiastype.py:39:4 Invalid type [31]: Expression `GoodAlias5[(int, str, [int, str], *tuple[(int, str, int)])]` is not a valid type.
 """
 conformance_automated = "Fail"
 errors_diff = """
@@ -36,8 +34,6 @@ Line 63: Expected 1 errors
 Line 64: Expected 1 errors
 Line 17: Unexpected errors ['aliases_typealiastype.py:17:41 Undefined attribute [16]: `list` has no attribute `__getitem__`.']
 Line 22: Unexpected errors ['aliases_typealiastype.py:22:13 Incompatible parameter type [6]: In call `typing.GenericMeta.__getitem__`, for 1st positional argument, expected `Tuple[typing.Any, Type[Variable[$synthetic_attribute_resolution_variable]]]` but got `Tuple[ParamSpec, TypeVar]`.', 'aliases_typealiastype.py:22:65 Undefined attribute [16]: `tuple` has no attribute `__getitem__`.']
-Line 27: Unexpected errors ['aliases_typealiastype.py:27:45 Undefined attribute [16]: `list` has no attribute `__getitem__`.']
 Line 35: Unexpected errors ['aliases_typealiastype.py:35:4 Undefined or invalid type [11]: Annotation `GoodAlias4` is not defined as a type.']
 Line 37: Unexpected errors ['aliases_typealiastype.py:37:4 Undefined or invalid type [11]: Annotation `GoodAlias5` is not defined as a type.']
-Line 39: Unexpected errors ['aliases_typealiastype.py:39:4 Invalid type [31]: Expression `GoodAlias5[(int, str, [int, str], *tuple[(int, str, int)])]` is not a valid type.']
 """

--- a/conformance/results/pyre/aliases_variance.toml
+++ b/conformance/results/pyre/aliases_variance.toml
@@ -1,9 +1,9 @@
 conformant = "Pass"
 output = """
-aliases_variance.py:24:0 Invalid type variance [46]: The type variable `Variable[T_co](covariant)` is incompatible with parent class type variable `Variable[T]` because subclasses cannot use more permissive type variables than their superclasses.
-aliases_variance.py:28:0 Invalid type variance [46]: The type variable `Variable[T_co](covariant)` is incompatible with parent class type variable `Variable[T]` because subclasses cannot use more permissive type variables than their superclasses.
-aliases_variance.py:32:0 Invalid type variance [46]: The type variable `Variable[T_co](covariant)` is incompatible with parent class type variable `Variable[T]` because subclasses cannot use more permissive type variables than their superclasses.
-aliases_variance.py:44:0 Invalid type variance [46]: The type variable `Variable[T_contra](contravariant)` is incompatible with parent class type variable `Variable[T]` because subclasses cannot use more permissive type variables than their superclasses.
+aliases_variance.py:24:0 Invalid type variance [46]: The type variable `Variable[T_co](covariant)` is incompatible with parent class type variable `Variable[T](invariant)` because subclasses cannot use more permissive type variables than their superclasses.
+aliases_variance.py:28:0 Invalid type variance [46]: The type variable `Variable[T_co](covariant)` is incompatible with parent class type variable `Variable[T](invariant)` because subclasses cannot use more permissive type variables than their superclasses.
+aliases_variance.py:32:0 Invalid type variance [46]: The type variable `Variable[T_co](covariant)` is incompatible with parent class type variable `Variable[T](invariant)` because subclasses cannot use more permissive type variables than their superclasses.
+aliases_variance.py:44:0 Invalid type variance [46]: The type variable `Variable[T_contra](contravariant)` is incompatible with parent class type variable `Variable[T](invariant)` because subclasses cannot use more permissive type variables than their superclasses.
 """
 conformance_automated = "Pass"
 errors_diff = """

--- a/conformance/results/pyre/annotations_forward_refs.toml
+++ b/conformance/results/pyre/annotations_forward_refs.toml
@@ -13,7 +13,7 @@ annotations_forward_refs.py:42:8 Invalid type [31]: Expression `"[int, str]"` is
 annotations_forward_refs.py:43:8 Invalid type [31]: Expression `"(int, str)"` is not a valid type.
 annotations_forward_refs.py:44:8 Undefined or invalid type [11]: Annotation `comprehension(int for generators(generator($target$i in range(1) if )))` is not defined as a type.
 annotations_forward_refs.py:45:8 Invalid type [31]: Expression `"{  }"` is not a valid type.
-annotations_forward_refs.py:46:8 Undefined or invalid type [11]: Annotation `lambda () (int)()` is not defined as a type.
+annotations_forward_refs.py:46:8 Invalid type [31]: Expression `lambda () (int)()` is not a valid type.
 annotations_forward_refs.py:47:8 Invalid type [31]: Expression `[int][0]` is not a valid type.
 annotations_forward_refs.py:48:8 Invalid type [31]: Expression `"int if 1 < 3 else str"` is not a valid type.
 annotations_forward_refs.py:49:8 Undefined or invalid type [11]: Annotation `var1` is not defined as a type.
@@ -24,6 +24,7 @@ annotations_forward_refs.py:53:9 Invalid type [31]: Expression `"int or str"` is
 annotations_forward_refs.py:55:9 Undefined or invalid type [11]: Annotation `types` is not defined as a type.
 annotations_forward_refs.py:80:12 Undefined or invalid type [11]: Annotation `ClassF` is not defined as a type.
 annotations_forward_refs.py:87:7 Undefined or invalid type [11]: Annotation `ClassD.int` is not defined as a type.
+annotations_forward_refs.py:96:0 Assert type [70]: Expected `int` but got `unknown`.
 annotations_forward_refs.py:103:7 Undefined or invalid type [11]: Annotation `
 """
 conformance_automated = "Fail"
@@ -36,5 +37,6 @@ Line 54: Expected 1 errors
 Line 66: Expected 1 errors
 Line 89: Expected 1 errors
 Line 87: Unexpected errors ['annotations_forward_refs.py:87:7 Undefined or invalid type [11]: Annotation `ClassD.int` is not defined as a type.']
+Line 96: Unexpected errors ['annotations_forward_refs.py:96:0 Assert type [70]: Expected `int` but got `unknown`.']
 Line 103: Unexpected errors ['annotations_forward_refs.py:103:7 Undefined or invalid type [11]: Annotation `']
 """

--- a/conformance/results/pyre/annotations_generators.toml
+++ b/conformance/results/pyre/annotations_generators.toml
@@ -15,12 +15,12 @@ annotations_generators.py:92:4 Incompatible return type [7]: Expected `int` but 
 annotations_generators.py:118:4 Incompatible return type [7]: Expected `Iterator[B]` but got `Generator[A, None, typing.Any]`.
 annotations_generators.py:119:4 Incompatible return type [7]: Expected `Iterator[B]` but got `Generator[int, None, typing.Any]`.
 annotations_generators.py:135:4 Incompatible return type [7]: Expected `Generator[None, str, None]` but got `Generator[None, int, typing.Any]`.
-annotations_generators.py:182:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `typing.Callable[[], Coroutine[typing.Any, typing.Any, AsyncIterator[int]]]` but got `typing.Callable(generator29)[[], AsyncIterator[int]]`.
+annotations_generators.py:182:0 Assert type [70]: Expected `typing.Callable[[], Coroutine[typing.Any, typing.Any, AsyncIterator[int]]]` but got `typing.Callable(generator29)[[], AsyncIterator[int]]`.
 """
 conformance_automated = "Fail"
 errors_diff = """
 Line 51: Expected 1 errors
 Line 86: Expected 1 errors
 Line 88: Unexpected errors ['annotations_generators.py:88:4 Incompatible return type [7]: Expected `int` but got `Generator[typing.Any, typing.Any, int]`.']
-Line 182: Unexpected errors ['annotations_generators.py:182:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `typing.Callable[[], Coroutine[typing.Any, typing.Any, AsyncIterator[int]]]` but got `typing.Callable(generator29)[[], AsyncIterator[int]]`.']
+Line 182: Unexpected errors ['annotations_generators.py:182:0 Assert type [70]: Expected `typing.Callable[[], Coroutine[typing.Any, typing.Any, AsyncIterator[int]]]` but got `typing.Callable(generator29)[[], AsyncIterator[int]]`.']
 """

--- a/conformance/results/pyre/annotations_methods.toml
+++ b/conformance/results/pyre/annotations_methods.toml
@@ -3,7 +3,7 @@ notes = """
 Type evaluation differs from other type checkers because of ambiguity in the spec related to method bindings.
 """
 output = """
-annotations_methods.py:42:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `A` but got `B`.
+annotations_methods.py:42:0 Assert type [70]: Expected `A` but got `B`.
 """
 conformance_automated = "Pass"
 errors_diff = """

--- a/conformance/results/pyre/callables_annotation.toml
+++ b/conformance/results/pyre/callables_annotation.toml
@@ -18,6 +18,7 @@ callables_annotation.py:59:4 Invalid type [31]: Expression `typing.Callable[([..
 callables_annotation.py:89:5 Invalid type [31]: Expression `typing.Callable[(typing.Concatenate[(int, ...)], str)]` is not a valid type.
 callables_annotation.py:145:8 Invalid type [31]: Expression `typing.Callable[(typing.Concatenate[(int, ...)], None)]` is not a valid type.
 callables_annotation.py:151:9 Invalid type [31]: Expression `typing.Callable[(typing.Concatenate[(int, ...)], None)]` is not a valid type.
+callables_annotation.py:155:4 Incompatible variable type [9]: ok9 is declared to have type `Proto4[[...]]` but is used as type `Proto3`.
 callables_annotation.py:156:4 Incompatible variable type [9]: ok10 is declared to have type `Proto3` but is used as type `Proto4[[...]]`.
 callables_annotation.py:157:4 Incompatible variable type [9]: ok11 is declared to have type `Proto6` but is used as type `Proto7`.
 callables_annotation.py:159:4 Incompatible variable type [9]: err1 is declared to have type `Proto5[typing.Any]` but is used as type `Proto8`.
@@ -39,6 +40,7 @@ Line 93: Expected 1 errors
 Line 89: Unexpected errors ['callables_annotation.py:89:5 Invalid type [31]: Expression `typing.Callable[(typing.Concatenate[(int, ...)], str)]` is not a valid type.']
 Line 145: Unexpected errors ['callables_annotation.py:145:8 Invalid type [31]: Expression `typing.Callable[(typing.Concatenate[(int, ...)], None)]` is not a valid type.']
 Line 151: Unexpected errors ['callables_annotation.py:151:9 Invalid type [31]: Expression `typing.Callable[(typing.Concatenate[(int, ...)], None)]` is not a valid type.']
+Line 155: Unexpected errors ['callables_annotation.py:155:4 Incompatible variable type [9]: ok9 is declared to have type `Proto4[[...]]` but is used as type `Proto3`.']
 Line 156: Unexpected errors ['callables_annotation.py:156:4 Incompatible variable type [9]: ok10 is declared to have type `Proto3` but is used as type `Proto4[[...]]`.']
 Line 157: Unexpected errors ['callables_annotation.py:157:4 Incompatible variable type [9]: ok11 is declared to have type `Proto6` but is used as type `Proto7`.']
 Line 166: Unexpected errors ['callables_annotation.py:166:0 Incompatible variable type [9]: Callback1 is declared to have type `TypeAlias` but is used as type `Type[typing.Callable[..., str]]`.']

--- a/conformance/results/pyre/callables_kwargs.toml
+++ b/conformance/results/pyre/callables_kwargs.toml
@@ -1,31 +1,21 @@
-conformant = "Unsupported"
+conformant = "Pass"
 notes = """
-Does not understand Unpack in the context of **kwargs annotation.
 """
 output = """
-callables_kwargs.py:22:20 Undefined or invalid type [11]: Annotation `Unpack` is not defined as a type.
-callables_kwargs.py:24:4 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `typing.Any`.
-callables_kwargs.py:32:8 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `str` but got `typing.Any`.
-callables_kwargs.py:35:4 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `str` but got `typing.Any`.
-callables_kwargs.py:52:4 Too many arguments [19]: Call `func1` expects 1 positional argument, 4 were provided.
-callables_kwargs.py:62:12 Incompatible parameter type [6]: In call `func2`, for 1st positional argument, expected `str` but got `object`.
-callables_kwargs.py:64:10 Incompatible parameter type [6]: In call `func2`, for 1st positional argument, expected `str` but got `int`.
-callables_kwargs.py:65:18 Incompatible parameter type [6]: In call `func2`, for 2nd positional argument, expected `str` but got `object`.
-callables_kwargs.py:122:20 Invalid type variable [34]: The type variable `Variable[T (bound to callables_kwargs.TD2)]` isn't present in the function's parameters.
+callables_kwargs.py:46:4 Missing argument [20]: Call `func1` expects argument `v3`.
+callables_kwargs.py:51:4 Unexpected keyword [28]: Unexpected keyword argument `v4` to call `func1`.
+callables_kwargs.py:52:4 Too many arguments [19]: Call `func1` expects 0 positional arguments, 3 were provided.
+callables_kwargs.py:58:12 Incompatible parameter type [6]: In call `func1`, for 1st positional argument, expected `TD2` but got `Dict[str, str]`.
+callables_kwargs.py:61:12 Incompatible parameter type [6]: In call `func1`, for 1st positional argument, expected `TD2` but got `Dict[str, Union[int, str]]`.
+callables_kwargs.py:63:4 Unexpected keyword [28]: Unexpected keyword argument `v1` to call `func1`.
+callables_kwargs.py:64:4 Unexpected keyword [28]: Unexpected keyword argument `v3` to call `func2`.
+callables_kwargs.py:65:4 Unexpected keyword [28]: Unexpected keyword argument `v1` to call `func2`.
+callables_kwargs.py:101:0 Incompatible variable type [9]: v3 is declared to have type `TDProtocol3` but is used as type `typing.Callable(func1)[[Keywords(Unpack[TD2])], None]`.
+callables_kwargs.py:102:0 Incompatible variable type [9]: v4 is declared to have type `TDProtocol4` but is used as type `typing.Callable(func1)[[Keywords(Unpack[TD2])], None]`.
+callables_kwargs.py:103:0 Incompatible variable type [9]: v5 is declared to have type `TDProtocol5` but is used as type `typing.Callable(func1)[[Keywords(Unpack[TD2])], None]`.
+callables_kwargs.py:111:21 Duplicate parameter [65]: Duplicate parameter name `v1`.
+callables_kwargs.py:122:12 Invalid type [31]: `Unpack` in kwargs may only be used with typed dictionaries. `Variable[T (bound to TD2)]` is not a typed dictionary.
 """
-conformance_automated = "Fail"
+conformance_automated = "Pass"
 errors_diff = """
-Line 46: Expected 1 errors
-Line 51: Expected 1 errors
-Line 58: Expected 1 errors
-Line 63: Expected 1 errors
-Line 101: Expected 1 errors
-Line 102: Expected 1 errors
-Line 103: Expected 1 errors
-Line 111: Expected 1 errors
-Line 22: Unexpected errors ['callables_kwargs.py:22:20 Undefined or invalid type [11]: Annotation `Unpack` is not defined as a type.']
-Line 24: Unexpected errors ['callables_kwargs.py:24:4 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `typing.Any`.']
-Line 32: Unexpected errors ['callables_kwargs.py:32:8 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `str` but got `typing.Any`.']
-Line 35: Unexpected errors ['callables_kwargs.py:35:4 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `str` but got `typing.Any`.']
-Line 62: Unexpected errors ['callables_kwargs.py:62:12 Incompatible parameter type [6]: In call `func2`, for 1st positional argument, expected `str` but got `object`.']
 """

--- a/conformance/results/pyre/callables_protocol.toml
+++ b/conformance/results/pyre/callables_protocol.toml
@@ -21,14 +21,12 @@ callables_protocol.py:186:4 Incompatible attribute type [8]: Attribute `other_at
 callables_protocol.py:187:4 Undefined attribute [16]: `Proto9` has no attribute `xxx`.
 callables_protocol.py:197:6 Undefined attribute [16]: `Proto9` has no attribute `other_attribute2`.
 callables_protocol.py:216:0 Incompatible variable type [9]: cb10 is declared to have type `Proto10` but is used as type `typing.Callable(cb10_good)[[], None]`.
-callables_protocol.py:259:0 Incompatible variable type [9]: cb12 is declared to have type `Proto12` but is used as type `typing.Callable(cb12_good2)[[Variable(typing.Any), Keywords(typing.Any)], None]`.
 callables_protocol.py:260:0 Incompatible variable type [9]: cb12 is declared to have type `Proto12` but is used as type `typing.Callable(cb12_bad1)[[Variable(typing.Any), KeywordOnly(kwarg0, typing.Any)], None]`.
+callables_protocol.py:284:0 Incompatible variable type [9]: cb13_2 is declared to have type `Proto13_Default` but is used as type `typing.Callable(cb13_no_default)[[Named(path, str)], str]`.
+callables_protocol.py:311:0 Incompatible variable type [9]: cb14_2 is declared to have type `Proto14_Default` but is used as type `typing.Callable(cb14_no_default)[[KeywordOnly(path, str)], str]`.
 """
 conformance_automated = "Fail"
 errors_diff = """
 Line 238: Expected 1 errors
-Line 284: Expected 1 errors
-Line 311: Expected 1 errors
 Line 216: Unexpected errors ['callables_protocol.py:216:0 Incompatible variable type [9]: cb10 is declared to have type `Proto10` but is used as type `typing.Callable(cb10_good)[[], None]`.']
-Line 259: Unexpected errors ['callables_protocol.py:259:0 Incompatible variable type [9]: cb12 is declared to have type `Proto12` but is used as type `typing.Callable(cb12_good2)[[Variable(typing.Any), Keywords(typing.Any)], None]`.']
 """

--- a/conformance/results/pyre/callables_subtyping.toml
+++ b/conformance/results/pyre/callables_subtyping.toml
@@ -4,11 +4,8 @@ Rejects standard parameter as incompatible with keyword-only parameter.
 Rejects use of Callable with ParamSpec in TypeAlias definition.
 """
 errors_diff = """
-Line 236: Expected 1 errors
+Line 196: Expected 1 errors
 Line 57: Unexpected errors ['callables_subtyping.py:57:4 Incompatible variable type [9]: f5 is declared to have type `KwOnly2` but is used as type `Standard2`.']
-Line 188: Unexpected errors ['callables_subtyping.py:188:4 Incompatible variable type [9]: f2 is declared to have type `KwOnly6` but is used as type `IntStrKwargs6`.']
-Line 189: Unexpected errors ['callables_subtyping.py:189:4 Incompatible variable type [9]: f3 is declared to have type `KwOnly6` but is used as type `StrKwargs6`.']
-Line 192: Unexpected errors ['callables_subtyping.py:192:4 Incompatible variable type [9]: f6 is declared to have type `StrKwargs6` but is used as type `IntStrKwargs6`.']
 Line 208: Unexpected errors ['callables_subtyping.py:208:0 Incompatible variable type [9]: TypeAliasWithP is declared to have type `TypeAlias` but is used as type `Type[typing.Callable[..., Variable[$synthetic_attribute_resolution_variable]]]`.', 'callables_subtyping.py:208:37 Incompatible parameter type [6]: In call `typing.GenericMeta.__getitem__`, for 1st positional argument, expected `Tuple[typing.Any, Type[Variable[$synthetic_attribute_resolution_variable]]]` but got `Tuple[ParamSpec, None]`.']
 Line 211: Unexpected errors ['callables_subtyping.py:211:39 Undefined or invalid type [11]: Annotation `TypeAliasWithP` is not defined as a type.']
 Line 253: Unexpected errors ['callables_subtyping.py:253:4 Missing overload implementation [42]: Overloaded function `Overloaded9.__call__` must have an implementation.']
@@ -36,18 +33,15 @@ callables_subtyping.py:151:4 Incompatible variable type [9]: f3 is declared to h
 callables_subtyping.py:154:4 Incompatible variable type [9]: f5 is declared to have type `FloatKwargs5` but is used as type `NoKwargs5`.
 callables_subtyping.py:155:4 Incompatible variable type [9]: f6 is declared to have type `FloatKwargs5` but is used as type `IntKwargs5`.
 callables_subtyping.py:187:4 Incompatible variable type [9]: f1 is declared to have type `KwOnly6` but is used as type `IntKwargs6`.
-callables_subtyping.py:188:4 Incompatible variable type [9]: f2 is declared to have type `KwOnly6` but is used as type `IntStrKwargs6`.
-callables_subtyping.py:189:4 Incompatible variable type [9]: f3 is declared to have type `KwOnly6` but is used as type `StrKwargs6`.
 callables_subtyping.py:190:4 Incompatible variable type [9]: f4 is declared to have type `IntStrKwargs6` but is used as type `StrKwargs6`.
 callables_subtyping.py:191:4 Incompatible variable type [9]: f5 is declared to have type `IntStrKwargs6` but is used as type `IntKwargs6`.
-callables_subtyping.py:192:4 Incompatible variable type [9]: f6 is declared to have type `StrKwargs6` but is used as type `IntStrKwargs6`.
 callables_subtyping.py:193:4 Incompatible variable type [9]: f7 is declared to have type `StrKwargs6` but is used as type `IntKwargs6`.
 callables_subtyping.py:195:4 Incompatible variable type [9]: f9 is declared to have type `IntKwargs6` but is used as type `StrKwargs6`.
-callables_subtyping.py:196:4 Incompatible variable type [9]: f10 is declared to have type `Standard6` but is used as type `IntStrKwargs6`.
 callables_subtyping.py:197:4 Incompatible variable type [9]: f11 is declared to have type `Standard6` but is used as type `StrKwargs6`.
 callables_subtyping.py:208:0 Incompatible variable type [9]: TypeAliasWithP is declared to have type `TypeAlias` but is used as type `Type[typing.Callable[..., Variable[$synthetic_attribute_resolution_variable]]]`.
 callables_subtyping.py:208:37 Incompatible parameter type [6]: In call `typing.GenericMeta.__getitem__`, for 1st positional argument, expected `Tuple[typing.Any, Type[Variable[$synthetic_attribute_resolution_variable]]]` but got `Tuple[ParamSpec, None]`.
 callables_subtyping.py:211:39 Undefined or invalid type [11]: Annotation `TypeAliasWithP` is not defined as a type.
+callables_subtyping.py:236:4 Incompatible variable type [9]: f1 is declared to have type `DefaultArg8` but is used as type `NoDefaultArg8`.
 callables_subtyping.py:237:4 Incompatible variable type [9]: f2 is declared to have type `DefaultArg8` but is used as type `NoX8`.
 callables_subtyping.py:240:4 Incompatible variable type [9]: f4 is declared to have type `NoDefaultArg8` but is used as type `NoX8`.
 callables_subtyping.py:243:4 Incompatible variable type [9]: f6 is declared to have type `NoX8` but is used as type `NoDefaultArg8`.

--- a/conformance/results/pyre/classes_classvar.toml
+++ b/conformance/results/pyre/classes_classvar.toml
@@ -17,7 +17,7 @@ classes_classvar.py:40:13 Unbound name [10]: Name `var` is used but not defined 
 classes_classvar.py:52:4 Incompatible attribute type [8]: Attribute `bad8` declared in class `ClassA` has type `List[str]` but is used as type `Dict[Variable[_KT], Variable[_VT]]`.
 classes_classvar.py:65:8 Undefined attribute [16]: `ClassA` has no attribute `xx`.
 classes_classvar.py:68:8 Incompatible return type [7]: Expected `CV[int]` but got `int`.
-classes_classvar.py:78:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `float` but got `typing.Any`.
+classes_classvar.py:78:0 Assert type [70]: Expected `float` but got `typing.Any`.
 classes_classvar.py:105:0 Invalid assignment [41]: Assigning to class variable through instance, did you mean to assign to `Starship.stats` instead?
 classes_classvar.py:134:0 Incompatible variable type [9]: a is declared to have type `ProtoA` but is used as type `ProtoAImpl`.
 """
@@ -34,5 +34,5 @@ Line 67: Expected 1 errors
 Line 71: Expected 1 errors
 Line 72: Expected 1 errors
 Line 68: Unexpected errors ['classes_classvar.py:68:8 Incompatible return type [7]: Expected `CV[int]` but got `int`.']
-Line 78: Unexpected errors ['classes_classvar.py:78:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `float` but got `typing.Any`.']
+Line 78: Unexpected errors ['classes_classvar.py:78:0 Assert type [70]: Expected `float` but got `typing.Any`.']
 """

--- a/conformance/results/pyre/classes_override.toml
+++ b/conformance/results/pyre/classes_override.toml
@@ -1,6 +1,5 @@
-conformant = "Partial"
+conformant = "Pass"
 notes = """
-Does not allow Any as a base class, leading to false positives.
 """
 output = """
 classes_override.py:53:4 Invalid override [40]: `classes_override.ChildA.method3` is decorated with @override, but no method of the same name exists in superclasses of `ChildA`.
@@ -9,11 +8,7 @@ classes_override.py:65:4 Invalid override [40]: `classes_override.ChildA.method4
 classes_override.py:79:4 Invalid override [40]: `classes_override.ChildA.static_method1` is decorated with @override, but no method of the same name exists in superclasses of `ChildA`.
 classes_override.py:84:4 Invalid override [40]: `classes_override.ChildA.class_method1` is decorated with @override, but no method of the same name exists in superclasses of `ChildA`.
 classes_override.py:89:4 Invalid override [40]: `classes_override.ChildA.property1` is decorated with @override, but no method of the same name exists in superclasses of `ChildA`.
-classes_override.py:95:14 Invalid inheritance [39]: `typing.Any` is not a valid parent class.
-classes_override.py:101:4 Invalid override [40]: `classes_override.ChildB.method1` is decorated with @override, but no method of the same name exists in superclasses of `ChildB`.
 """
-conformance_automated = "Fail"
+conformance_automated = "Pass"
 errors_diff = """
-Line 95: Unexpected errors ['classes_override.py:95:14 Invalid inheritance [39]: `typing.Any` is not a valid parent class.']
-Line 101: Unexpected errors ['classes_override.py:101:4 Invalid override [40]: `classes_override.ChildB.method1` is decorated with @override, but no method of the same name exists in superclasses of `ChildB`.']
 """

--- a/conformance/results/pyre/constructors_call_init.toml
+++ b/conformance/results/pyre/constructors_call_init.toml
@@ -3,24 +3,26 @@ notes = """
 Does not infer type of Self for self parameter of __init__ method.
 Does not report errors during binding to self parameter of __init__ method.
 Does not reject use of class-scoped type variables in annotation of self parameter in __init__ method.
+Incorrectly raises Incompatible overload type errors.
+Incorrectly raises compatibility type errors.
 """
 conformance_automated = "Fail"
 errors_diff = """
 Line 42: Expected 1 errors
 Line 56: Expected 1 errors
 Line 107: Expected 1 errors
-Line 24: Unexpected errors ['constructors_call_init.py:24:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Class1[int]` but got `Class1[typing_extensions.Literal[1]]`.']
+Line 24: Unexpected errors ['constructors_call_init.py:24:0 Assert type [70]: Expected `Class1[int]` but got `Class1[typing_extensions.Literal[1]]`.']
 Line 61: Unexpected errors ['constructors_call_init.py:61:4 Incompatible overload [43]: The implementation of `Class5.__init__` does not accept all possible arguments of overload defined on line `61`.']
 Line 63: Unexpected errors ['constructors_call_init.py:63:4 Incompatible overload [43]: The implementation of `Class5.__init__` does not accept all possible arguments of overload defined on line `63`.']
-Line 91: Unexpected errors ["constructors_call_init.py:91:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Class6[int, str]` but got `Class6[typing_extensions.Literal[0], typing_extensions.Literal['']]`."]
-Line 99: Unexpected errors ["constructors_call_init.py:99:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Class7[str, int]` but got `Class7[typing_extensions.Literal[''], typing_extensions.Literal[0]]`."]
+Line 91: Unexpected errors ["constructors_call_init.py:91:0 Assert type [70]: Expected `Class6[int, str]` but got `Class6[typing_extensions.Literal[0], typing_extensions.Literal['']]`."]
+Line 99: Unexpected errors ["constructors_call_init.py:99:0 Assert type [70]: Expected `Class7[str, int]` but got `Class7[typing_extensions.Literal[''], typing_extensions.Literal[0]]`."]
 """
 output = """
 constructors_call_init.py:21:12 Incompatible parameter type [6]: In call `Class1.__init__`, for 1st positional argument, expected `int` but got `float`.
-constructors_call_init.py:24:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Class1[int]` but got `Class1[typing_extensions.Literal[1]]`.
+constructors_call_init.py:24:0 Assert type [70]: Expected `Class1[int]` but got `Class1[typing_extensions.Literal[1]]`.
 constructors_call_init.py:61:4 Incompatible overload [43]: The implementation of `Class5.__init__` does not accept all possible arguments of overload defined on line `61`.
 constructors_call_init.py:63:4 Incompatible overload [43]: The implementation of `Class5.__init__` does not accept all possible arguments of overload defined on line `63`.
-constructors_call_init.py:91:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Class6[int, str]` but got `Class6[typing_extensions.Literal[0], typing_extensions.Literal['']]`.
-constructors_call_init.py:99:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Class7[str, int]` but got `Class7[typing_extensions.Literal[''], typing_extensions.Literal[0]]`.
+constructors_call_init.py:91:0 Assert type [70]: Expected `Class6[int, str]` but got `Class6[typing_extensions.Literal[0], typing_extensions.Literal['']]`.
+constructors_call_init.py:99:0 Assert type [70]: Expected `Class7[str, int]` but got `Class7[typing_extensions.Literal[''], typing_extensions.Literal[0]]`.
 constructors_call_init.py:130:0 Too many arguments [19]: Call `object.__init__` expects 0 positional arguments, 1 was provided.
 """

--- a/conformance/results/pyre/constructors_call_new.toml
+++ b/conformance/results/pyre/constructors_call_new.toml
@@ -2,29 +2,30 @@ conformant = "Partial"
 notes = """
 Does not support __new__ return type that is not a subclass of the class being constructed.
 Does not report errors during binding to cls parameter of __new__ method.
+Incorrectly raises compatibility type errors.
 """
 conformance_automated = "Fail"
 errors_diff = """
 Line 145: Expected 1 errors
-Line 23: Unexpected errors ['constructors_call_new.py:23:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Class1[int]` but got `Class1[typing_extensions.Literal[1]]`.']
-Line 35: Unexpected errors ['constructors_call_new.py:35:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Class2[int]` but got `Class2[typing_extensions.Literal[1]]`.']
-Line 36: Unexpected errors ["constructors_call_new.py:36:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Class2[str]` but got `Class2[typing_extensions.Literal['']]`."]
-Line 49: Unexpected errors ['constructors_call_new.py:49:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `Class3`.', 'constructors_call_new.py:49:12 Missing argument [20]: Call `Class3.__init__` expects argument `x`.']
-Line 64: Unexpected errors ['constructors_call_new.py:64:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `typing.Any` but got `Class4`.', 'constructors_call_new.py:64:12 Missing argument [20]: Call `Class4.__init__` expects argument `x`.']
-Line 76: Unexpected errors ['constructors_call_new.py:76:4 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `NoReturn` but got `Class5`.', 'constructors_call_new.py:76:16 Missing argument [20]: Call `Class5.__init__` expects argument `x`.']
-Line 89: Unexpected errors ['constructors_call_new.py:89:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Union[Class6, int]` but got `Class6`.', 'constructors_call_new.py:89:12 Missing argument [20]: Call `Class6.__init__` expects argument `x`.']
+Line 23: Unexpected errors ['constructors_call_new.py:23:0 Assert type [70]: Expected `Class1[int]` but got `Class1[typing_extensions.Literal[1]]`.']
+Line 35: Unexpected errors ['constructors_call_new.py:35:0 Assert type [70]: Expected `Class2[int]` but got `Class2[typing_extensions.Literal[1]]`.']
+Line 36: Unexpected errors ["constructors_call_new.py:36:0 Assert type [70]: Expected `Class2[str]` but got `Class2[typing_extensions.Literal['']]`."]
+Line 49: Unexpected errors ['constructors_call_new.py:49:0 Assert type [70]: Expected `int` but got `Class3`.', 'constructors_call_new.py:49:12 Missing argument [20]: Call `Class3.__init__` expects argument `x`.']
+Line 64: Unexpected errors ['constructors_call_new.py:64:0 Assert type [70]: Expected `typing.Any` but got `Class4`.', 'constructors_call_new.py:64:12 Missing argument [20]: Call `Class4.__init__` expects argument `x`.']
+Line 76: Unexpected errors ['constructors_call_new.py:76:4 Assert type [70]: Expected `NoReturn` but got `Class5`.', 'constructors_call_new.py:76:16 Missing argument [20]: Call `Class5.__init__` expects argument `x`.']
+Line 89: Unexpected errors ['constructors_call_new.py:89:0 Assert type [70]: Expected `Union[Class6, int]` but got `Class6`.', 'constructors_call_new.py:89:12 Missing argument [20]: Call `Class6.__init__` expects argument `x`.']
 """
 output = """
 constructors_call_new.py:21:12 Incompatible parameter type [6]: In call `Class1.__new__`, for 1st positional argument, expected `int` but got `float`.
-constructors_call_new.py:23:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Class1[int]` but got `Class1[typing_extensions.Literal[1]]`.
-constructors_call_new.py:35:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Class2[int]` but got `Class2[typing_extensions.Literal[1]]`.
-constructors_call_new.py:36:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Class2[str]` but got `Class2[typing_extensions.Literal['']]`.
-constructors_call_new.py:49:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `Class3`.
+constructors_call_new.py:23:0 Assert type [70]: Expected `Class1[int]` but got `Class1[typing_extensions.Literal[1]]`.
+constructors_call_new.py:35:0 Assert type [70]: Expected `Class2[int]` but got `Class2[typing_extensions.Literal[1]]`.
+constructors_call_new.py:36:0 Assert type [70]: Expected `Class2[str]` but got `Class2[typing_extensions.Literal['']]`.
+constructors_call_new.py:49:0 Assert type [70]: Expected `int` but got `Class3`.
 constructors_call_new.py:49:12 Missing argument [20]: Call `Class3.__init__` expects argument `x`.
-constructors_call_new.py:64:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `typing.Any` but got `Class4`.
+constructors_call_new.py:64:0 Assert type [70]: Expected `typing.Any` but got `Class4`.
 constructors_call_new.py:64:12 Missing argument [20]: Call `Class4.__init__` expects argument `x`.
-constructors_call_new.py:76:4 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `NoReturn` but got `Class5`.
+constructors_call_new.py:76:4 Assert type [70]: Expected `NoReturn` but got `Class5`.
 constructors_call_new.py:76:16 Missing argument [20]: Call `Class5.__init__` expects argument `x`.
-constructors_call_new.py:89:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Union[Class6, int]` but got `Class6`.
+constructors_call_new.py:89:0 Assert type [70]: Expected `Union[Class6, int]` but got `Class6`.
 constructors_call_new.py:89:12 Missing argument [20]: Call `Class6.__init__` expects argument `x`.
 """

--- a/conformance/results/pyre/constructors_callable.toml
+++ b/conformance/results/pyre/constructors_callable.toml
@@ -4,6 +4,7 @@ Does not generate a union type for __new__ and __init__ when converting class to
 Does not ignore __init__ based on __new__ return type when converting class to callable.
 Does not support __new__ return type that is different from class being constructed.
 Does not use annotated type of self in __init__ method to generate return type of callable.
+Incorrectly raises incompatibility type errors.
 """
 conformance_automated = "Fail"
 errors_diff = """
@@ -11,17 +12,17 @@ Line 127: Expected 1 errors
 Line 144: Expected 1 errors
 Line 184: Expected 1 errors
 Line 195: Expected 1 errors
-Line 78: Unexpected errors ['constructors_callable.py:78:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `Class4`.']
-Line 126: Unexpected errors ['constructors_callable.py:126:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Class6Proxy` but got `Class6`.', 'constructors_callable.py:126:12 Missing argument [20]: PositionalOnly call expects argument `x`.']
-Line 143: Unexpected errors ['constructors_callable.py:143:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `typing.Any` but got `Class6Any`.', 'constructors_callable.py:143:12 Missing argument [20]: PositionalOnly call expects argument `x`.']
+Line 78: Unexpected errors ['constructors_callable.py:78:0 Assert type [70]: Expected `int` but got `Class4`.']
+Line 126: Unexpected errors ['constructors_callable.py:126:0 Assert type [70]: Expected `Class6Proxy` but got `Class6`.', 'constructors_callable.py:126:12 Missing argument [20]: PositionalOnly call expects argument `x`.']
+Line 143: Unexpected errors ['constructors_callable.py:143:0 Assert type [70]: Expected `typing.Any` but got `Class6Any`.', 'constructors_callable.py:143:12 Missing argument [20]: PositionalOnly call expects argument `x`.']
 Line 153: Unexpected errors ['constructors_callable.py:153:4 Incompatible overload [43]: The implementation of `Class7.__init__` does not accept all possible arguments of overload defined on line `153`.']
 Line 155: Unexpected errors ['constructors_callable.py:155:4 Incompatible overload [43]: The implementation of `Class7.__init__` does not accept all possible arguments of overload defined on line `155`.']
-Line 164: Unexpected errors ['constructors_callable.py:164:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Class7[int]` but got `Class7[typing.Any]`.']
-Line 165: Unexpected errors ['constructors_callable.py:165:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Class7[str]` but got `Class7[typing.Any]`.', 'constructors_callable.py:165:15 Incompatible parameter type [6]: In anonymous call, for 1st positional argument, expected `int` but got `str`.']
+Line 164: Unexpected errors ['constructors_callable.py:164:0 Assert type [70]: Expected `Class7[int]` but got `Class7[typing.Any]`.']
+Line 165: Unexpected errors ['constructors_callable.py:165:0 Assert type [70]: Expected `Class7[str]` but got `Class7[typing.Any]`.', 'constructors_callable.py:165:15 Incompatible parameter type [6]: In anonymous call, for 1st positional argument, expected `int` but got `str`.']
 Line 181: Unexpected errors ['constructors_callable.py:181:22 Incompatible parameter type [6]: In call `accepts_callable`, for 1st positional argument, expected `typing.Callable[constructors_callable.P, Variable[R]]` but got `Type[Class8]`.']
-Line 183: Unexpected errors ['constructors_callable.py:183:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Class8[str]` but got `typing.Any`.']
+Line 183: Unexpected errors ['constructors_callable.py:183:0 Assert type [70]: Expected `Class8[str]` but got `typing.Any`.']
 Line 192: Unexpected errors ['constructors_callable.py:192:22 Incompatible parameter type [6]: In call `accepts_callable`, for 1st positional argument, expected `typing.Callable[constructors_callable.P, Variable[R]]` but got `Type[Class9]`.']
-Line 194: Unexpected errors ['constructors_callable.py:194:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Class9` but got `typing.Any`.']
+Line 194: Unexpected errors ['constructors_callable.py:194:0 Assert type [70]: Expected `Class9` but got `typing.Any`.']
 """
 output = """
 constructors_callable.py:36:0 Revealed type [-1]: Revealed type for `r1` is `typing.Callable[[Named(x, int)], Class1]`.
@@ -34,26 +35,26 @@ constructors_callable.py:65:0 Missing argument [20]: PositionalOnly call expects
 constructors_callable.py:66:0 Unexpected keyword [28]: Unexpected keyword argument `y` to anonymous call.
 constructors_callable.py:67:0 Too many arguments [19]: PositionalOnly call expects 1 positional argument, 2 were provided.
 constructors_callable.py:77:0 Revealed type [-1]: Revealed type for `r4` is `typing.Callable[[Named(x, int)], Class4]`.
-constructors_callable.py:78:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `Class4`.
+constructors_callable.py:78:0 Assert type [70]: Expected `int` but got `Class4`.
 constructors_callable.py:79:0 Missing argument [20]: PositionalOnly call expects argument `x`.
 constructors_callable.py:80:0 Unexpected keyword [28]: Unexpected keyword argument `y` to anonymous call.
 constructors_callable.py:97:0 Revealed type [-1]: Revealed type for `r5` is `typing.Callable[[Variable(typing.Any), Keywords(typing.Any)], NoReturn]`.
 constructors_callable.py:125:0 Revealed type [-1]: Revealed type for `r6` is `typing.Callable[[Named(x, int)], Class6]`.
-constructors_callable.py:126:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Class6Proxy` but got `Class6`.
+constructors_callable.py:126:0 Assert type [70]: Expected `Class6Proxy` but got `Class6`.
 constructors_callable.py:126:12 Missing argument [20]: PositionalOnly call expects argument `x`.
 constructors_callable.py:142:0 Revealed type [-1]: Revealed type for `r6_any` is `typing.Callable[[Named(x, int)], Class6Any]`.
-constructors_callable.py:143:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `typing.Any` but got `Class6Any`.
+constructors_callable.py:143:0 Assert type [70]: Expected `typing.Any` but got `Class6Any`.
 constructors_callable.py:143:12 Missing argument [20]: PositionalOnly call expects argument `x`.
 constructors_callable.py:153:4 Incompatible overload [43]: The implementation of `Class7.__init__` does not accept all possible arguments of overload defined on line `153`.
 constructors_callable.py:155:4 Incompatible overload [43]: The implementation of `Class7.__init__` does not accept all possible arguments of overload defined on line `155`.
 constructors_callable.py:161:0 Revealed type [-1]: Revealed type for `r7` is `typing.Callable[[Named(x, int)], Class7[typing.Any]]`.
-constructors_callable.py:164:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Class7[int]` but got `Class7[typing.Any]`.
-constructors_callable.py:165:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Class7[str]` but got `Class7[typing.Any]`.
+constructors_callable.py:164:0 Assert type [70]: Expected `Class7[int]` but got `Class7[typing.Any]`.
+constructors_callable.py:165:0 Assert type [70]: Expected `Class7[str]` but got `Class7[typing.Any]`.
 constructors_callable.py:165:15 Incompatible parameter type [6]: In anonymous call, for 1st positional argument, expected `int` but got `str`.
 constructors_callable.py:181:22 Incompatible parameter type [6]: In call `accepts_callable`, for 1st positional argument, expected `typing.Callable[constructors_callable.P, Variable[R]]` but got `Type[Class8]`.
 constructors_callable.py:182:0 Revealed type [-1]: Revealed type for `r8` is `typing.Callable[..., typing.Any]`.
-constructors_callable.py:183:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Class8[str]` but got `typing.Any`.
+constructors_callable.py:183:0 Assert type [70]: Expected `Class8[str]` but got `typing.Any`.
 constructors_callable.py:192:22 Incompatible parameter type [6]: In call `accepts_callable`, for 1st positional argument, expected `typing.Callable[constructors_callable.P, Variable[R]]` but got `Type[Class9]`.
 constructors_callable.py:193:0 Revealed type [-1]: Revealed type for `r9` is `typing.Callable[..., typing.Any]`.
-constructors_callable.py:194:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Class9` but got `typing.Any`.
+constructors_callable.py:194:0 Assert type [70]: Expected `Class9` but got `typing.Any`.
 """

--- a/conformance/results/pyre/dataclasses_descriptors.toml
+++ b/conformance/results/pyre/dataclasses_descriptors.toml
@@ -1,19 +1,20 @@
 conformant = "Partial"
 notes = """
 Incorrectly generates error when calling constructor of dataclass with descriptor.
+Incorrectly raises incompatibility type errors.
 """
 output = """
 dataclasses_descriptors.py:35:10 Incompatible parameter type [6]: In call `DC1.__init__`, for 1st positional argument, expected `Desc1` but got `int`.
-dataclasses_descriptors.py:61:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `List[int]` but got `Desc2[int]`.
-dataclasses_descriptors.py:62:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `List[str]` but got `Desc2[str]`.
-dataclasses_descriptors.py:66:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `Desc2[int]`.
-dataclasses_descriptors.py:67:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `str` but got `Desc2[str]`.
+dataclasses_descriptors.py:61:0 Assert type [70]: Expected `List[int]` but got `Desc2[int]`.
+dataclasses_descriptors.py:62:0 Assert type [70]: Expected `List[str]` but got `Desc2[str]`.
+dataclasses_descriptors.py:66:0 Assert type [70]: Expected `int` but got `Desc2[int]`.
+dataclasses_descriptors.py:67:0 Assert type [70]: Expected `str` but got `Desc2[str]`.
 """
 conformance_automated = "Fail"
 errors_diff = """
 Line 35: Unexpected errors ['dataclasses_descriptors.py:35:10 Incompatible parameter type [6]: In call `DC1.__init__`, for 1st positional argument, expected `Desc1` but got `int`.']
-Line 61: Unexpected errors ['dataclasses_descriptors.py:61:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `List[int]` but got `Desc2[int]`.']
-Line 62: Unexpected errors ['dataclasses_descriptors.py:62:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `List[str]` but got `Desc2[str]`.']
-Line 66: Unexpected errors ['dataclasses_descriptors.py:66:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `Desc2[int]`.']
-Line 67: Unexpected errors ['dataclasses_descriptors.py:67:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `str` but got `Desc2[str]`.']
+Line 61: Unexpected errors ['dataclasses_descriptors.py:61:0 Assert type [70]: Expected `List[int]` but got `Desc2[int]`.']
+Line 62: Unexpected errors ['dataclasses_descriptors.py:62:0 Assert type [70]: Expected `List[str]` but got `Desc2[str]`.']
+Line 66: Unexpected errors ['dataclasses_descriptors.py:66:0 Assert type [70]: Expected `int` but got `Desc2[int]`.']
+Line 67: Unexpected errors ['dataclasses_descriptors.py:67:0 Assert type [70]: Expected `str` but got `Desc2[str]`.']
 """

--- a/conformance/results/pyre/dataclasses_transform_func.toml
+++ b/conformance/results/pyre/dataclasses_transform_func.toml
@@ -5,7 +5,6 @@ Does not detect non-frozen class inheriting from frozen class.
 Emits "attribute not initialized" error for dataclass field.
 """
 output = """
-dataclasses_transform_func.py:20:0 Incompatible overload [43]: The implementation of `create_model` does not accept all possible arguments of overload defined on line `20`.
 dataclasses_transform_func.py:25:5 Invalid type variable [34]: The type variable `Variable[T]` isn't present in the function's parameters.
 dataclasses_transform_func.py:29:0 Incompatible overload [43]: This definition does not have the same decorators as the preceding overload(s).
 dataclasses_transform_func.py:35:4 Uninitialized attribute [13]: Attribute `id` is declared in class `Customer1` to have type `int` but is never initialized.
@@ -27,7 +26,6 @@ dataclasses_transform_func.py:97:0 Invalid assignment [41]: Cannot reassign fina
 conformance_automated = "Fail"
 errors_diff = """
 Lines 89, 90: Expected error (tag 'Customer3Subclass')
-Line 20: Unexpected errors ['dataclasses_transform_func.py:20:0 Incompatible overload [43]: The implementation of `create_model` does not accept all possible arguments of overload defined on line `20`.']
 Line 25: Unexpected errors ["dataclasses_transform_func.py:25:5 Invalid type variable [34]: The type variable `Variable[T]` isn't present in the function's parameters."]
 Line 29: Unexpected errors ['dataclasses_transform_func.py:29:0 Incompatible overload [43]: This definition does not have the same decorators as the preceding overload(s).']
 Line 35: Unexpected errors ['dataclasses_transform_func.py:35:4 Uninitialized attribute [13]: Attribute `id` is declared in class `Customer1` to have type `int` but is never initialized.']

--- a/conformance/results/pyre/dataclasses_usage.toml
+++ b/conformance/results/pyre/dataclasses_usage.toml
@@ -3,6 +3,7 @@ notes = """
 Does not report error when field with no default follows field with default.
 Complains on `assert_type` when used for bound methods vs `Callable`.
 Does not understand `__dataclass_fields__`.
+Incorrectly raises incompatibility type errors.
 """
 output = """
 dataclasses_usage.py:50:5 Missing argument [20]: Call `InventoryItem.__init__` expects argument `unit_price`.
@@ -11,14 +12,13 @@ dataclasses_usage.py:52:5 Too many arguments [19]: Call `InventoryItem.__init__`
 dataclasses_usage.py:72:4 Undefined attribute [16]: `typing.Type` has no attribute `a`.
 dataclasses_usage.py:83:5 Too many arguments [19]: Call `DC4.__init__` expects 1 positional argument, 2 were provided.
 dataclasses_usage.py:88:4 Incompatible attribute type [8]: Attribute `a` declared in class `DC5` has type `int` but is used as type `str`.
-dataclasses_usage.py:106:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `typing.Callable[[str], int]` but got `BoundMethod[typing.Callable[[str], int], DC6]`.
 dataclasses_usage.py:127:0 Too many arguments [19]: Call `DC7.__init__` expects 1 positional argument, 2 were provided.
 dataclasses_usage.py:130:0 Missing argument [20]: Call `DC8.__init__` expects argument `y`.
 dataclasses_usage.py:173:4 Uninitialized attribute [13]: Attribute `x` is declared in class `DC13` to have type `int` but is never initialized.
 dataclasses_usage.py:174:4 Uninitialized attribute [13]: Attribute `x_squared` is declared in class `DC13` to have type `int` but is never initialized.
 dataclasses_usage.py:179:0 Too many arguments [19]: Call `object.__init__` expects 0 positional arguments, 1 was provided.
 dataclasses_usage.py:205:0 Incompatible variable type [9]: v7 is declared to have type `DataclassProto` but is used as type `DC15`.
-dataclasses_usage.py:213:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `DC16[int]` but got `DC16[typing_extensions.Literal[1]]`.
+dataclasses_usage.py:213:0 Assert type [70]: Expected `DC16[int]` but got `DC16[typing_extensions.Literal[1]]`.
 """
 conformance_automated = "Fail"
 errors_diff = """
@@ -26,9 +26,8 @@ Lines 58, 61: Expected error (tag 'DC1')
 Lines 64, 67: Expected error (tag 'DC2')
 Lines 70, 73: Expected error (tag 'DC3')
 Line 72: Unexpected errors ['dataclasses_usage.py:72:4 Undefined attribute [16]: `typing.Type` has no attribute `a`.']
-Line 106: Unexpected errors ['dataclasses_usage.py:106:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `typing.Callable[[str], int]` but got `BoundMethod[typing.Callable[[str], int], DC6]`.']
 Line 173: Unexpected errors ['dataclasses_usage.py:173:4 Uninitialized attribute [13]: Attribute `x` is declared in class `DC13` to have type `int` but is never initialized.']
 Line 174: Unexpected errors ['dataclasses_usage.py:174:4 Uninitialized attribute [13]: Attribute `x_squared` is declared in class `DC13` to have type `int` but is never initialized.']
 Line 205: Unexpected errors ['dataclasses_usage.py:205:0 Incompatible variable type [9]: v7 is declared to have type `DataclassProto` but is used as type `DC15`.']
-Line 213: Unexpected errors ['dataclasses_usage.py:213:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `DC16[int]` but got `DC16[typing_extensions.Literal[1]]`.']
+Line 213: Unexpected errors ['dataclasses_usage.py:213:0 Assert type [70]: Expected `DC16[int]` but got `DC16[typing_extensions.Literal[1]]`.']
 """

--- a/conformance/results/pyre/directives_assert_type.toml
+++ b/conformance/results/pyre/directives_assert_type.toml
@@ -1,13 +1,12 @@
 conformant = "Pass"
 notes = """
-Does not weaken literal types in `assert_type`, which some (other) tests rely on.
 """
 output = """
-directives_assert_type.py:27:4 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `Union[int, str]`.
-directives_assert_type.py:28:4 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `typing.Any`.
-directives_assert_type.py:29:4 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `typing_extensions.Literal[4]`.
+directives_assert_type.py:27:4 Assert type [70]: Expected `int` but got `Union[int, str]`.
+directives_assert_type.py:28:4 Assert type [70]: Expected `int` but got `typing.Any`.
+directives_assert_type.py:29:4 Assert type [70]: Expected `int` but got `typing_extensions.Literal[4]`.
 directives_assert_type.py:31:4 Missing argument [20]: Call `assert_type` expects argument in position 0.
-directives_assert_type.py:32:4 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `str`.
+directives_assert_type.py:32:4 Assert type [70]: Expected `int` but got `typing_extensions.Literal['']`.
 directives_assert_type.py:33:4 Too many arguments [19]: Call `assert_type` expects 2 positional arguments, 3 were provided.
 """
 conformance_automated = "Pass"

--- a/conformance/results/pyre/directives_reveal_type.toml
+++ b/conformance/results/pyre/directives_reveal_type.toml
@@ -1,6 +1,5 @@
-conformant = "Partial"
+conformant = "Pass"
 notes = """
-Produces errors rather than warnings on `reveal_type`.
 """
 output = """
 directives_reveal_type.py:14:4 Revealed type [-1]: Revealed type for `a` is `typing.Union[int, str]`.
@@ -8,9 +7,8 @@ directives_reveal_type.py:15:4 Revealed type [-1]: Revealed type for `b` is `typ
 directives_reveal_type.py:16:4 Revealed type [-1]: Revealed type for `c` is `typing.Any`.
 directives_reveal_type.py:17:4 Revealed type [-1]: Revealed type for `d` is `ForwardReference`.
 directives_reveal_type.py:19:4 Missing argument [20]: Call `reveal_type` expects argument in position 0.
-directives_reveal_type.py:20:4 Revealed type [-1]: Revealed type for `a` is `typing.Union[int, str]`.
+directives_reveal_type.py:20:4 Too many arguments [19]: Call `reveal_type` expects 1 positional argument, 2 were provided.
 """
-conformance_automated = "Fail"
+conformance_automated = "Pass"
 errors_diff = """
-Line 20: Expected 1 errors
 """

--- a/conformance/results/pyre/directives_type_ignore_file1.toml
+++ b/conformance/results/pyre/directives_type_ignore_file1.toml
@@ -1,11 +1,8 @@
-conformant = "Unsupported"
+conformant = "Pass"
 notes = """
-Does not support file-level `#type: ignore` comment.
 """
 output = """
-directives_type_ignore_file1.py:16:0 Incompatible variable type [9]: x is declared to have type `int` but is used as type `str`.
 """
-conformance_automated = "Fail"
+conformance_automated = "Pass"
 errors_diff = """
-Line 16: Unexpected errors ['directives_type_ignore_file1.py:16:0 Incompatible variable type [9]: x is declared to have type `int` but is used as type `str`.']
 """

--- a/conformance/results/pyre/directives_version_platform.toml
+++ b/conformance/results/pyre/directives_version_platform.toml
@@ -1,16 +1,10 @@
-conformant = "Partial"
+conformant = "Pass"
 notes = """
-Does not support sys.platform checks.
-Does not support os.name checks.
 """
 output = """
-directives_version_platform.py:31:4 Incompatible variable type [9]: val5 is declared to have type `int` but is used as type `str`.
-directives_version_platform.py:36:4 Incompatible variable type [9]: val6 is declared to have type `int` but is used as type `str`.
 directives_version_platform.py:40:4 Incompatible variable type [9]: val7 is declared to have type `int` but is used as type `str`.
 directives_version_platform.py:45:4 Incompatible variable type [9]: val8 is declared to have type `int` but is used as type `str`.
 """
-conformance_automated = "Fail"
+conformance_automated = "Pass"
 errors_diff = """
-Line 31: Unexpected errors ['directives_version_platform.py:31:4 Incompatible variable type [9]: val5 is declared to have type `int` but is used as type `str`.']
-Line 36: Unexpected errors ['directives_version_platform.py:36:4 Incompatible variable type [9]: val6 is declared to have type `int` but is used as type `str`.']
 """

--- a/conformance/results/pyre/enums_behaviors.toml
+++ b/conformance/results/pyre/enums_behaviors.toml
@@ -1,10 +1,9 @@
-conformant = "Partial"
+conformant = "Pass"
 notes = """
-Does not enforce that Enum classes are implicitly final.
 """
-conformance_automated = "Fail"
+conformance_automated = "Pass"
 errors_diff = """
-Line 39: Expected 1 errors
 """
 output = """
+enums_behaviors.py:39:0 Invalid inheritance [39]: Cannot inherit from final enum `Shape`. Enums with defined members cannot be extended.
 """

--- a/conformance/results/pyre/enums_definition.toml
+++ b/conformance/results/pyre/enums_definition.toml
@@ -1,11 +1,8 @@
-conformant = "Partial"
+conformant = "Pass"
 notes = """
-Does not support custom Enum classes based on EnumType metaclass.
-Does not support some functional forms for Enum class definitions (optional).
 """
-conformance_automated = "Fail"
+conformance_automated = "Pass"
 errors_diff = """
-Line 75: Unexpected errors ['enums_definition.py:75:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `typing_extensions.Literal[Color11.RED]` but got `int`.']
 """
 output = """
 enums_definition.py:24:9 Too many arguments [19]: Call `Enum.__new__` expects 1 positional argument, 4 were provided.
@@ -13,7 +10,8 @@ enums_definition.py:27:9 Too many arguments [19]: Call `Enum.__new__` expects 1 
 enums_definition.py:28:9 Too many arguments [19]: Call `Enum.__new__` expects 1 positional argument, 2 were provided.
 enums_definition.py:31:9 Too many arguments [19]: Call `Enum.__new__` expects 1 positional argument, 2 were provided.
 enums_definition.py:33:12 Undefined attribute [16]: `Enum` has no attribute `RED`.
+enums_definition.py:38:0 Assert type [70]: Expected `typing_extensions.Literal[Color7.RED]` but got `unknown`.
 enums_definition.py:38:12 Undefined attribute [16]: `Color7` has no attribute `RED`.
+enums_definition.py:39:0 Assert type [70]: Expected `typing_extensions.Literal[Color8.RED]` but got `unknown`.
 enums_definition.py:39:12 Undefined attribute [16]: `Color8` has no attribute `RED`.
-enums_definition.py:75:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `typing_extensions.Literal[Color11.RED]` but got `int`.
 """

--- a/conformance/results/pyre/enums_expansion.toml
+++ b/conformance/results/pyre/enums_expansion.toml
@@ -1,12 +1,11 @@
 conformant = "Pass"
 notes = """
-Does not perform type narrowing based on enum literal expansion (optional).
 """
 conformance_automated = "Pass"
 errors_diff = """
 """
 output = """
-enums_expansion.py:25:8 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `typing_extensions.Literal[Color.GREEN]` but got `Color`.
-enums_expansion.py:35:12 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Never` but got `Color`.
-enums_expansion.py:53:8 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `typing_extensions.Literal[CustomFlags.FLAG3]` but got `CustomFlags`.
+enums_expansion.py:25:8 Assert type [70]: Expected `typing_extensions.Literal[Color.GREEN]` but got `Color`.
+enums_expansion.py:35:12 Assert type [70]: Expected `Never` but got `Color`.
+enums_expansion.py:53:8 Assert type [70]: Expected `typing_extensions.Literal[CustomFlags.FLAG3]` but got `CustomFlags`.
 """

--- a/conformance/results/pyre/enums_member_names.toml
+++ b/conformance/results/pyre/enums_member_names.toml
@@ -6,8 +6,8 @@ conformance_automated = "Pass"
 errors_diff = """
 """
 output = """
-enums_member_names.py:21:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `typing_extensions.Literal['RED']` but got `str`.
-enums_member_names.py:22:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `typing_extensions.Literal['RED']` but got `typing.Any`.
-enums_member_names.py:26:4 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Union[typing_extensions.Literal['BLUE'], typing_extensions.Literal['RED']]` but got `typing.Any`.
-enums_member_names.py:30:4 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Union[typing_extensions.Literal['BLUE'], typing_extensions.Literal['GREEN'], typing_extensions.Literal['RED']]` but got `typing.Any`.
+enums_member_names.py:21:0 Assert type [70]: Expected `typing_extensions.Literal['RED']` but got `str`.
+enums_member_names.py:22:0 Assert type [70]: Expected `typing_extensions.Literal['RED']` but got `str`.
+enums_member_names.py:26:4 Assert type [70]: Expected `Union[typing_extensions.Literal['BLUE'], typing_extensions.Literal['RED']]` but got `str`.
+enums_member_names.py:30:4 Assert type [70]: Expected `Union[typing_extensions.Literal['BLUE'], typing_extensions.Literal['GREEN'], typing_extensions.Literal['RED']]` but got `str`.
 """

--- a/conformance/results/pyre/enums_member_values.toml
+++ b/conformance/results/pyre/enums_member_values.toml
@@ -1,23 +1,17 @@
-conformant = "Partial"
+conformant = "Pass"
 notes = """
-Does not enforce declared type of `_value_`.
-Does not enforce assigned tuple types for enum members (optional).
-Does not evaluate literal types for enum member values (optional).
-Does not evaluate literal types for auto values (optional).
 """
-conformance_automated = "Fail"
+conformance_automated = "Pass"
 errors_diff = """
-Line 78: Expected 1 errors
-Line 85: Expected 1 errors
-Line 76: Unexpected errors ['enums_member_values.py:76:4 Uninitialized attribute [13]: Attribute `_value_` is declared in class `Color3` to have type `Color3` but is never initialized.']
 """
 output = """
-enums_member_values.py:21:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `typing_extensions.Literal[1]` but got `typing.Any`.
-enums_member_values.py:22:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `typing_extensions.Literal[1]` but got `typing.Any`.
-enums_member_values.py:26:4 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Union[typing_extensions.Literal[1], typing_extensions.Literal[3]]` but got `typing.Any`.
-enums_member_values.py:30:4 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Union[typing_extensions.Literal[1], typing_extensions.Literal[2], typing_extensions.Literal[3]]` but got `typing.Any`.
-enums_member_values.py:54:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `typing_extensions.Literal[1]` but got `typing.Any`.
-enums_member_values.py:68:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `typing_extensions.Literal[1]` but got `typing.Any`.
-enums_member_values.py:76:4 Uninitialized attribute [13]: Attribute `_value_` is declared in class `Color3` to have type `Color3` but is never initialized.
-enums_member_values.py:96:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `typing.Any`.
+enums_member_values.py:21:0 Assert type [70]: Expected `typing_extensions.Literal[1]` but got `typing.Any`.
+enums_member_values.py:22:0 Assert type [70]: Expected `typing_extensions.Literal[1]` but got `typing.Any`.
+enums_member_values.py:26:4 Assert type [70]: Expected `Union[typing_extensions.Literal[1], typing_extensions.Literal[3]]` but got `typing.Any`.
+enums_member_values.py:30:4 Assert type [70]: Expected `Union[typing_extensions.Literal[1], typing_extensions.Literal[2], typing_extensions.Literal[3]]` but got `typing.Any`.
+enums_member_values.py:54:0 Assert type [70]: Expected `typing_extensions.Literal[1]` but got `typing.Any`.
+enums_member_values.py:68:0 Assert type [70]: Expected `typing_extensions.Literal[1]` but got `typing.Any`.
+enums_member_values.py:78:4 Incompatible attribute type [8]: Attribute `GREEN` declared in class `Color3` has type `int` but is used as type `str`.
+enums_member_values.py:85:8 Incompatible attribute type [8]: Attribute `_value_` declared in class `Planet2` has type `str` but is used as type `int`.
+enums_member_values.py:96:0 Assert type [70]: Expected `int` but got `typing.Any`.
 """

--- a/conformance/results/pyre/enums_members.toml
+++ b/conformance/results/pyre/enums_members.toml
@@ -11,30 +11,18 @@ Does not support `_ignore_` mechanism (optional).
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 50: Expected 1 errors
 Line 82: Expected 1 errors
 Line 83: Expected 1 errors
 Line 116: Expected 1 errors
 Line 129: Expected 1 errors
-Line 27: Unexpected errors ['enums_members.py:27:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `str` but got `Pet`.']
-Line 28: Unexpected errors ['enums_members.py:28:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `str` but got `Pet`.']
-Line 35: Unexpected errors ['enums_members.py:35:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `str` but got `Pet2`.']
-Line 36: Unexpected errors ['enums_members.py:36:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `str` but got `Pet2`.']
-Line 100: Unexpected errors ['enums_members.py:100:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `typing_extensions.Literal[TrafficLight.YELLOW]` but got `typing_extensions.Literal[TrafficLight.AMBER]`.']
-Line 117: Unexpected errors ['enums_members.py:117:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `typing_extensions.Literal[Example.c]` but got `member[typing.Callable(Example.c)[[Named(self, Example)], None]]`.']
-Line 139: Unexpected errors ['enums_members.py:139:4 Inconsistent override [15]: `_ignore_` overrides attribute defined in `Enum` inconsistently. Type `Pet5` is not a subtype of the overridden attribute `typing.Union[typing.List[str], str]`.']
+Line 100: Unexpected errors ['enums_members.py:100:0 Assert type [70]: Expected `typing_extensions.Literal[TrafficLight.YELLOW]` but got `typing_extensions.Literal[TrafficLight.AMBER]`.']
 """
 output = """
-enums_members.py:27:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `str` but got `Pet`.
-enums_members.py:28:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `str` but got `Pet`.
-enums_members.py:35:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `str` but got `Pet2`.
-enums_members.py:36:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `str` but got `Pet2`.
-enums_members.py:84:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `typing_extensions.Literal[Pet4.species]` but got `str`.
-enums_members.py:85:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `typing_extensions.Literal[Pet4.speak]` but got `typing.Callable(Pet4.speak)[[Named(self, Pet4)], None]`.
-enums_members.py:100:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `typing_extensions.Literal[TrafficLight.YELLOW]` but got `typing_extensions.Literal[TrafficLight.AMBER]`.
-enums_members.py:117:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `typing_extensions.Literal[Example.c]` but got `member[typing.Callable(Example.c)[[Named(self, Example)], None]]`.
+enums_members.py:50:4 Illegal annotation target [35]: Target `enums_members.Pet3.DOG` cannot be annotated as it is an enum member. Enum value types can be specified by annotating the `_value_` attribute.
+enums_members.py:84:0 Assert type [70]: Expected `typing_extensions.Literal[Pet4.species]` but got `str`.
+enums_members.py:85:0 Assert type [70]: Expected `typing_extensions.Literal[Pet4.speak]` but got `typing.Callable(Pet4.speak)[[Named(self, Pet4)], None]`.
+enums_members.py:100:0 Assert type [70]: Expected `typing_extensions.Literal[TrafficLight.YELLOW]` but got `typing_extensions.Literal[TrafficLight.AMBER]`.
 enums_members.py:128:8 Revealed type [-1]: Revealed type for `enums_members.Example2._Example2__B` is `typing_extensions.Literal[Example2._Example2__B]` (final).
-enums_members.py:139:4 Inconsistent override [15]: `_ignore_` overrides attribute defined in `Enum` inconsistently. Type `Pet5` is not a subtype of the overridden attribute `typing.Union[typing.List[str], str]`.
-enums_members.py:146:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `Pet5`.
-enums_members.py:147:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `Pet5`.
+enums_members.py:146:0 Assert type [70]: Expected `int` but got `typing_extensions.Literal[Pet5.DOG]`.
+enums_members.py:147:0 Assert type [70]: Expected `int` but got `typing_extensions.Literal[Pet5.FISH]`.
 """

--- a/conformance/results/pyre/exceptions_context_managers.toml
+++ b/conformance/results/pyre/exceptions_context_managers.toml
@@ -1,13 +1,13 @@
-conformant = "Unsupported"
+conformant = "Partial"
 notes = """
-Does not understand context manager exception rules.
+assert_type causes failures.
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 50: Unexpected errors ['exceptions_context_managers.py:50:4 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Union[int, str]` but got `str`.']
-Line 57: Unexpected errors ['exceptions_context_managers.py:57:4 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Union[int, str]` but got `str`.']
+Line 50: Unexpected errors ['exceptions_context_managers.py:50:4 Assert type [70]: Expected `Union[int, str]` but got `str`.']
+Line 57: Unexpected errors ['exceptions_context_managers.py:57:4 Assert type [70]: Expected `Union[int, str]` but got `str`.']
 """
 output = """
-exceptions_context_managers.py:50:4 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Union[int, str]` but got `str`.
-exceptions_context_managers.py:57:4 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Union[int, str]` but got `str`.
+exceptions_context_managers.py:50:4 Assert type [70]: Expected `Union[int, str]` but got `str`.
+exceptions_context_managers.py:57:4 Assert type [70]: Expected `Union[int, str]` but got `str`.
 """

--- a/conformance/results/pyre/generics_basic.toml
+++ b/conformance/results/pyre/generics_basic.toml
@@ -12,14 +12,14 @@ generics_basic.py:34:15 Incompatible parameter type [6]: In call `str.__add__`, 
 generics_basic.py:40:14 Incompatible parameter type [6]: In call `concat`, for 2nd positional argument, expected `Variable[AnyStr <: [str, bytes]]` but got `bytes`.
 generics_basic.py:41:14 Incompatible parameter type [6]: In call `concat`, for 2nd positional argument, expected `Variable[AnyStr <: [str, bytes]]` but got `str`.
 generics_basic.py:49:0 Invalid type [31]: TypeVar can't have a single explicit constraint. Did you mean `bound=str`?
-generics_basic.py:55:52 Undefined attribute [16]: `list` has no attribute `__getitem__`.
 generics_basic.py:69:14 Incompatible parameter type [6]: In call `concat`, for 2nd positional argument, expected `Variable[AnyStr <: [str, bytes]]` but got `bytes`.
 generics_basic.py:121:0 Duplicate type variables [59]: Duplicate type variable `T` in Generic[...].
+generics_basic.py:157:7 Incompatible parameter type [6]: In call `typing.Mapping.__getitem__`, for 1st positional argument, expected `str` but got `int`.
+generics_basic.py:158:7 Incompatible parameter type [6]: In call `typing.Mapping.__getitem__`, for 1st positional argument, expected `str` but got `int`.
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 157: Expected 1 errors
-Line 158: Expected 1 errors
+Line 55: Expected 1 errors
 Line 191: Expected 1 errors
 Line 34: Unexpected errors ['generics_basic.py:34:4 Incompatible return type [7]: Expected `Variable[AnyStr <: [str, bytes]]` but got `str`.', 'generics_basic.py:34:15 Incompatible parameter type [6]: In call `str.__add__`, for 1st positional argument, expected `str` but got `Variable[AnyStr <: [str, bytes]]`.']
 """

--- a/conformance/results/pyre/generics_defaults.toml
+++ b/conformance/results/pyre/generics_defaults.toml
@@ -6,64 +6,64 @@ output = """
 generics_defaults.py:24:31 Undefined or invalid type [11]: Annotation `DefaultStrT` is not defined as a type.
 generics_defaults.py:24:31 Undefined or invalid type [11]: Annotation `T` is not defined as a type.
 generics_defaults.py:27:20 Undefined or invalid type [11]: Annotation `DefaultIntT` is not defined as a type.
-generics_defaults.py:30:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Type[NoNonDefaults[]]` but got `Type[NoNonDefaults]`.
+generics_defaults.py:30:0 Assert type [70]: Expected `Type[NoNonDefaults[]]` but got `Type[NoNonDefaults]`.
 generics_defaults.py:30:27 Invalid type parameters [24]: Non-generic type `NoNonDefaults` cannot take parameters.
-generics_defaults.py:31:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Type[NoNonDefaults[]]` but got `typing.Any`.
+generics_defaults.py:31:0 Assert type [70]: Expected `Type[NoNonDefaults[]]` but got `typing.Any`.
 generics_defaults.py:31:12 Undefined attribute [16]: `NoNonDefaults` has no attribute `__getitem__`.
 generics_defaults.py:31:32 Invalid type parameters [24]: Non-generic type `NoNonDefaults` cannot take parameters.
-generics_defaults.py:32:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Type[NoNonDefaults[]]` but got `typing.Any`.
+generics_defaults.py:32:0 Assert type [70]: Expected `Type[NoNonDefaults[]]` but got `typing.Any`.
 generics_defaults.py:32:37 Invalid type parameters [24]: Non-generic type `NoNonDefaults` cannot take parameters.
 generics_defaults.py:35:17 Undefined or invalid type [11]: Annotation `DefaultBoolT` is not defined as a type.
-generics_defaults.py:38:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Type[OneDefault[]]` but got `typing.Any`.
+generics_defaults.py:38:0 Assert type [70]: Expected `Type[OneDefault[]]` but got `typing.Any`.
 generics_defaults.py:38:12 Undefined attribute [16]: `OneDefault` has no attribute `__getitem__`.
 generics_defaults.py:38:31 Invalid type parameters [24]: Non-generic type `OneDefault` cannot take parameters.
-generics_defaults.py:39:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `OneDefault[]` but got `typing.Any`.
+generics_defaults.py:39:0 Assert type [70]: Expected `OneDefault[]` but got `typing.Any`.
 generics_defaults.py:39:33 Invalid type parameters [24]: Non-generic type `OneDefault` cannot take parameters.
 generics_defaults.py:42:21 Undefined or invalid type [11]: Annotation `T1` is not defined as a type.
 generics_defaults.py:42:21 Undefined or invalid type [11]: Annotation `T2` is not defined as a type.
-generics_defaults.py:45:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Type[AllTheDefaults[]]` but got `Type[AllTheDefaults]`.
+generics_defaults.py:45:0 Assert type [70]: Expected `Type[AllTheDefaults[]]` but got `Type[AllTheDefaults]`.
 generics_defaults.py:45:28 Invalid type parameters [24]: Non-generic type `AllTheDefaults` cannot take parameters.
-generics_defaults.py:46:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Type[AllTheDefaults[]]` but got `typing.Any`.
+generics_defaults.py:46:0 Assert type [70]: Expected `Type[AllTheDefaults[]]` but got `typing.Any`.
 generics_defaults.py:47:4 Undefined attribute [16]: `AllTheDefaults` has no attribute `__getitem__`.
 generics_defaults.py:47:34 Invalid type parameters [24]: Non-generic type `AllTheDefaults` cannot take parameters.
-generics_defaults.py:52:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Type[AllTheDefaults[]]` but got `typing.Any`.
+generics_defaults.py:52:0 Assert type [70]: Expected `Type[AllTheDefaults[]]` but got `typing.Any`.
 generics_defaults.py:53:34 Invalid type parameters [24]: Non-generic type `AllTheDefaults` cannot take parameters.
-generics_defaults.py:55:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Type[AllTheDefaults[]]` but got `typing.Any`.
+generics_defaults.py:55:0 Assert type [70]: Expected `Type[AllTheDefaults[]]` but got `typing.Any`.
 generics_defaults.py:57:4 Invalid type parameters [24]: Non-generic type `AllTheDefaults` cannot take parameters.
-generics_defaults.py:59:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Type[AllTheDefaults[]]` but got `typing.Any`.
+generics_defaults.py:59:0 Assert type [70]: Expected `Type[AllTheDefaults[]]` but got `typing.Any`.
 generics_defaults.py:61:4 Invalid type parameters [24]: Non-generic type `AllTheDefaults` cannot take parameters.
-generics_defaults.py:63:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Type[AllTheDefaults[]]` but got `typing.Any`.
+generics_defaults.py:63:0 Assert type [70]: Expected `Type[AllTheDefaults[]]` but got `typing.Any`.
 generics_defaults.py:65:4 Invalid type parameters [24]: Non-generic type `AllTheDefaults` cannot take parameters.
-generics_defaults.py:73:33 Incompatible parameter type [6]: In call `ParamSpec.__init__`, for argument `default`, expected `Union[None, Type[typing.Any], str]` but got `List[Type[Union[int, str]]]`.
 generics_defaults.py:76:22 Undefined or invalid type [11]: Annotation `DefaultP` is not defined as a type.
-generics_defaults.py:79:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Type[Class_ParamSpec[]]` but got `Type[Class_ParamSpec]`.
+generics_defaults.py:79:0 Assert type [70]: Expected `Type[Class_ParamSpec[]]` but got `Type[Class_ParamSpec]`.
 generics_defaults.py:79:29 Invalid type parameters [24]: Non-generic type `Class_ParamSpec` cannot take parameters.
-generics_defaults.py:80:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Class_ParamSpec[]` but got `Class_ParamSpec`.
+generics_defaults.py:80:0 Assert type [70]: Expected `Class_ParamSpec[]` but got `Class_ParamSpec`.
 generics_defaults.py:80:31 Invalid type parameters [24]: Non-generic type `Class_ParamSpec` cannot take parameters.
-generics_defaults.py:81:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Class_ParamSpec[]` but got `typing.Any`.
+generics_defaults.py:81:0 Assert type [70]: Expected `Class_ParamSpec[]` but got `typing.Any`.
 generics_defaults.py:81:12 Undefined attribute [16]: `Class_ParamSpec` has no attribute `__getitem__`.
 generics_defaults.py:81:45 Invalid type parameters [24]: Non-generic type `Class_ParamSpec` cannot take parameters.
-generics_defaults.py:88:53 Undefined attribute [16]: `tuple` has no attribute `__getitem__`.
-generics_defaults.py:91:25 Invalid type [31]: Expression `typing.Generic[(*DefaultTs)]` is not a valid type.
-generics_defaults.py:94:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Type[Class_TypeVarTuple[]]` but got `Type[Class_TypeVarTuple]`.
-generics_defaults.py:94:32 Invalid type [31]: Expression `type[generics_defaults.Class_TypeVarTuple[(*tuple[(str, int)])]]` is not a valid type.
+generics_defaults.py:91:25 Undefined or invalid type [11]: Annotation `DefaultTs` is not defined as a type.
+generics_defaults.py:94:0 Assert type [70]: Expected `Type[Class_TypeVarTuple[]]` but got `Type[Class_TypeVarTuple]`.
 generics_defaults.py:94:32 Invalid type parameters [24]: Non-generic type `Class_TypeVarTuple` cannot take parameters.
-generics_defaults.py:95:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Class_TypeVarTuple[]` but got `Class_TypeVarTuple`.
+generics_defaults.py:95:0 Assert type [70]: Expected `Class_TypeVarTuple[]` but got `Class_TypeVarTuple`.
 generics_defaults.py:95:34 Invalid type parameters [24]: Non-generic type `Class_TypeVarTuple` cannot take parameters.
-generics_defaults.py:96:31 Incompatible parameter type [6]: In call `typing.GenericMeta.__getitem__`, for 1st positional argument, expected `Tuple[]` but got `Tuple[Type[int], Type[bool]]`. Expected has length 0, but actual has length 2.
+generics_defaults.py:96:0 Assert type [70]: Expected `Class_TypeVarTuple[]` but got `typing.Any`.
+generics_defaults.py:96:12 Undefined attribute [16]: `Class_TypeVarTuple` has no attribute `__getitem__`.
+generics_defaults.py:96:45 Invalid type parameters [24]: Non-generic type `Class_TypeVarTuple` cannot take parameters.
 generics_defaults.py:124:13 Undefined or invalid type [11]: Annotation `T4` is not defined as a type.
-generics_defaults.py:138:11 Invalid type [31]: Expression `typing.Generic[(*Ts, T5)]` is not a valid type.
+generics_defaults.py:127:0 Assert type [70]: Expected `int` but got `unknown`.
+generics_defaults.py:138:11 Invalid type variable [34]: The current class isn't generic with respect to the type variable `Ts`.
 generics_defaults.py:138:11 Undefined or invalid type [11]: Annotation `T5` is not defined as a type.
-generics_defaults.py:145:19 Incompatible parameter type [6]: In call `ParamSpec.__init__`, for argument `default`, expected `Union[None, Type[typing.Any], str]` but got `List[Type[float]]`.
-generics_defaults.py:148:11 Invalid type [31]: Expression `typing.Generic[(*Ts, P)]` is not a valid type.
+generics_defaults.py:148:11 Invalid type variable [34]: The current class isn't generic with respect to the type variable `Ts`.
 generics_defaults.py:148:11 Undefined or invalid type [11]: Annotation `P` is not defined as a type.
-generics_defaults.py:151:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Type[Foo6[]]` but got `typing.Any`.
+generics_defaults.py:151:0 Assert type [70]: Expected `Type[Foo6[]]` but got `typing.Any`.
 generics_defaults.py:151:12 Undefined attribute [16]: `Foo6` has no attribute `__getitem__`.
 generics_defaults.py:151:28 Invalid type parameters [24]: Non-generic type `Foo6` cannot take parameters.
-generics_defaults.py:152:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Type[Foo6[]]` but got `typing.Any`.
+generics_defaults.py:152:0 Assert type [70]: Expected `Type[Foo6[]]` but got `typing.Any`.
 generics_defaults.py:152:37 Invalid type parameters [24]: Non-generic type `Foo6` cannot take parameters.
-generics_defaults.py:166:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `typing.Callable[[Foo7[]], Foo7[]]` but got `typing.Callable(Foo7.meth)[[Variable[_Self_generics_defaults_Foo7__ (bound to Foo7)]], Variable[_Self_generics_defaults_Foo7__ (bound to Foo7)]]`.
+generics_defaults.py:166:0 Assert type [70]: Expected `typing.Callable[[Foo7[]], Foo7[]]` but got `typing.Callable(Foo7.meth)[[Variable[_Self_generics_defaults_Foo7__ (bound to Foo7)]], Variable[_Self_generics_defaults_Foo7__ (bound to Foo7)]]`.
 generics_defaults.py:166:23 Invalid type parameters [24]: Non-generic type `Foo7` cannot take parameters.
+generics_defaults.py:167:0 Assert type [70]: Expected `int` but got `unknown`.
 """
 conformance_automated = "Fail"
 errors_diff = """
@@ -71,38 +71,37 @@ Line 50: Expected 1 errors
 Line 104: Expected 1 errors
 Line 111: Expected 1 errors
 Line 27: Unexpected errors ['generics_defaults.py:27:20 Undefined or invalid type [11]: Annotation `DefaultIntT` is not defined as a type.']
-Line 30: Unexpected errors ['generics_defaults.py:30:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Type[NoNonDefaults[]]` but got `Type[NoNonDefaults]`.', 'generics_defaults.py:30:27 Invalid type parameters [24]: Non-generic type `NoNonDefaults` cannot take parameters.']
-Line 31: Unexpected errors ['generics_defaults.py:31:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Type[NoNonDefaults[]]` but got `typing.Any`.', 'generics_defaults.py:31:12 Undefined attribute [16]: `NoNonDefaults` has no attribute `__getitem__`.', 'generics_defaults.py:31:32 Invalid type parameters [24]: Non-generic type `NoNonDefaults` cannot take parameters.']
-Line 32: Unexpected errors ['generics_defaults.py:32:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Type[NoNonDefaults[]]` but got `typing.Any`.', 'generics_defaults.py:32:37 Invalid type parameters [24]: Non-generic type `NoNonDefaults` cannot take parameters.']
+Line 30: Unexpected errors ['generics_defaults.py:30:0 Assert type [70]: Expected `Type[NoNonDefaults[]]` but got `Type[NoNonDefaults]`.', 'generics_defaults.py:30:27 Invalid type parameters [24]: Non-generic type `NoNonDefaults` cannot take parameters.']
+Line 31: Unexpected errors ['generics_defaults.py:31:0 Assert type [70]: Expected `Type[NoNonDefaults[]]` but got `typing.Any`.', 'generics_defaults.py:31:12 Undefined attribute [16]: `NoNonDefaults` has no attribute `__getitem__`.', 'generics_defaults.py:31:32 Invalid type parameters [24]: Non-generic type `NoNonDefaults` cannot take parameters.']
+Line 32: Unexpected errors ['generics_defaults.py:32:0 Assert type [70]: Expected `Type[NoNonDefaults[]]` but got `typing.Any`.', 'generics_defaults.py:32:37 Invalid type parameters [24]: Non-generic type `NoNonDefaults` cannot take parameters.']
 Line 35: Unexpected errors ['generics_defaults.py:35:17 Undefined or invalid type [11]: Annotation `DefaultBoolT` is not defined as a type.']
-Line 38: Unexpected errors ['generics_defaults.py:38:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Type[OneDefault[]]` but got `typing.Any`.', 'generics_defaults.py:38:12 Undefined attribute [16]: `OneDefault` has no attribute `__getitem__`.', 'generics_defaults.py:38:31 Invalid type parameters [24]: Non-generic type `OneDefault` cannot take parameters.']
-Line 39: Unexpected errors ['generics_defaults.py:39:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `OneDefault[]` but got `typing.Any`.', 'generics_defaults.py:39:33 Invalid type parameters [24]: Non-generic type `OneDefault` cannot take parameters.']
+Line 38: Unexpected errors ['generics_defaults.py:38:0 Assert type [70]: Expected `Type[OneDefault[]]` but got `typing.Any`.', 'generics_defaults.py:38:12 Undefined attribute [16]: `OneDefault` has no attribute `__getitem__`.', 'generics_defaults.py:38:31 Invalid type parameters [24]: Non-generic type `OneDefault` cannot take parameters.']
+Line 39: Unexpected errors ['generics_defaults.py:39:0 Assert type [70]: Expected `OneDefault[]` but got `typing.Any`.', 'generics_defaults.py:39:33 Invalid type parameters [24]: Non-generic type `OneDefault` cannot take parameters.']
 Line 42: Unexpected errors ['generics_defaults.py:42:21 Undefined or invalid type [11]: Annotation `T1` is not defined as a type.', 'generics_defaults.py:42:21 Undefined or invalid type [11]: Annotation `T2` is not defined as a type.']
-Line 45: Unexpected errors ['generics_defaults.py:45:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Type[AllTheDefaults[]]` but got `Type[AllTheDefaults]`.', 'generics_defaults.py:45:28 Invalid type parameters [24]: Non-generic type `AllTheDefaults` cannot take parameters.']
-Line 46: Unexpected errors ['generics_defaults.py:46:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Type[AllTheDefaults[]]` but got `typing.Any`.']
+Line 45: Unexpected errors ['generics_defaults.py:45:0 Assert type [70]: Expected `Type[AllTheDefaults[]]` but got `Type[AllTheDefaults]`.', 'generics_defaults.py:45:28 Invalid type parameters [24]: Non-generic type `AllTheDefaults` cannot take parameters.']
+Line 46: Unexpected errors ['generics_defaults.py:46:0 Assert type [70]: Expected `Type[AllTheDefaults[]]` but got `typing.Any`.']
 Line 47: Unexpected errors ['generics_defaults.py:47:4 Undefined attribute [16]: `AllTheDefaults` has no attribute `__getitem__`.', 'generics_defaults.py:47:34 Invalid type parameters [24]: Non-generic type `AllTheDefaults` cannot take parameters.']
-Line 52: Unexpected errors ['generics_defaults.py:52:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Type[AllTheDefaults[]]` but got `typing.Any`.']
+Line 52: Unexpected errors ['generics_defaults.py:52:0 Assert type [70]: Expected `Type[AllTheDefaults[]]` but got `typing.Any`.']
 Line 53: Unexpected errors ['generics_defaults.py:53:34 Invalid type parameters [24]: Non-generic type `AllTheDefaults` cannot take parameters.']
-Line 55: Unexpected errors ['generics_defaults.py:55:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Type[AllTheDefaults[]]` but got `typing.Any`.']
+Line 55: Unexpected errors ['generics_defaults.py:55:0 Assert type [70]: Expected `Type[AllTheDefaults[]]` but got `typing.Any`.']
 Line 57: Unexpected errors ['generics_defaults.py:57:4 Invalid type parameters [24]: Non-generic type `AllTheDefaults` cannot take parameters.']
-Line 59: Unexpected errors ['generics_defaults.py:59:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Type[AllTheDefaults[]]` but got `typing.Any`.']
+Line 59: Unexpected errors ['generics_defaults.py:59:0 Assert type [70]: Expected `Type[AllTheDefaults[]]` but got `typing.Any`.']
 Line 61: Unexpected errors ['generics_defaults.py:61:4 Invalid type parameters [24]: Non-generic type `AllTheDefaults` cannot take parameters.']
-Line 63: Unexpected errors ['generics_defaults.py:63:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Type[AllTheDefaults[]]` but got `typing.Any`.']
+Line 63: Unexpected errors ['generics_defaults.py:63:0 Assert type [70]: Expected `Type[AllTheDefaults[]]` but got `typing.Any`.']
 Line 65: Unexpected errors ['generics_defaults.py:65:4 Invalid type parameters [24]: Non-generic type `AllTheDefaults` cannot take parameters.']
-Line 73: Unexpected errors ['generics_defaults.py:73:33 Incompatible parameter type [6]: In call `ParamSpec.__init__`, for argument `default`, expected `Union[None, Type[typing.Any], str]` but got `List[Type[Union[int, str]]]`.']
 Line 76: Unexpected errors ['generics_defaults.py:76:22 Undefined or invalid type [11]: Annotation `DefaultP` is not defined as a type.']
-Line 79: Unexpected errors ['generics_defaults.py:79:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Type[Class_ParamSpec[]]` but got `Type[Class_ParamSpec]`.', 'generics_defaults.py:79:29 Invalid type parameters [24]: Non-generic type `Class_ParamSpec` cannot take parameters.']
-Line 80: Unexpected errors ['generics_defaults.py:80:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Class_ParamSpec[]` but got `Class_ParamSpec`.', 'generics_defaults.py:80:31 Invalid type parameters [24]: Non-generic type `Class_ParamSpec` cannot take parameters.']
-Line 81: Unexpected errors ['generics_defaults.py:81:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Class_ParamSpec[]` but got `typing.Any`.', 'generics_defaults.py:81:12 Undefined attribute [16]: `Class_ParamSpec` has no attribute `__getitem__`.', 'generics_defaults.py:81:45 Invalid type parameters [24]: Non-generic type `Class_ParamSpec` cannot take parameters.']
-Line 88: Unexpected errors ['generics_defaults.py:88:53 Undefined attribute [16]: `tuple` has no attribute `__getitem__`.']
-Line 91: Unexpected errors ['generics_defaults.py:91:25 Invalid type [31]: Expression `typing.Generic[(*DefaultTs)]` is not a valid type.']
-Line 94: Unexpected errors ['generics_defaults.py:94:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Type[Class_TypeVarTuple[]]` but got `Type[Class_TypeVarTuple]`.', 'generics_defaults.py:94:32 Invalid type [31]: Expression `type[generics_defaults.Class_TypeVarTuple[(*tuple[(str, int)])]]` is not a valid type.', 'generics_defaults.py:94:32 Invalid type parameters [24]: Non-generic type `Class_TypeVarTuple` cannot take parameters.']
-Line 95: Unexpected errors ['generics_defaults.py:95:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Class_TypeVarTuple[]` but got `Class_TypeVarTuple`.', 'generics_defaults.py:95:34 Invalid type parameters [24]: Non-generic type `Class_TypeVarTuple` cannot take parameters.']
-Line 96: Unexpected errors ['generics_defaults.py:96:31 Incompatible parameter type [6]: In call `typing.GenericMeta.__getitem__`, for 1st positional argument, expected `Tuple[]` but got `Tuple[Type[int], Type[bool]]`. Expected has length 0, but actual has length 2.']
+Line 79: Unexpected errors ['generics_defaults.py:79:0 Assert type [70]: Expected `Type[Class_ParamSpec[]]` but got `Type[Class_ParamSpec]`.', 'generics_defaults.py:79:29 Invalid type parameters [24]: Non-generic type `Class_ParamSpec` cannot take parameters.']
+Line 80: Unexpected errors ['generics_defaults.py:80:0 Assert type [70]: Expected `Class_ParamSpec[]` but got `Class_ParamSpec`.', 'generics_defaults.py:80:31 Invalid type parameters [24]: Non-generic type `Class_ParamSpec` cannot take parameters.']
+Line 81: Unexpected errors ['generics_defaults.py:81:0 Assert type [70]: Expected `Class_ParamSpec[]` but got `typing.Any`.', 'generics_defaults.py:81:12 Undefined attribute [16]: `Class_ParamSpec` has no attribute `__getitem__`.', 'generics_defaults.py:81:45 Invalid type parameters [24]: Non-generic type `Class_ParamSpec` cannot take parameters.']
+Line 91: Unexpected errors ['generics_defaults.py:91:25 Undefined or invalid type [11]: Annotation `DefaultTs` is not defined as a type.']
+Line 94: Unexpected errors ['generics_defaults.py:94:0 Assert type [70]: Expected `Type[Class_TypeVarTuple[]]` but got `Type[Class_TypeVarTuple]`.', 'generics_defaults.py:94:32 Invalid type parameters [24]: Non-generic type `Class_TypeVarTuple` cannot take parameters.']
+Line 95: Unexpected errors ['generics_defaults.py:95:0 Assert type [70]: Expected `Class_TypeVarTuple[]` but got `Class_TypeVarTuple`.', 'generics_defaults.py:95:34 Invalid type parameters [24]: Non-generic type `Class_TypeVarTuple` cannot take parameters.']
+Line 96: Unexpected errors ['generics_defaults.py:96:0 Assert type [70]: Expected `Class_TypeVarTuple[]` but got `typing.Any`.', 'generics_defaults.py:96:12 Undefined attribute [16]: `Class_TypeVarTuple` has no attribute `__getitem__`.', 'generics_defaults.py:96:45 Invalid type parameters [24]: Non-generic type `Class_TypeVarTuple` cannot take parameters.']
 Line 124: Unexpected errors ['generics_defaults.py:124:13 Undefined or invalid type [11]: Annotation `T4` is not defined as a type.']
-Line 145: Unexpected errors ['generics_defaults.py:145:19 Incompatible parameter type [6]: In call `ParamSpec.__init__`, for argument `default`, expected `Union[None, Type[typing.Any], str]` but got `List[Type[float]]`.']
-Line 148: Unexpected errors ['generics_defaults.py:148:11 Invalid type [31]: Expression `typing.Generic[(*Ts, P)]` is not a valid type.', 'generics_defaults.py:148:11 Undefined or invalid type [11]: Annotation `P` is not defined as a type.']
-Line 151: Unexpected errors ['generics_defaults.py:151:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Type[Foo6[]]` but got `typing.Any`.', 'generics_defaults.py:151:12 Undefined attribute [16]: `Foo6` has no attribute `__getitem__`.', 'generics_defaults.py:151:28 Invalid type parameters [24]: Non-generic type `Foo6` cannot take parameters.']
-Line 152: Unexpected errors ['generics_defaults.py:152:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Type[Foo6[]]` but got `typing.Any`.', 'generics_defaults.py:152:37 Invalid type parameters [24]: Non-generic type `Foo6` cannot take parameters.']
-Line 166: Unexpected errors ['generics_defaults.py:166:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `typing.Callable[[Foo7[]], Foo7[]]` but got `typing.Callable(Foo7.meth)[[Variable[_Self_generics_defaults_Foo7__ (bound to Foo7)]], Variable[_Self_generics_defaults_Foo7__ (bound to Foo7)]]`.', 'generics_defaults.py:166:23 Invalid type parameters [24]: Non-generic type `Foo7` cannot take parameters.']
+Line 127: Unexpected errors ['generics_defaults.py:127:0 Assert type [70]: Expected `int` but got `unknown`.']
+Line 148: Unexpected errors ["generics_defaults.py:148:11 Invalid type variable [34]: The current class isn't generic with respect to the type variable `Ts`.", 'generics_defaults.py:148:11 Undefined or invalid type [11]: Annotation `P` is not defined as a type.']
+Line 151: Unexpected errors ['generics_defaults.py:151:0 Assert type [70]: Expected `Type[Foo6[]]` but got `typing.Any`.', 'generics_defaults.py:151:12 Undefined attribute [16]: `Foo6` has no attribute `__getitem__`.', 'generics_defaults.py:151:28 Invalid type parameters [24]: Non-generic type `Foo6` cannot take parameters.']
+Line 152: Unexpected errors ['generics_defaults.py:152:0 Assert type [70]: Expected `Type[Foo6[]]` but got `typing.Any`.', 'generics_defaults.py:152:37 Invalid type parameters [24]: Non-generic type `Foo6` cannot take parameters.']
+Line 166: Unexpected errors ['generics_defaults.py:166:0 Assert type [70]: Expected `typing.Callable[[Foo7[]], Foo7[]]` but got `typing.Callable(Foo7.meth)[[Variable[_Self_generics_defaults_Foo7__ (bound to Foo7)]], Variable[_Self_generics_defaults_Foo7__ (bound to Foo7)]]`.', 'generics_defaults.py:166:23 Invalid type parameters [24]: Non-generic type `Foo7` cannot take parameters.']
+Line 167: Unexpected errors ['generics_defaults.py:167:0 Assert type [70]: Expected `int` but got `unknown`.']
 """

--- a/conformance/results/pyre/generics_defaults_referential.toml
+++ b/conformance/results/pyre/generics_defaults_referential.toml
@@ -3,18 +3,18 @@ output = """
 generics_defaults_referential.py:20:12 Undefined or invalid type [11]: Annotation `StartT` is not defined as a type.
 generics_defaults_referential.py:20:12 Undefined or invalid type [11]: Annotation `StepT` is not defined as a type.
 generics_defaults_referential.py:20:12 Undefined or invalid type [11]: Annotation `StopT` is not defined as a type.
-generics_defaults_referential.py:23:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Type[slice[]]` but got `Type[slice]`.
+generics_defaults_referential.py:23:0 Assert type [70]: Expected `Type[slice[]]` but got `Type[slice]`.
 generics_defaults_referential.py:23:19 Invalid type parameters [24]: Non-generic type `slice` cannot take parameters.
-generics_defaults_referential.py:24:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `slice[]` but got `slice`.
+generics_defaults_referential.py:24:0 Assert type [70]: Expected `slice[]` but got `slice`.
 generics_defaults_referential.py:24:21 Invalid type parameters [24]: Non-generic type `slice` cannot take parameters.
-generics_defaults_referential.py:25:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `slice[]` but got `typing.Any`.
+generics_defaults_referential.py:25:0 Assert type [70]: Expected `slice[]` but got `typing.Any`.
 generics_defaults_referential.py:25:12 Undefined attribute [16]: `slice` has no attribute `__getitem__`.
 generics_defaults_referential.py:25:26 Invalid type parameters [24]: Non-generic type `slice` cannot take parameters.
-generics_defaults_referential.py:26:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `slice[]` but got `typing.Any`.
+generics_defaults_referential.py:26:0 Assert type [70]: Expected `slice[]` but got `typing.Any`.
 generics_defaults_referential.py:26:41 Invalid type parameters [24]: Non-generic type `slice` cannot take parameters.
 generics_defaults_referential.py:31:10 Undefined or invalid type [11]: Annotation `DefaultStrT` is not defined as a type.
 generics_defaults_referential.py:31:10 Undefined or invalid type [11]: Annotation `T2` is not defined as a type.
-generics_defaults_referential.py:35:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Foo[]` but got `Foo`.
+generics_defaults_referential.py:35:0 Assert type [70]: Expected `Foo[]` but got `Foo`.
 generics_defaults_referential.py:35:24 Invalid type parameters [24]: Non-generic type `Foo` cannot take parameters.
 generics_defaults_referential.py:36:0 Undefined attribute [16]: `Foo` has no attribute `__getitem__`.
 generics_defaults_referential.py:46:11 Undefined or invalid type [11]: Annotation `S1` is not defined as a type.
@@ -24,16 +24,16 @@ generics_defaults_referential.py:53:13 Undefined or invalid type [11]: Annotatio
 generics_defaults_referential.py:87:47 Undefined attribute [16]: `list` has no attribute `__getitem__`.
 generics_defaults_referential.py:90:10 Undefined or invalid type [11]: Annotation `ListDefaultT` is not defined as a type.
 generics_defaults_referential.py:90:10 Undefined or invalid type [11]: Annotation `Z1` is not defined as a type.
-generics_defaults_referential.py:94:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Type[Bar[]]` but got `Type[Bar]`.
+generics_defaults_referential.py:94:0 Assert type [70]: Expected `Type[Bar[]]` but got `Type[Bar]`.
 generics_defaults_referential.py:94:17 Invalid type parameters [24]: Non-generic type `Bar` cannot take parameters.
-generics_defaults_referential.py:95:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Type[Bar[]]` but got `typing.Any`.
+generics_defaults_referential.py:95:0 Assert type [70]: Expected `Type[Bar[]]` but got `typing.Any`.
 generics_defaults_referential.py:95:12 Undefined attribute [16]: `Bar` has no attribute `__getitem__`.
 generics_defaults_referential.py:95:22 Invalid type parameters [24]: Non-generic type `Bar` cannot take parameters.
-generics_defaults_referential.py:96:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Bar[]` but got `typing.Any`.
+generics_defaults_referential.py:96:0 Assert type [70]: Expected `Bar[]` but got `typing.Any`.
 generics_defaults_referential.py:96:29 Invalid type parameters [24]: Non-generic type `Bar` cannot take parameters.
-generics_defaults_referential.py:97:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Bar[]` but got `typing.Any`.
+generics_defaults_referential.py:97:0 Assert type [70]: Expected `Bar[]` but got `typing.Any`.
 generics_defaults_referential.py:97:40 Invalid type parameters [24]: Non-generic type `Bar` cannot take parameters.
-generics_defaults_referential.py:98:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Bar[]` but got `typing.Any`.
+generics_defaults_referential.py:98:0 Assert type [70]: Expected `Bar[]` but got `typing.Any`.
 generics_defaults_referential.py:98:34 Invalid type parameters [24]: Non-generic type `Bar` cannot take parameters.
 """
 conformance_automated = "Fail"
@@ -44,18 +44,18 @@ Line 68: Expected 1 errors
 Line 74: Expected 1 errors
 Line 78: Expected 1 errors
 Line 20: Unexpected errors ['generics_defaults_referential.py:20:12 Undefined or invalid type [11]: Annotation `StartT` is not defined as a type.', 'generics_defaults_referential.py:20:12 Undefined or invalid type [11]: Annotation `StepT` is not defined as a type.', 'generics_defaults_referential.py:20:12 Undefined or invalid type [11]: Annotation `StopT` is not defined as a type.']
-Line 23: Unexpected errors ['generics_defaults_referential.py:23:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Type[slice[]]` but got `Type[slice]`.', 'generics_defaults_referential.py:23:19 Invalid type parameters [24]: Non-generic type `slice` cannot take parameters.']
-Line 24: Unexpected errors ['generics_defaults_referential.py:24:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `slice[]` but got `slice`.', 'generics_defaults_referential.py:24:21 Invalid type parameters [24]: Non-generic type `slice` cannot take parameters.']
-Line 25: Unexpected errors ['generics_defaults_referential.py:25:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `slice[]` but got `typing.Any`.', 'generics_defaults_referential.py:25:12 Undefined attribute [16]: `slice` has no attribute `__getitem__`.', 'generics_defaults_referential.py:25:26 Invalid type parameters [24]: Non-generic type `slice` cannot take parameters.']
-Line 26: Unexpected errors ['generics_defaults_referential.py:26:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `slice[]` but got `typing.Any`.', 'generics_defaults_referential.py:26:41 Invalid type parameters [24]: Non-generic type `slice` cannot take parameters.']
+Line 23: Unexpected errors ['generics_defaults_referential.py:23:0 Assert type [70]: Expected `Type[slice[]]` but got `Type[slice]`.', 'generics_defaults_referential.py:23:19 Invalid type parameters [24]: Non-generic type `slice` cannot take parameters.']
+Line 24: Unexpected errors ['generics_defaults_referential.py:24:0 Assert type [70]: Expected `slice[]` but got `slice`.', 'generics_defaults_referential.py:24:21 Invalid type parameters [24]: Non-generic type `slice` cannot take parameters.']
+Line 25: Unexpected errors ['generics_defaults_referential.py:25:0 Assert type [70]: Expected `slice[]` but got `typing.Any`.', 'generics_defaults_referential.py:25:12 Undefined attribute [16]: `slice` has no attribute `__getitem__`.', 'generics_defaults_referential.py:25:26 Invalid type parameters [24]: Non-generic type `slice` cannot take parameters.']
+Line 26: Unexpected errors ['generics_defaults_referential.py:26:0 Assert type [70]: Expected `slice[]` but got `typing.Any`.', 'generics_defaults_referential.py:26:41 Invalid type parameters [24]: Non-generic type `slice` cannot take parameters.']
 Line 31: Unexpected errors ['generics_defaults_referential.py:31:10 Undefined or invalid type [11]: Annotation `DefaultStrT` is not defined as a type.', 'generics_defaults_referential.py:31:10 Undefined or invalid type [11]: Annotation `T2` is not defined as a type.']
-Line 35: Unexpected errors ['generics_defaults_referential.py:35:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Foo[]` but got `Foo`.', 'generics_defaults_referential.py:35:24 Invalid type parameters [24]: Non-generic type `Foo` cannot take parameters.']
+Line 35: Unexpected errors ['generics_defaults_referential.py:35:0 Assert type [70]: Expected `Foo[]` but got `Foo`.', 'generics_defaults_referential.py:35:24 Invalid type parameters [24]: Non-generic type `Foo` cannot take parameters.']
 Line 46: Unexpected errors ['generics_defaults_referential.py:46:11 Undefined or invalid type [11]: Annotation `S1` is not defined as a type.', 'generics_defaults_referential.py:46:11 Undefined or invalid type [11]: Annotation `S2` is not defined as a type.']
 Line 87: Unexpected errors ['generics_defaults_referential.py:87:47 Undefined attribute [16]: `list` has no attribute `__getitem__`.']
 Line 90: Unexpected errors ['generics_defaults_referential.py:90:10 Undefined or invalid type [11]: Annotation `ListDefaultT` is not defined as a type.', 'generics_defaults_referential.py:90:10 Undefined or invalid type [11]: Annotation `Z1` is not defined as a type.']
-Line 94: Unexpected errors ['generics_defaults_referential.py:94:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Type[Bar[]]` but got `Type[Bar]`.', 'generics_defaults_referential.py:94:17 Invalid type parameters [24]: Non-generic type `Bar` cannot take parameters.']
-Line 95: Unexpected errors ['generics_defaults_referential.py:95:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Type[Bar[]]` but got `typing.Any`.', 'generics_defaults_referential.py:95:12 Undefined attribute [16]: `Bar` has no attribute `__getitem__`.', 'generics_defaults_referential.py:95:22 Invalid type parameters [24]: Non-generic type `Bar` cannot take parameters.']
-Line 96: Unexpected errors ['generics_defaults_referential.py:96:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Bar[]` but got `typing.Any`.', 'generics_defaults_referential.py:96:29 Invalid type parameters [24]: Non-generic type `Bar` cannot take parameters.']
-Line 97: Unexpected errors ['generics_defaults_referential.py:97:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Bar[]` but got `typing.Any`.', 'generics_defaults_referential.py:97:40 Invalid type parameters [24]: Non-generic type `Bar` cannot take parameters.']
-Line 98: Unexpected errors ['generics_defaults_referential.py:98:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Bar[]` but got `typing.Any`.', 'generics_defaults_referential.py:98:34 Invalid type parameters [24]: Non-generic type `Bar` cannot take parameters.']
+Line 94: Unexpected errors ['generics_defaults_referential.py:94:0 Assert type [70]: Expected `Type[Bar[]]` but got `Type[Bar]`.', 'generics_defaults_referential.py:94:17 Invalid type parameters [24]: Non-generic type `Bar` cannot take parameters.']
+Line 95: Unexpected errors ['generics_defaults_referential.py:95:0 Assert type [70]: Expected `Type[Bar[]]` but got `typing.Any`.', 'generics_defaults_referential.py:95:12 Undefined attribute [16]: `Bar` has no attribute `__getitem__`.', 'generics_defaults_referential.py:95:22 Invalid type parameters [24]: Non-generic type `Bar` cannot take parameters.']
+Line 96: Unexpected errors ['generics_defaults_referential.py:96:0 Assert type [70]: Expected `Bar[]` but got `typing.Any`.', 'generics_defaults_referential.py:96:29 Invalid type parameters [24]: Non-generic type `Bar` cannot take parameters.']
+Line 97: Unexpected errors ['generics_defaults_referential.py:97:0 Assert type [70]: Expected `Bar[]` but got `typing.Any`.', 'generics_defaults_referential.py:97:40 Invalid type parameters [24]: Non-generic type `Bar` cannot take parameters.']
+Line 98: Unexpected errors ['generics_defaults_referential.py:98:0 Assert type [70]: Expected `Bar[]` but got `typing.Any`.', 'generics_defaults_referential.py:98:34 Invalid type parameters [24]: Non-generic type `Bar` cannot take parameters.']
 """

--- a/conformance/results/pyre/generics_defaults_specialization.toml
+++ b/conformance/results/pyre/generics_defaults_specialization.toml
@@ -7,18 +7,21 @@ generics_defaults_specialization.py:19:30 Undefined or invalid type [11]: Annota
 generics_defaults_specialization.py:19:30 Undefined or invalid type [11]: Annotation `T2` is not defined as a type.
 generics_defaults_specialization.py:22:21 Undefined attribute [16]: `SomethingWithNoDefaults` has no attribute `__getitem__`.
 generics_defaults_specialization.py:25:14 Undefined or invalid type [11]: Annotation `MyAlias` is not defined as a type.
+generics_defaults_specialization.py:26:4 Assert type [70]: Expected `SomethingWithNoDefaults[]` but got `unknown`.
 generics_defaults_specialization.py:26:20 Invalid type parameters [24]: Non-generic type `SomethingWithNoDefaults` cannot take parameters.
+generics_defaults_specialization.py:27:4 Assert type [70]: Expected `SomethingWithNoDefaults[]` but got `unknown`.
 generics_defaults_specialization.py:27:20 Invalid type parameters [24]: Non-generic type `SomethingWithNoDefaults` cannot take parameters.
 generics_defaults_specialization.py:30:0 Undefined attribute [16]: `TypeAlias` has no attribute `__getitem__`.
 generics_defaults_specialization.py:38:17 Undefined or invalid type [11]: Annotation `DefaultStrT` is not defined as a type.
-generics_defaults_specialization.py:45:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Type[Bar[]]` but got `Type[Bar]`.
+generics_defaults_specialization.py:45:0 Assert type [70]: Expected `Type[Bar[]]` but got `Type[Bar]`.
 generics_defaults_specialization.py:45:17 Invalid type parameters [24]: Non-generic type `Bar` cannot take parameters.
-generics_defaults_specialization.py:46:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Bar[]` but got `Bar`.
+generics_defaults_specialization.py:46:0 Assert type [70]: Expected `Bar[]` but got `Bar`.
 generics_defaults_specialization.py:46:19 Invalid type parameters [24]: Non-generic type `Bar` cannot take parameters.
-generics_defaults_specialization.py:47:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Bar[]` but got `typing.Any`.
+generics_defaults_specialization.py:47:0 Assert type [70]: Expected `Bar[]` but got `typing.Any`.
 generics_defaults_specialization.py:47:12 Undefined attribute [16]: `Bar` has no attribute `__getitem__`.
 generics_defaults_specialization.py:47:25 Invalid type parameters [24]: Non-generic type `Bar` cannot take parameters.
 generics_defaults_specialization.py:50:10 Invalid type parameters [24]: Non-generic type `SubclassMe` cannot take parameters.
+generics_defaults_specialization.py:53:0 Assert type [70]: Expected `str` but got `unknown`.
 generics_defaults_specialization.py:55:0 Undefined attribute [16]: `Foo` has no attribute `__getitem__`.
 generics_defaults_specialization.py:58:10 Undefined or invalid type [11]: Annotation `DefaultIntT` is not defined as a type.
 generics_defaults_specialization.py:65:0 Incompatible variable type [9]: v1 is declared to have type `Baz[]` but is used as type `Spam`.
@@ -29,13 +32,14 @@ errors_diff = """
 Line 19: Unexpected errors ['generics_defaults_specialization.py:19:30 Undefined or invalid type [11]: Annotation `T1` is not defined as a type.', 'generics_defaults_specialization.py:19:30 Undefined or invalid type [11]: Annotation `T2` is not defined as a type.']
 Line 22: Unexpected errors ['generics_defaults_specialization.py:22:21 Undefined attribute [16]: `SomethingWithNoDefaults` has no attribute `__getitem__`.']
 Line 25: Unexpected errors ['generics_defaults_specialization.py:25:14 Undefined or invalid type [11]: Annotation `MyAlias` is not defined as a type.']
-Line 26: Unexpected errors ['generics_defaults_specialization.py:26:20 Invalid type parameters [24]: Non-generic type `SomethingWithNoDefaults` cannot take parameters.']
-Line 27: Unexpected errors ['generics_defaults_specialization.py:27:20 Invalid type parameters [24]: Non-generic type `SomethingWithNoDefaults` cannot take parameters.']
+Line 26: Unexpected errors ['generics_defaults_specialization.py:26:4 Assert type [70]: Expected `SomethingWithNoDefaults[]` but got `unknown`.', 'generics_defaults_specialization.py:26:20 Invalid type parameters [24]: Non-generic type `SomethingWithNoDefaults` cannot take parameters.']
+Line 27: Unexpected errors ['generics_defaults_specialization.py:27:4 Assert type [70]: Expected `SomethingWithNoDefaults[]` but got `unknown`.', 'generics_defaults_specialization.py:27:20 Invalid type parameters [24]: Non-generic type `SomethingWithNoDefaults` cannot take parameters.']
 Line 38: Unexpected errors ['generics_defaults_specialization.py:38:17 Undefined or invalid type [11]: Annotation `DefaultStrT` is not defined as a type.']
-Line 45: Unexpected errors ['generics_defaults_specialization.py:45:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Type[Bar[]]` but got `Type[Bar]`.', 'generics_defaults_specialization.py:45:17 Invalid type parameters [24]: Non-generic type `Bar` cannot take parameters.']
-Line 46: Unexpected errors ['generics_defaults_specialization.py:46:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Bar[]` but got `Bar`.', 'generics_defaults_specialization.py:46:19 Invalid type parameters [24]: Non-generic type `Bar` cannot take parameters.']
-Line 47: Unexpected errors ['generics_defaults_specialization.py:47:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Bar[]` but got `typing.Any`.', 'generics_defaults_specialization.py:47:12 Undefined attribute [16]: `Bar` has no attribute `__getitem__`.', 'generics_defaults_specialization.py:47:25 Invalid type parameters [24]: Non-generic type `Bar` cannot take parameters.']
+Line 45: Unexpected errors ['generics_defaults_specialization.py:45:0 Assert type [70]: Expected `Type[Bar[]]` but got `Type[Bar]`.', 'generics_defaults_specialization.py:45:17 Invalid type parameters [24]: Non-generic type `Bar` cannot take parameters.']
+Line 46: Unexpected errors ['generics_defaults_specialization.py:46:0 Assert type [70]: Expected `Bar[]` but got `Bar`.', 'generics_defaults_specialization.py:46:19 Invalid type parameters [24]: Non-generic type `Bar` cannot take parameters.']
+Line 47: Unexpected errors ['generics_defaults_specialization.py:47:0 Assert type [70]: Expected `Bar[]` but got `typing.Any`.', 'generics_defaults_specialization.py:47:12 Undefined attribute [16]: `Bar` has no attribute `__getitem__`.', 'generics_defaults_specialization.py:47:25 Invalid type parameters [24]: Non-generic type `Bar` cannot take parameters.']
 Line 50: Unexpected errors ['generics_defaults_specialization.py:50:10 Invalid type parameters [24]: Non-generic type `SubclassMe` cannot take parameters.']
+Line 53: Unexpected errors ['generics_defaults_specialization.py:53:0 Assert type [70]: Expected `str` but got `unknown`.']
 Line 58: Unexpected errors ['generics_defaults_specialization.py:58:10 Undefined or invalid type [11]: Annotation `DefaultIntT` is not defined as a type.']
 Line 65: Unexpected errors ['generics_defaults_specialization.py:65:0 Incompatible variable type [9]: v1 is declared to have type `Baz[]` but is used as type `Spam`.', 'generics_defaults_specialization.py:65:4 Invalid type parameters [24]: Non-generic type `Baz` cannot take parameters.']
 """

--- a/conformance/results/pyre/generics_paramspec_components.toml
+++ b/conformance/results/pyre/generics_paramspec_components.toml
@@ -13,7 +13,7 @@ generics_paramspec_components.py:17:44 Undefined or invalid type [11]: Annotatio
 generics_paramspec_components.py:49:8 Call error [29]: `typing.Callable[generics_paramspec_components.P, int]` cannot be safely called because the types and kinds of its parameters depend on a type variable.
 generics_paramspec_components.py:70:8 Call error [29]: `typing.Callable[typing.Concatenate[int, generics_paramspec_components.P], int]` cannot be safely called because the types and kinds of its parameters depend on a type variable.
 generics_paramspec_components.py:72:8 Missing argument [20]: PositionalOnly call expects argument in position 0.
-generics_paramspec_components.py:83:8 Unexpected keyword [28]: Unexpected keyword argument `x` to call `foo`.
+generics_paramspec_components.py:83:8 Unexpected keyword [28]: Unexpected keyword argument `x` to call `outer.foo`.
 generics_paramspec_components.py:98:19 Incompatible parameter type [6]: In call `twice`, for 2nd positional argument, expected `int` but got `str`.
 generics_paramspec_components.py:98:24 Incompatible parameter type [6]: In call `twice`, for 3rd positional argument, expected `str` but got `int`.
 """

--- a/conformance/results/pyre/generics_paramspec_semantics.toml
+++ b/conformance/results/pyre/generics_paramspec_semantics.toml
@@ -7,9 +7,9 @@ generics_paramspec_semantics.py:61:22 Incompatible parameter type [6]: In call `
 generics_paramspec_semantics.py:98:3 Incompatible parameter type [6]: In anonymous call, for 1st positional argument, expected `str` but got `int`.
 generics_paramspec_semantics.py:108:3 Incompatible parameter type [6]: In anonymous call, for 1st positional argument, expected `bool` but got `int`.
 generics_paramspec_semantics.py:120:3 Incompatible parameter type [6]: In anonymous call, for 1st positional argument, expected `str` but got `int`.
-generics_paramspec_semantics.py:127:1 Invalid decoration [56]: Pyre doesn't yet support decorators with ParamSpec applied to generic functions Please add # pyre-ignore[56] to `generics_paramspec_semantics.expects_int_first`.
-generics_paramspec_semantics.py:132:1 Invalid decoration [56]: Pyre doesn't yet support decorators with ParamSpec applied to generic functions Please add # pyre-ignore[56] to `generics_paramspec_semantics.expects_int_first`.
-generics_paramspec_semantics.py:137:1 Invalid decoration [56]: Pyre doesn't yet support decorators with ParamSpec applied to generic functions Please add # pyre-ignore[56] to `generics_paramspec_semantics.expects_int_first`.
+generics_paramspec_semantics.py:127:1 Invalid decoration [56]: Pyre doesn't yet support decorators with ParamSpec applied to generic functions. Consider using a context manager instead of a decorator, if possible.
+generics_paramspec_semantics.py:132:1 Invalid decoration [56]: Pyre doesn't yet support decorators with ParamSpec applied to generic functions. Consider using a context manager instead of a decorator, if possible.
+generics_paramspec_semantics.py:137:1 Invalid decoration [56]: Pyre doesn't yet support decorators with ParamSpec applied to generic functions. Consider using a context manager instead of a decorator, if possible.
 """
 conformance_automated = "Pass"
 errors_diff = """

--- a/conformance/results/pyre/generics_scoping.toml
+++ b/conformance/results/pyre/generics_scoping.toml
@@ -2,17 +2,18 @@ conformant = "Partial"
 notes = """
 False negative on generic class nested within generic function with same type variable.
 False negative on generic class nested within generic class with same type variable.
+False negative on assert_type uses.
 """
 output = """
-generics_scoping.py:14:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `typing_extensions.Literal[1]`.
-generics_scoping.py:15:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `str` but got `typing_extensions.Literal['a']`.
+generics_scoping.py:14:0 Assert type [70]: Expected `int` but got `typing_extensions.Literal[1]`.
+generics_scoping.py:15:0 Assert type [70]: Expected `str` but got `typing_extensions.Literal['a']`.
 generics_scoping.py:29:9 Incompatible parameter type [6]: In call `MyClass.meth_2`, for 1st positional argument, expected `int` but got `str`.
-generics_scoping.py:42:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `str` but got `typing_extensions.Literal['abc']`.
-generics_scoping.py:43:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `bytes` but got `typing_extensions.Literal[b'abc']`.
+generics_scoping.py:42:0 Assert type [70]: Expected `str` but got `typing_extensions.Literal['abc']`.
+generics_scoping.py:43:0 Assert type [70]: Expected `bytes` but got `typing_extensions.Literal[b'abc']`.
 generics_scoping.py:50:7 Invalid type variable [34]: The type variable `Variable[S]` isn't present in the function's parameters.
 generics_scoping.py:54:13 Invalid type variable [34]: The current class isn't generic with respect to the type variable `Variable[S]`. To reference the type variable, you can modify the class to inherit from `typing.Generic[S]`.
 generics_scoping.py:78:11 Invalid type variable [34]: The current class isn't generic with respect to the type variable `Variable[T]`. To reference the type variable, you can modify the class to inherit from `typing.Generic[T]`.
-generics_scoping.py:87:23 Undefined attribute [16]: `list` has no attribute `__getitem__`.
+generics_scoping.py:87:4 Incompatible attribute type [8]: Attribute `alias` declared in class `Outer` has type `TypeAlias` but is used as type `Type[List[Variable[T]]]`.
 generics_scoping.py:94:13 Invalid type variable [34]: The type variable `Variable[T]` can only be used to annotate generic classes or functions.
 generics_scoping.py:95:13 Invalid type variable [34]: The type variable `Variable[T]` can only be used to annotate generic classes or functions.
 generics_scoping.py:96:0 Undefined attribute [16]: `list` has no attribute `__getitem__`.
@@ -21,8 +22,8 @@ conformance_automated = "Fail"
 errors_diff = """
 Line 65: Expected 1 errors
 Line 75: Expected 1 errors
-Line 14: Unexpected errors ['generics_scoping.py:14:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `typing_extensions.Literal[1]`.']
-Line 15: Unexpected errors ["generics_scoping.py:15:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `str` but got `typing_extensions.Literal['a']`."]
-Line 42: Unexpected errors ["generics_scoping.py:42:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `str` but got `typing_extensions.Literal['abc']`."]
-Line 43: Unexpected errors ["generics_scoping.py:43:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `bytes` but got `typing_extensions.Literal[b'abc']`."]
+Line 14: Unexpected errors ['generics_scoping.py:14:0 Assert type [70]: Expected `int` but got `typing_extensions.Literal[1]`.']
+Line 15: Unexpected errors ["generics_scoping.py:15:0 Assert type [70]: Expected `str` but got `typing_extensions.Literal['a']`."]
+Line 42: Unexpected errors ["generics_scoping.py:42:0 Assert type [70]: Expected `str` but got `typing_extensions.Literal['abc']`."]
+Line 43: Unexpected errors ["generics_scoping.py:43:0 Assert type [70]: Expected `bytes` but got `typing_extensions.Literal[b'abc']`."]
 """

--- a/conformance/results/pyre/generics_self_advanced.toml
+++ b/conformance/results/pyre/generics_self_advanced.toml
@@ -1,23 +1,24 @@
 conformant = "Partial"
 notes = """
 Does not handle use of `Self` within class body correctly.
+False negatives on assert_type uses.
 """
 output = """
 generics_self_advanced.py:25:7 Undefined or invalid type [11]: Annotation `Self` is not defined as a type.
-generics_self_advanced.py:35:8 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `unknown` but got `ChildB`.
-generics_self_advanced.py:37:8 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `unknown` but got `typing.Any`.
-generics_self_advanced.py:38:8 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `unknown` but got `ChildB`.
-generics_self_advanced.py:42:8 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `unknown` but got `Type[ChildB]`.
-generics_self_advanced.py:44:8 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `unknown` but got `typing.Any`.
-generics_self_advanced.py:45:8 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `unknown` but got `ChildB`.
+generics_self_advanced.py:35:8 Assert type [70]: Expected `unknown` but got `ChildB`.
+generics_self_advanced.py:37:8 Assert type [70]: Expected `unknown` but got `typing.Any`.
+generics_self_advanced.py:38:8 Assert type [70]: Expected `unknown` but got `ChildB`.
+generics_self_advanced.py:42:8 Assert type [70]: Expected `unknown` but got `Type[ChildB]`.
+generics_self_advanced.py:44:8 Assert type [70]: Expected `unknown` but got `typing.Any`.
+generics_self_advanced.py:45:8 Assert type [70]: Expected `unknown` but got `ChildB`.
 """
 conformance_automated = "Fail"
 errors_diff = """
 Line 25: Unexpected errors ['generics_self_advanced.py:25:7 Undefined or invalid type [11]: Annotation `Self` is not defined as a type.']
-Line 35: Unexpected errors ['generics_self_advanced.py:35:8 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `unknown` but got `ChildB`.']
-Line 37: Unexpected errors ['generics_self_advanced.py:37:8 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `unknown` but got `typing.Any`.']
-Line 38: Unexpected errors ['generics_self_advanced.py:38:8 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `unknown` but got `ChildB`.']
-Line 42: Unexpected errors ['generics_self_advanced.py:42:8 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `unknown` but got `Type[ChildB]`.']
-Line 44: Unexpected errors ['generics_self_advanced.py:44:8 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `unknown` but got `typing.Any`.']
-Line 45: Unexpected errors ['generics_self_advanced.py:45:8 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `unknown` but got `ChildB`.']
+Line 35: Unexpected errors ['generics_self_advanced.py:35:8 Assert type [70]: Expected `unknown` but got `ChildB`.']
+Line 37: Unexpected errors ['generics_self_advanced.py:37:8 Assert type [70]: Expected `unknown` but got `typing.Any`.']
+Line 38: Unexpected errors ['generics_self_advanced.py:38:8 Assert type [70]: Expected `unknown` but got `ChildB`.']
+Line 42: Unexpected errors ['generics_self_advanced.py:42:8 Assert type [70]: Expected `unknown` but got `Type[ChildB]`.']
+Line 44: Unexpected errors ['generics_self_advanced.py:44:8 Assert type [70]: Expected `unknown` but got `typing.Any`.']
+Line 45: Unexpected errors ['generics_self_advanced.py:45:8 Assert type [70]: Expected `unknown` but got `ChildB`.']
 """

--- a/conformance/results/pyre/generics_self_basic.toml
+++ b/conformance/results/pyre/generics_self_basic.toml
@@ -3,17 +3,17 @@ notes = """
 Does not handle use of `Self` as a generic type.
 """
 output = """
-generics_self_basic.py:14:8 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `unknown` but got `Variable[_Self_generics_self_basic_Shape__ (bound to Shape)]`.
+generics_self_basic.py:14:8 Assert type [70]: Expected `unknown` but got `Variable[_Self_generics_self_basic_Shape__ (bound to Shape)]`.
 generics_self_basic.py:14:26 Undefined or invalid type [11]: Annotation `Self` is not defined as a type.
 generics_self_basic.py:20:8 Incompatible return type [7]: Expected `Variable[_Self_generics_self_basic_Shape__ (bound to Shape)]` but got `Shape`.
-generics_self_basic.py:27:8 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `unknown` but got `Type[Variable[_Self_generics_self_basic_Shape__ (bound to Shape)]]`.
+generics_self_basic.py:27:8 Assert type [70]: Expected `unknown` but got `Type[Variable[_Self_generics_self_basic_Shape__ (bound to Shape)]]`.
 generics_self_basic.py:33:8 Incompatible return type [7]: Expected `Variable[_Self_generics_self_basic_Shape__ (bound to Shape)]` but got `Shape`.
-generics_self_basic.py:40:8 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `unknown` but got `Variable[_Self_generics_self_basic_Shape__ (bound to Shape)]`.
+generics_self_basic.py:40:8 Assert type [70]: Expected `unknown` but got `Variable[_Self_generics_self_basic_Shape__ (bound to Shape)]`.
+generics_self_basic.py:67:25 Invalid type parameters [24]: Non-generic type `_Self_generics_self_basic_Container__` cannot take parameters.
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 67: Expected 1 errors
-Line 14: Unexpected errors ['generics_self_basic.py:14:8 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `unknown` but got `Variable[_Self_generics_self_basic_Shape__ (bound to Shape)]`.', 'generics_self_basic.py:14:26 Undefined or invalid type [11]: Annotation `Self` is not defined as a type.']
-Line 27: Unexpected errors ['generics_self_basic.py:27:8 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `unknown` but got `Type[Variable[_Self_generics_self_basic_Shape__ (bound to Shape)]]`.']
-Line 40: Unexpected errors ['generics_self_basic.py:40:8 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `unknown` but got `Variable[_Self_generics_self_basic_Shape__ (bound to Shape)]`.']
+Line 14: Unexpected errors ['generics_self_basic.py:14:8 Assert type [70]: Expected `unknown` but got `Variable[_Self_generics_self_basic_Shape__ (bound to Shape)]`.', 'generics_self_basic.py:14:26 Undefined or invalid type [11]: Annotation `Self` is not defined as a type.']
+Line 27: Unexpected errors ['generics_self_basic.py:27:8 Assert type [70]: Expected `unknown` but got `Type[Variable[_Self_generics_self_basic_Shape__ (bound to Shape)]]`.']
+Line 40: Unexpected errors ['generics_self_basic.py:40:8 Assert type [70]: Expected `unknown` but got `Variable[_Self_generics_self_basic_Shape__ (bound to Shape)]`.']
 """

--- a/conformance/results/pyre/generics_syntax_compatibility.toml
+++ b/conformance/results/pyre/generics_syntax_compatibility.toml
@@ -1,11 +1,14 @@
-conformant = "Unsupported"
+conformant = "Partial"
 notes = """
-Type parameter syntax not yet support.
+False negative on mixing legacy and PEP695 syntax.
+Does not detect mixing legacy and PEP695 syntax in methods.
 """
 output = """
-generics_syntax_compatibility.py:14:13 Parsing failure [404]: invalid syntax
+generics_syntax_compatibility.py:14:16 Invalid type variable [34]: The current class isn't generic with respect to the type variable `Variable[K]`. To reference the type variable, you can modify the class to inherit from `typing.Generic[K]`.
+generics_syntax_compatibility.py:18:19 Invalid type variable [34]: The current class isn't generic with respect to the type variable `Variable[K]`. To reference the type variable, you can modify the class to inherit from `typing.Generic[K]`.
 """
 conformance_automated = "Fail"
 errors_diff = """
 Line 26: Expected 1 errors
+Line 18: Unexpected errors ["generics_syntax_compatibility.py:18:19 Invalid type variable [34]: The current class isn't generic with respect to the type variable `Variable[K]`. To reference the type variable, you can modify the class to inherit from `typing.Generic[K]`."]
 """

--- a/conformance/results/pyre/generics_syntax_declarations.toml
+++ b/conformance/results/pyre/generics_syntax_declarations.toml
@@ -1,21 +1,20 @@
-conformant = "Unsupported"
+conformant = "Partial"
 notes = """
-Type parameter syntax not yet support.
+Does not detect incorrect use of legacy style syntax mixed with PEP695 syntax.
+False negatives due to assert_type use.
 """
 output = """
-generics_syntax_declarations.py:13:17 Parsing failure [404]: invalid syntax
+generics_syntax_declarations.py:32:8 Undefined attribute [16]: `Variable[T (bound to str)]` has no attribute `is_integer`.
+generics_syntax_declarations.py:44:20 Invalid bound [75]: `dict[(str, V)]` is not valid bound.
+generics_syntax_declarations.py:48:16 Invalid bound [75]: `[str, int]` is not valid bound.
+generics_syntax_declarations.py:60:16 Invalid bound [75]: `()` is not valid bound.
+generics_syntax_declarations.py:64:16 Invalid bound [75]: `(str)` is not valid bound.
+generics_syntax_declarations.py:71:16 Invalid bound [75]: `$local_generics_syntax_declarations$t1` is not valid bound.
+generics_syntax_declarations.py:75:16 Invalid bound [75]: `(3, bytes)` is not valid bound.
+generics_syntax_declarations.py:79:16 Invalid bound [75]: `(list[S], str)` is not valid bound.
 """
 conformance_automated = "Fail"
 errors_diff = """
 Line 17: Expected 1 errors
 Line 25: Expected 1 errors
-Line 32: Expected 1 errors
-Line 44: Expected 1 errors
-Line 48: Expected 1 errors
-Line 60: Expected 1 errors
-Line 64: Expected 1 errors
-Line 71: Expected 1 errors
-Line 75: Expected 1 errors
-Line 79: Expected 1 errors
-Line 13: Unexpected errors ['generics_syntax_declarations.py:13:17 Parsing failure [404]: invalid syntax']
 """

--- a/conformance/results/pyre/generics_syntax_infer_variance.toml
+++ b/conformance/results/pyre/generics_syntax_infer_variance.toml
@@ -1,29 +1,33 @@
-conformant = "Unsupported"
+conformant = "Partial"
 notes = """
-Type parameter syntax not yet support.
+Incorrectly determines that a class cannot be instantiated with __getitem__.
+Incorrectly handles mixing legacy and PEP695 syntax.
 """
 output = """
-generics_syntax_infer_variance.py:132:25 Parsing failure [404]: invalid syntax
+generics_syntax_infer_variance.py:15:0 Invalid variance definition [77]: Cannot use infer_variance with predefined variance.
+generics_syntax_infer_variance.py:17:0 Invalid variance definition [77]: Cannot use infer_variance with predefined variance.
+generics_syntax_infer_variance.py:29:0 Incompatible variable type [9]: vco1_2 is declared to have type `ShouldBeCovariant1[int]` but is used as type `ShouldBeCovariant1[float]`.
+generics_syntax_infer_variance.py:36:36 Invalid class instantiation [45]: Cannot instantiate abstract class `ShouldBeCovariant2` with abstract methods `__getitem__`, `__len__`.
+generics_syntax_infer_variance.py:37:0 Incompatible variable type [9]: vco2_2 is declared to have type `ShouldBeCovariant2[int]` but is used as type `ShouldBeCovariant2[float]`.
+generics_syntax_infer_variance.py:37:34 Invalid class instantiation [45]: Cannot instantiate abstract class `ShouldBeCovariant2` with abstract methods `__getitem__`, `__len__`.
+generics_syntax_infer_variance.py:46:0 Incompatible variable type [9]: vco3_2 is declared to have type `ShouldBeCovariant3[int]` but is used as type `ShouldBeCovariant3[float]`.
+generics_syntax_infer_variance.py:75:0 Incompatible variable type [9]: vo5_2 is declared to have type `ShouldBeCovariant5[int]` but is used as type `ShouldBeCovariant5[float]`.
+generics_syntax_infer_variance.py:86:0 Incompatible variable type [9]: vo6_2 is declared to have type `ShouldBeCovariant6[int]` but is used as type `ShouldBeCovariant6[float]`.
+generics_syntax_infer_variance.py:102:0 Incompatible variable type [9]: vinv1_1 is declared to have type `ShouldBeInvariant1[float]` but is used as type `ShouldBeInvariant1[int]`.
+generics_syntax_infer_variance.py:103:0 Incompatible variable type [9]: vinv1_2 is declared to have type `ShouldBeInvariant1[int]` but is used as type `ShouldBeInvariant1[float]`.
+generics_syntax_infer_variance.py:117:0 Incompatible variable type [9]: vinv2_1 is declared to have type `ShouldBeInvariant2[float]` but is used as type `ShouldBeInvariant2[int]`.
+generics_syntax_infer_variance.py:118:0 Incompatible variable type [9]: vinv2_2 is declared to have type `ShouldBeInvariant2[int]` but is used as type `ShouldBeInvariant2[float]`.
+generics_syntax_infer_variance.py:125:0 Incompatible variable type [9]: vinv3_1 is declared to have type `ShouldBeInvariant3[float, str]` but is used as type `ShouldBeInvariant3[int, str]`.
+generics_syntax_infer_variance.py:126:0 Incompatible variable type [9]: vinv3_2 is declared to have type `ShouldBeInvariant3[int, str]` but is used as type `ShouldBeInvariant3[float, str]`.
+generics_syntax_infer_variance.py:127:0 Incompatible variable type [9]: vinv3_3 is declared to have type `ShouldBeInvariant3[str, float]` but is used as type `ShouldBeInvariant3[str, int]`.
+generics_syntax_infer_variance.py:128:0 Incompatible variable type [9]: vinv3_4 is declared to have type `ShouldBeInvariant3[str, int]` but is used as type `ShouldBeInvariant3[str, float]`.
+generics_syntax_infer_variance.py:133:7 Invalid type variable [34]: The current class isn't generic with respect to the type variable `Variable[T]`. To reference the type variable, you can modify the class to inherit from `typing.Generic[T]`.
+generics_syntax_infer_variance.py:155:0 Incompatible variable type [9]: vcontra1_1 is declared to have type `ShouldBeContravariant1[float]` but is used as type `ShouldBeContravariant1[int]`.
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 15: Expected 1 errors
-Line 17: Expected 1 errors
-Line 29: Expected 1 errors
-Line 37: Expected 1 errors
-Line 46: Expected 1 errors
-Line 75: Expected 1 errors
-Line 86: Expected 1 errors
-Line 102: Expected 1 errors
-Line 103: Expected 1 errors
-Line 117: Expected 1 errors
-Line 118: Expected 1 errors
-Line 125: Expected 1 errors
-Line 126: Expected 1 errors
-Line 127: Expected 1 errors
-Line 128: Expected 1 errors
 Line 136: Expected 1 errors
 Line 144: Expected 1 errors
-Line 155: Expected 1 errors
-Line 132: Unexpected errors ['generics_syntax_infer_variance.py:132:25 Parsing failure [404]: invalid syntax']
+Line 36: Unexpected errors ['generics_syntax_infer_variance.py:36:36 Invalid class instantiation [45]: Cannot instantiate abstract class `ShouldBeCovariant2` with abstract methods `__getitem__`, `__len__`.']
+Line 133: Unexpected errors ["generics_syntax_infer_variance.py:133:7 Invalid type variable [34]: The current class isn't generic with respect to the type variable `Variable[T]`. To reference the type variable, you can modify the class to inherit from `typing.Generic[T]`."]
 """

--- a/conformance/results/pyre/generics_syntax_scoping.toml
+++ b/conformance/results/pyre/generics_syntax_scoping.toml
@@ -1,16 +1,20 @@
-conformant = "Unsupported"
+conformant = "Partial"
 notes = """
-Type parameter syntax not yet support.
+Does not properly handle mixing legacy syntax with PEP695 syntax.
 """
 output = """
-generics_syntax_scoping.py:14:13 Parsing failure [404]: invalid syntax
+generics_syntax_scoping.py:14:19 Invalid bound [75]: `typing.Sequence[$local_generics_syntax_scoping$S]` is not valid bound.
+generics_syntax_scoping.py:18:16 Invalid bound [75]: `typing.Sequence[$local_generics_syntax_scoping$T]` is not valid bound.
+generics_syntax_scoping.py:27:38 Undefined or invalid type [11]: Annotation `T` is not defined as a type.
+generics_syntax_scoping.py:31:41 Incompatible parameter type [6]: In call `typing.GenericMeta.__getitem__`, for 1st positional argument, expected `Type[Variable[T]]` but got `int`.
+generics_syntax_scoping.py:98:28 Undefined or invalid type [11]: Annotation `ClassE.T` is not defined as a type.
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 18: Expected 1 errors
 Line 35: Expected 1 errors
 Line 44: Expected 1 errors
 Line 92: Expected 1 errors
 Line 95: Expected 1 errors
-Line 98: Expected 1 errors
+Line 27: Unexpected errors ['generics_syntax_scoping.py:27:38 Undefined or invalid type [11]: Annotation `T` is not defined as a type.']
+Line 31: Unexpected errors ['generics_syntax_scoping.py:31:41 Incompatible parameter type [6]: In call `typing.GenericMeta.__getitem__`, for 1st positional argument, expected `Type[Variable[T]]` but got `int`.']
 """

--- a/conformance/results/pyre/generics_type_erasure.toml
+++ b/conformance/results/pyre/generics_type_erasure.toml
@@ -3,15 +3,16 @@ notes = """
 Does not erase unspecified type variables to `Any` prior to `assert_type` handling.
 False negatives on instance attribute access on the type.
 Does not infer type of `DefaultDict` with explicit type parameters on constructor.
+False negatives on assert_type uses.
 """
 output = """
-generics_type_erasure.py:17:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Node[str]` but got `Node[typing_extensions.Literal['']]`.
-generics_type_erasure.py:18:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Node[int]` but got `Node[typing_extensions.Literal[0]]`.
-generics_type_erasure.py:19:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Node[typing.Any]` but got `Node[Variable[T]]`.
-generics_type_erasure.py:21:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `typing_extensions.Literal[0]`.
+generics_type_erasure.py:17:0 Assert type [70]: Expected `Node[str]` but got `Node[typing_extensions.Literal['']]`.
+generics_type_erasure.py:18:0 Assert type [70]: Expected `Node[int]` but got `Node[typing_extensions.Literal[0]]`.
+generics_type_erasure.py:19:0 Assert type [70]: Expected `Node[typing.Any]` but got `Node[Variable[T]]`.
+generics_type_erasure.py:21:0 Assert type [70]: Expected `int` but got `typing_extensions.Literal[0]`.
 generics_type_erasure.py:38:15 Incompatible parameter type [6]: In call `Node.__init__`, for 1st positional argument, expected `Optional[int]` but got `str`.
 generics_type_erasure.py:40:15 Incompatible parameter type [6]: In call `Node.__init__`, for 1st positional argument, expected `Optional[str]` but got `int`.
-generics_type_erasure.py:56:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `bytes` but got `typing.Any`.
+generics_type_erasure.py:56:0 Assert type [70]: Expected `bytes` but got `typing.Any`.
 """
 conformance_automated = "Fail"
 errors_diff = """
@@ -20,9 +21,9 @@ Line 43: Expected 1 errors
 Line 44: Expected 1 errors
 Line 45: Expected 1 errors
 Line 46: Expected 1 errors
-Line 17: Unexpected errors ["generics_type_erasure.py:17:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Node[str]` but got `Node[typing_extensions.Literal['']]`."]
-Line 18: Unexpected errors ['generics_type_erasure.py:18:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Node[int]` but got `Node[typing_extensions.Literal[0]]`.']
-Line 19: Unexpected errors ['generics_type_erasure.py:19:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Node[typing.Any]` but got `Node[Variable[T]]`.']
-Line 21: Unexpected errors ['generics_type_erasure.py:21:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `typing_extensions.Literal[0]`.']
-Line 56: Unexpected errors ['generics_type_erasure.py:56:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `bytes` but got `typing.Any`.']
+Line 17: Unexpected errors ["generics_type_erasure.py:17:0 Assert type [70]: Expected `Node[str]` but got `Node[typing_extensions.Literal['']]`."]
+Line 18: Unexpected errors ['generics_type_erasure.py:18:0 Assert type [70]: Expected `Node[int]` but got `Node[typing_extensions.Literal[0]]`.']
+Line 19: Unexpected errors ['generics_type_erasure.py:19:0 Assert type [70]: Expected `Node[typing.Any]` but got `Node[Variable[T]]`.']
+Line 21: Unexpected errors ['generics_type_erasure.py:21:0 Assert type [70]: Expected `int` but got `typing_extensions.Literal[0]`.']
+Line 56: Unexpected errors ['generics_type_erasure.py:56:0 Assert type [70]: Expected `bytes` but got `typing.Any`.']
 """

--- a/conformance/results/pyre/generics_typevartuple_args.toml
+++ b/conformance/results/pyre/generics_typevartuple_args.toml
@@ -1,32 +1,25 @@
-conformant = "Unsupported"
+conformant = "Partial"
 notes = """
-Does not support star expressions for `Unpack`.
+Does not property handle TypeVarTuple.
 """
 output = """
-generics_typevartuple_args.py:16:25 Invalid type [31]: Expression `*Ts` is not a valid type.
-generics_typevartuple_args.py:16:33 Invalid type [31]: Expression `tuple[(*Ts)]` is not a valid type.
-generics_typevartuple_args.py:27:30 Invalid type [31]: Expression `*tuple[(*Ts, generics_typevartuple_args.Env)]` is not a valid type.
-generics_typevartuple_args.py:27:76 Invalid type [31]: Expression `tuple[(*Ts)]` is not a valid type.
-generics_typevartuple_args.py:42:17 Invalid type [31]: Expression `*tuple[(int, ...)]` is not a valid type.
-generics_typevartuple_args.py:51:17 Invalid type [31]: Expression `*tuple[(int, *tuple[(str, ...)], str)]` is not a valid type.
-generics_typevartuple_args.py:62:17 Invalid type [31]: Expression `*tuple[(int, str)]` is not a valid type.
-generics_typevartuple_args.py:70:17 Invalid type [31]: Expression `tuple[(*Ts)]` is not a valid type.
-generics_typevartuple_args.py:75:12 Incompatible parameter type [6]: In call `func4`, for 2nd positional argument, expected `Tuple[]` but got `Tuple[int, int]`. Expected has length 1, but actual has length 2.
+generics_typevartuple_args.py:20:0 Assert type [70]: Expected `Tuple[int, str]` but got `Tuple[typing_extensions.Literal[1], typing_extensions.Literal['a']]`.
+generics_typevartuple_args.py:32:0 Assert type [70]: Expected `Tuple[int, str]` but got `Tuple[typing_extensions.Literal[0], typing_extensions.Literal['']]`.
+generics_typevartuple_args.py:33:0 Invalid argument [32]: Argument types `typing_extensions.Literal[0], typing_extensions.Literal['']` are not compatible with expected variadic elements `*generics_typevartuple_args.Ts, generics_typevartuple_args.Env`.
+generics_typevartuple_args.py:34:0 Invalid argument [32]: Argument types `typing_extensions.Literal[0], typing_extensions.Literal['']` are not compatible with expected variadic elements `*generics_typevartuple_args.Ts, generics_typevartuple_args.Env`.
+generics_typevartuple_args.py:48:9 Incompatible parameter type [6]: In call `func1`, for 2nd positional argument, expected `int` but got `str`.
+generics_typevartuple_args.py:57:0 Invalid argument [32]: Argument types `typing_extensions.Literal[1], typing_extensions.Literal[1], typing_extensions.Literal['']` are not compatible with expected variadic elements `int, *Tuple[str, ...], str`.
+generics_typevartuple_args.py:58:0 Invalid argument [32]: Argument types `typing_extensions.Literal[1]` are not compatible with expected variadic elements `int, *Tuple[str, ...], str`.
+generics_typevartuple_args.py:59:0 Invalid argument [32]: Argument types `typing_extensions.Literal['']` are not compatible with expected variadic elements `int, *Tuple[str, ...], str`.
+generics_typevartuple_args.py:66:6 Incompatible parameter type [6]: In call `func3`, for 1st positional argument, expected `Unpack[Tuple[int, str]]` but got `int`.
+generics_typevartuple_args.py:66:9 Incompatible parameter type [6]: In call `func3`, for 2nd positional argument, expected `Unpack[Tuple[int, str]]` but got `str`.
+generics_typevartuple_args.py:67:6 Incompatible parameter type [6]: In call `func3`, for 1st positional argument, expected `Unpack[Tuple[int, str]]` but got `int`.
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 33: Expected 1 errors
-Line 34: Expected 1 errors
-Line 48: Expected 1 errors
-Line 57: Expected 1 errors
-Line 58: Expected 1 errors
-Line 59: Expected 1 errors
-Line 67: Expected 1 errors
+Line 75: Expected 1 errors
 Line 76: Expected 1 errors
-Line 16: Unexpected errors ['generics_typevartuple_args.py:16:25 Invalid type [31]: Expression `*Ts` is not a valid type.', 'generics_typevartuple_args.py:16:33 Invalid type [31]: Expression `tuple[(*Ts)]` is not a valid type.']
-Line 27: Unexpected errors ['generics_typevartuple_args.py:27:30 Invalid type [31]: Expression `*tuple[(*Ts, generics_typevartuple_args.Env)]` is not a valid type.', 'generics_typevartuple_args.py:27:76 Invalid type [31]: Expression `tuple[(*Ts)]` is not a valid type.']
-Line 42: Unexpected errors ['generics_typevartuple_args.py:42:17 Invalid type [31]: Expression `*tuple[(int, ...)]` is not a valid type.']
-Line 51: Unexpected errors ['generics_typevartuple_args.py:51:17 Invalid type [31]: Expression `*tuple[(int, *tuple[(str, ...)], str)]` is not a valid type.']
-Line 62: Unexpected errors ['generics_typevartuple_args.py:62:17 Invalid type [31]: Expression `*tuple[(int, str)]` is not a valid type.']
-Line 70: Unexpected errors ['generics_typevartuple_args.py:70:17 Invalid type [31]: Expression `tuple[(*Ts)]` is not a valid type.']
+Line 20: Unexpected errors ["generics_typevartuple_args.py:20:0 Assert type [70]: Expected `Tuple[int, str]` but got `Tuple[typing_extensions.Literal[1], typing_extensions.Literal['a']]`."]
+Line 32: Unexpected errors ["generics_typevartuple_args.py:32:0 Assert type [70]: Expected `Tuple[int, str]` but got `Tuple[typing_extensions.Literal[0], typing_extensions.Literal['']]`."]
+Line 66: Unexpected errors ['generics_typevartuple_args.py:66:6 Incompatible parameter type [6]: In call `func3`, for 1st positional argument, expected `Unpack[Tuple[int, str]]` but got `int`.', 'generics_typevartuple_args.py:66:9 Incompatible parameter type [6]: In call `func3`, for 2nd positional argument, expected `Unpack[Tuple[int, str]]` but got `str`.']
 """

--- a/conformance/results/pyre/generics_typevartuple_basic.toml
+++ b/conformance/results/pyre/generics_typevartuple_basic.toml
@@ -1,73 +1,33 @@
-conformant = "Unsupported"
+conformant = "Partial"
 notes = """
 Does not support TypeVarTuple.
+False negatives due to assert_type.
 """
 output = """
-generics_typevartuple_basic.py:12:13 Invalid type [31]: Expression `typing.Generic[(*Ts)]` is not a valid type.
-generics_typevartuple_basic.py:16:17 Invalid type [31]: Expression `*Ts` is not a valid type.
-generics_typevartuple_basic.py:16:25 Invalid type [31]: Expression `tuple[(*Ts)]` is not a valid type.
-generics_typevartuple_basic.py:23:12 Invalid type [31]: Expression `typing.Generic[(*Shape)]` is not a valid type.
-generics_typevartuple_basic.py:24:30 Invalid type [31]: Expression `tuple[(*Shape)]` is not a valid type.
-generics_typevartuple_basic.py:25:21 Invalid type [31]: Expression `tuple[(*Shape)]` is not a valid type.
-generics_typevartuple_basic.py:27:27 Invalid type [31]: Expression `tuple[(*Shape)]` is not a valid type.
-generics_typevartuple_basic.py:36:0 Incompatible variable type [9]: v1 is declared to have type `Array[]` but is used as type `Array`.
-generics_typevartuple_basic.py:36:4 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.
-generics_typevartuple_basic.py:36:33 Incompatible parameter type [6]: In call `Array.__init__`, for 1st positional argument, expected `Tuple[]` but got `Tuple[Height, Width]`. Expected has length 1, but actual has length 2.
-generics_typevartuple_basic.py:37:0 Incompatible variable type [9]: v2 is declared to have type `Array[]` but is used as type `Array`.
-generics_typevartuple_basic.py:37:4 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.
-generics_typevartuple_basic.py:37:40 Incompatible parameter type [6]: In call `Array.__init__`, for 1st positional argument, expected `Tuple[]` but got `Tuple[Batch, Height, Width]`. Expected has length 1, but actual has length 3.
-generics_typevartuple_basic.py:38:0 Incompatible variable type [9]: v3 is declared to have type `Array[]` but is used as type `Array`.
-generics_typevartuple_basic.py:38:4 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.
-generics_typevartuple_basic.py:39:4 Incompatible parameter type [6]: In call `Array.__init__`, for 1st positional argument, expected `Tuple[]` but got `Tuple[Time, Batch, Height, Width]`. Expected has length 1, but actual has length 4.
-generics_typevartuple_basic.py:42:0 Incompatible variable type [9]: v4 is declared to have type `Array[]` but is used as type `Array`.
-generics_typevartuple_basic.py:42:4 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.
-generics_typevartuple_basic.py:42:33 Incompatible parameter type [6]: In call `Array.__init__`, for 1st positional argument, expected `Tuple[]` but got `Height`.
-generics_typevartuple_basic.py:43:0 Incompatible variable type [9]: v5 is declared to have type `Array[]` but is used as type `Array`.
-generics_typevartuple_basic.py:43:4 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.
-generics_typevartuple_basic.py:43:40 Incompatible parameter type [6]: In call `Array.__init__`, for 1st positional argument, expected `Tuple[]` but got `Tuple[Batch, Width]`. Expected has length 1, but actual has length 2.
-generics_typevartuple_basic.py:44:0 Incompatible variable type [9]: v6 is declared to have type `Array[]` but is used as type `Array`.
-generics_typevartuple_basic.py:44:4 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.
-generics_typevartuple_basic.py:45:4 Incompatible parameter type [6]: In call `Array.__init__`, for 1st positional argument, expected `Tuple[]` but got `Tuple[Time, Batch, Width, Height]`. Expected has length 1, but actual has length 4.
+generics_typevartuple_basic.py:42:33 Incompatible parameter type [6]: In call `Array.__init__`, for 1st positional argument, expected `typing.Tuple[*generics_typevartuple_basic.Shape]` but got `Height`.
+generics_typevartuple_basic.py:43:0 Incompatible variable type [9]: v5 is declared to have type `Array[Batch, Height, Width]` but is used as type `Array[Batch, Width]`.
+generics_typevartuple_basic.py:44:0 Incompatible variable type [9]: v6 is declared to have type `Array[Time, Batch, Height, Width]` but is used as type `Array[Time, Batch, Width, Height]`.
 generics_typevartuple_basic.py:52:13 Undefined or invalid type [11]: Annotation `Shape` is not defined as a type.
-generics_typevartuple_basic.py:54:21 Invalid type [31]: Expression `tuple[(*Shape)]` is not a valid type.
+generics_typevartuple_basic.py:54:21 Invalid type variable [34]: The type variable `Shape` isn't present in the function's parameters.
 generics_typevartuple_basic.py:65:6 Unexpected keyword [28]: Unexpected keyword argument `covariant` to call `TypeVarTuple.__init__`.
 generics_typevartuple_basic.py:66:6 Too many arguments [19]: Call `TypeVarTuple.__init__` expects 1 positional argument, 3 were provided.
 generics_typevartuple_basic.py:67:6 Unexpected keyword [28]: Unexpected keyword argument `bound` to call `TypeVarTuple.__init__`.
-generics_typevartuple_basic.py:75:16 Invalid type [31]: Expression `tuple[(*Ts)]` is not a valid type.
-generics_typevartuple_basic.py:75:34 Invalid type [31]: Expression `tuple[(*Ts)]` is not a valid type.
-generics_typevartuple_basic.py:75:49 Invalid type [31]: Expression `tuple[(*Ts)]` is not a valid type.
-generics_typevartuple_basic.py:90:6 Incompatible parameter type [6]: In call `func2`, for 1st positional argument, expected `Tuple[]` but got `Tuple[int, int]`. Expected has length 1, but actual has length 2.
-generics_typevartuple_basic.py:93:16 Invalid type [31]: Expression `generics_typevartuple_basic.Array[(*Shape)]` is not a valid type.
-generics_typevartuple_basic.py:93:16 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.
-generics_typevartuple_basic.py:93:34 Invalid type [31]: Expression `generics_typevartuple_basic.Array[(*Shape)]` is not a valid type.
-generics_typevartuple_basic.py:93:34 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.
-generics_typevartuple_basic.py:93:52 Invalid type [31]: Expression `generics_typevartuple_basic.Array[(*Shape)]` is not a valid type.
-generics_typevartuple_basic.py:93:52 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.
-generics_typevartuple_basic.py:97:13 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.
-generics_typevartuple_basic.py:97:31 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.
-generics_typevartuple_basic.py:97:48 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.
-generics_typevartuple_basic.py:106:13 Invalid type [31]: Expression `typing.Generic[(*Ts1, *Ts2)]` is not a valid type.
+generics_typevartuple_basic.py:84:0 Assert type [70]: Expected `Tuple[int]` but got `Tuple[typing_extensions.Literal[0]]`.
+generics_typevartuple_basic.py:84:24 Incompatible parameter type [6]: In call `func2`, for 2nd positional argument, expected `typing.Tuple[*generics_typevartuple_basic.Ts]` but got `Tuple[int]`.
+generics_typevartuple_basic.py:87:12 Incompatible parameter type [6]: In call `func2`, for 2nd positional argument, expected `typing.Tuple[*generics_typevartuple_basic.Ts]` but got `Tuple[int]`.
+generics_typevartuple_basic.py:89:12 Incompatible parameter type [6]: In call `func2`, for 2nd positional argument, expected `typing.Tuple[*generics_typevartuple_basic.Ts]` but got `Tuple[str]`.
+generics_typevartuple_basic.py:90:14 Incompatible parameter type [6]: In call `func2`, for 2nd positional argument, expected `typing.Tuple[*generics_typevartuple_basic.Ts]` but got `Tuple[int]`.
+generics_typevartuple_basic.py:99:16 Incompatible parameter type [6]: In call `multiply`, for 2nd positional argument, expected `Array[*generics_typevartuple_basic.Shape]` but got `Array[Width]`.
+generics_typevartuple_basic.py:100:16 Incompatible parameter type [6]: In call `multiply`, for 2nd positional argument, expected `Array[*generics_typevartuple_basic.Shape]` but got `Array[Height, Width]`.
+generics_typevartuple_basic.py:106:13 Undefined or invalid type [11]: Annotation `Ts1` is not defined as a type.
+generics_typevartuple_basic.py:106:13 Undefined or invalid type [11]: Annotation `Ts2` is not defined as a type.
 """
 conformance_automated = "Fail"
 errors_diff = """
 Line 53: Expected 1 errors
 Line 56: Expected 1 errors
 Line 59: Expected 1 errors
-Line 89: Expected 1 errors
-Line 99: Expected 1 errors
-Line 100: Expected 1 errors
-Line 12: Unexpected errors ['generics_typevartuple_basic.py:12:13 Invalid type [31]: Expression `typing.Generic[(*Ts)]` is not a valid type.']
-Line 16: Unexpected errors ['generics_typevartuple_basic.py:16:17 Invalid type [31]: Expression `*Ts` is not a valid type.', 'generics_typevartuple_basic.py:16:25 Invalid type [31]: Expression `tuple[(*Ts)]` is not a valid type.']
-Line 23: Unexpected errors ['generics_typevartuple_basic.py:23:12 Invalid type [31]: Expression `typing.Generic[(*Shape)]` is not a valid type.']
-Line 24: Unexpected errors ['generics_typevartuple_basic.py:24:30 Invalid type [31]: Expression `tuple[(*Shape)]` is not a valid type.']
-Line 25: Unexpected errors ['generics_typevartuple_basic.py:25:21 Invalid type [31]: Expression `tuple[(*Shape)]` is not a valid type.']
-Line 27: Unexpected errors ['generics_typevartuple_basic.py:27:27 Invalid type [31]: Expression `tuple[(*Shape)]` is not a valid type.']
-Line 36: Unexpected errors ['generics_typevartuple_basic.py:36:0 Incompatible variable type [9]: v1 is declared to have type `Array[]` but is used as type `Array`.', 'generics_typevartuple_basic.py:36:4 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.', 'generics_typevartuple_basic.py:36:33 Incompatible parameter type [6]: In call `Array.__init__`, for 1st positional argument, expected `Tuple[]` but got `Tuple[Height, Width]`. Expected has length 1, but actual has length 2.']
-Line 37: Unexpected errors ['generics_typevartuple_basic.py:37:0 Incompatible variable type [9]: v2 is declared to have type `Array[]` but is used as type `Array`.', 'generics_typevartuple_basic.py:37:4 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.', 'generics_typevartuple_basic.py:37:40 Incompatible parameter type [6]: In call `Array.__init__`, for 1st positional argument, expected `Tuple[]` but got `Tuple[Batch, Height, Width]`. Expected has length 1, but actual has length 3.']
-Line 38: Unexpected errors ['generics_typevartuple_basic.py:38:0 Incompatible variable type [9]: v3 is declared to have type `Array[]` but is used as type `Array`.', 'generics_typevartuple_basic.py:38:4 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.']
-Line 39: Unexpected errors ['generics_typevartuple_basic.py:39:4 Incompatible parameter type [6]: In call `Array.__init__`, for 1st positional argument, expected `Tuple[]` but got `Tuple[Time, Batch, Height, Width]`. Expected has length 1, but actual has length 4.']
-Line 54: Unexpected errors ['generics_typevartuple_basic.py:54:21 Invalid type [31]: Expression `tuple[(*Shape)]` is not a valid type.']
-Line 75: Unexpected errors ['generics_typevartuple_basic.py:75:16 Invalid type [31]: Expression `tuple[(*Ts)]` is not a valid type.', 'generics_typevartuple_basic.py:75:34 Invalid type [31]: Expression `tuple[(*Ts)]` is not a valid type.', 'generics_typevartuple_basic.py:75:49 Invalid type [31]: Expression `tuple[(*Ts)]` is not a valid type.']
-Line 93: Unexpected errors ['generics_typevartuple_basic.py:93:16 Invalid type [31]: Expression `generics_typevartuple_basic.Array[(*Shape)]` is not a valid type.', 'generics_typevartuple_basic.py:93:16 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.', 'generics_typevartuple_basic.py:93:34 Invalid type [31]: Expression `generics_typevartuple_basic.Array[(*Shape)]` is not a valid type.', 'generics_typevartuple_basic.py:93:34 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.', 'generics_typevartuple_basic.py:93:52 Invalid type [31]: Expression `generics_typevartuple_basic.Array[(*Shape)]` is not a valid type.', 'generics_typevartuple_basic.py:93:52 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.']
-Line 97: Unexpected errors ['generics_typevartuple_basic.py:97:13 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.', 'generics_typevartuple_basic.py:97:31 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.', 'generics_typevartuple_basic.py:97:48 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.']
+Line 54: Unexpected errors ["generics_typevartuple_basic.py:54:21 Invalid type variable [34]: The type variable `Shape` isn't present in the function's parameters."]
+Line 84: Unexpected errors ['generics_typevartuple_basic.py:84:0 Assert type [70]: Expected `Tuple[int]` but got `Tuple[typing_extensions.Literal[0]]`.', 'generics_typevartuple_basic.py:84:24 Incompatible parameter type [6]: In call `func2`, for 2nd positional argument, expected `typing.Tuple[*generics_typevartuple_basic.Ts]` but got `Tuple[int]`.']
+Line 87: Unexpected errors ['generics_typevartuple_basic.py:87:12 Incompatible parameter type [6]: In call `func2`, for 2nd positional argument, expected `typing.Tuple[*generics_typevartuple_basic.Ts]` but got `Tuple[int]`.']
 """

--- a/conformance/results/pyre/generics_typevartuple_callable.toml
+++ b/conformance/results/pyre/generics_typevartuple_callable.toml
@@ -1,28 +1,12 @@
-conformant = "Unsupported"
+conformant = "Partial"
 notes = """
-Does not support TypeVarTuple.
+False negatives due to assert_type.
 """
 output = """
-generics_typevartuple_callable.py:17:31 Invalid type [31]: Expression `typing.Callable[([*Ts], None)]` is not a valid type.
-generics_typevartuple_callable.py:17:60 Invalid type [31]: Expression `tuple[(*Ts)]` is not a valid type.
-generics_typevartuple_callable.py:25:8 Incompatible parameter type [6]: In call `Process.__init__`, for argument `target`, expected `typing.Callable[[unknown], None]` but got `typing.Callable(func1)[[Named(arg1, int), Named(arg2, str)], None]`.
-generics_typevartuple_callable.py:25:22 Incompatible parameter type [6]: In call `Process.__init__`, for argument `args`, expected `Tuple[]` but got `Tuple[int, str]`. Expected has length 1, but actual has length 2.
-generics_typevartuple_callable.py:26:8 Incompatible parameter type [6]: In call `Process.__init__`, for argument `target`, expected `typing.Callable[[unknown], None]` but got `typing.Callable(func1)[[Named(arg1, int), Named(arg2, str)], None]`.
-generics_typevartuple_callable.py:26:22 Incompatible parameter type [6]: In call `Process.__init__`, for argument `args`, expected `Tuple[]` but got `Tuple[str, int]`. Expected has length 1, but actual has length 2.
-generics_typevartuple_callable.py:29:13 Invalid type [31]: Expression `typing.Callable[([int, *Ts, T], tuple[(T, *Ts)])]` is not a valid type.
-generics_typevartuple_callable.py:29:56 Invalid type [31]: Expression `tuple[(*Ts, T)]` is not a valid type.
-generics_typevartuple_callable.py:41:18 Incompatible parameter type [6]: In call `func2`, for 1st positional argument, expected `typing.Callable[[int, unknown, Variable[T]], Tuple[Variable[T], unknown]]` but got `typing.Callable(callback1)[[Named(a, int), Named(b, str), Named(c, int), Named(d, complex)], Tuple[complex, str, int]]`.
-generics_typevartuple_callable.py:42:18 Incompatible parameter type [6]: In call `func2`, for 1st positional argument, expected `typing.Callable[[int, unknown, Variable[T]], Tuple[Variable[T], unknown]]` but got `typing.Callable(callback2)[[Named(a, int), Named(d, str)], Tuple[str]]`.
-generics_typevartuple_callable.py:45:17 Invalid type [31]: Expression `*tuple[(int, *Ts, T)]` is not a valid type.
-generics_typevartuple_callable.py:45:42 Invalid type [31]: Expression `tuple[(T, *Ts)]` is not a valid type.
-generics_typevartuple_callable.py:45:42 Invalid type variable [34]: The type variable `Variable[T]` isn't present in the function's parameters.
+generics_typevartuple_callable.py:26:8 Incompatible parameter type [6]: In call `Process.__init__`, for argument `target`, expected `typing.Callable[[Variable(*generics_typevartuple_callable.Ts)], None]` but got `typing.Callable(func1)[[Named(arg1, int), Named(arg2, str)], None]`.
+generics_typevartuple_callable.py:49:0 Assert type [70]: Expected `Tuple[float, str, complex]` but got `Tuple[float, typing_extensions.Literal[''], complex]`.
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 17: Unexpected errors ['generics_typevartuple_callable.py:17:31 Invalid type [31]: Expression `typing.Callable[([*Ts], None)]` is not a valid type.', 'generics_typevartuple_callable.py:17:60 Invalid type [31]: Expression `tuple[(*Ts)]` is not a valid type.']
-Line 25: Unexpected errors ['generics_typevartuple_callable.py:25:8 Incompatible parameter type [6]: In call `Process.__init__`, for argument `target`, expected `typing.Callable[[unknown], None]` but got `typing.Callable(func1)[[Named(arg1, int), Named(arg2, str)], None]`.', 'generics_typevartuple_callable.py:25:22 Incompatible parameter type [6]: In call `Process.__init__`, for argument `args`, expected `Tuple[]` but got `Tuple[int, str]`. Expected has length 1, but actual has length 2.']
-Line 29: Unexpected errors ['generics_typevartuple_callable.py:29:13 Invalid type [31]: Expression `typing.Callable[([int, *Ts, T], tuple[(T, *Ts)])]` is not a valid type.', 'generics_typevartuple_callable.py:29:56 Invalid type [31]: Expression `tuple[(*Ts, T)]` is not a valid type.']
-Line 41: Unexpected errors ['generics_typevartuple_callable.py:41:18 Incompatible parameter type [6]: In call `func2`, for 1st positional argument, expected `typing.Callable[[int, unknown, Variable[T]], Tuple[Variable[T], unknown]]` but got `typing.Callable(callback1)[[Named(a, int), Named(b, str), Named(c, int), Named(d, complex)], Tuple[complex, str, int]]`.']
-Line 42: Unexpected errors ['generics_typevartuple_callable.py:42:18 Incompatible parameter type [6]: In call `func2`, for 1st positional argument, expected `typing.Callable[[int, unknown, Variable[T]], Tuple[Variable[T], unknown]]` but got `typing.Callable(callback2)[[Named(a, int), Named(d, str)], Tuple[str]]`.']
-Line 45: Unexpected errors ['generics_typevartuple_callable.py:45:17 Invalid type [31]: Expression `*tuple[(int, *Ts, T)]` is not a valid type.', 'generics_typevartuple_callable.py:45:42 Invalid type [31]: Expression `tuple[(T, *Ts)]` is not a valid type.', "generics_typevartuple_callable.py:45:42 Invalid type variable [34]: The type variable `Variable[T]` isn't present in the function's parameters."]
+Line 49: Unexpected errors ["generics_typevartuple_callable.py:49:0 Assert type [70]: Expected `Tuple[float, str, complex]` but got `Tuple[float, typing_extensions.Literal[''], complex]`."]
 """

--- a/conformance/results/pyre/generics_typevartuple_concat.toml
+++ b/conformance/results/pyre/generics_typevartuple_concat.toml
@@ -1,39 +1,14 @@
-conformant = "Unsupported"
+conformant = "Partial"
 notes = """
-Does not support TypeVarTuple.
+False negatives due to assert_type.
+False compatability error message.
 """
 output = """
-generics_typevartuple_concat.py:22:12 Invalid type [31]: Expression `typing.Generic[(*Ts)]` is not a valid type.
-generics_typevartuple_concat.py:26:22 Invalid type [31]: Expression `generics_typevartuple_concat.Array[(*Shape)]` is not a valid type.
-generics_typevartuple_concat.py:26:22 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.
-generics_typevartuple_concat.py:26:40 Invalid type [31]: Expression `generics_typevartuple_concat.Array[(generics_typevartuple_concat.Batch, *Shape)]` is not a valid type.
-generics_typevartuple_concat.py:26:40 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.
-generics_typevartuple_concat.py:30:22 Invalid type [31]: Expression `generics_typevartuple_concat.Array[(generics_typevartuple_concat.Batch, *Shape)]` is not a valid type.
-generics_typevartuple_concat.py:30:22 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.
-generics_typevartuple_concat.py:30:47 Invalid type [31]: Expression `generics_typevartuple_concat.Array[(*Shape)]` is not a valid type.
-generics_typevartuple_concat.py:30:47 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.
-generics_typevartuple_concat.py:34:26 Invalid type [31]: Expression `generics_typevartuple_concat.Array[(*Shape)]` is not a valid type.
-generics_typevartuple_concat.py:34:26 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.
-generics_typevartuple_concat.py:34:44 Invalid type [31]: Expression `generics_typevartuple_concat.Array[(generics_typevartuple_concat.Batch, *Shape, generics_typevartuple_concat.Channels)]` is not a valid type.
-generics_typevartuple_concat.py:34:44 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.
-generics_typevartuple_concat.py:38:13 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.
-generics_typevartuple_concat.py:47:26 Invalid type [31]: Expression `tuple[(*Ts)]` is not a valid type.
-generics_typevartuple_concat.py:47:41 Invalid type [31]: Expression `tuple[(T, *Ts)]` is not a valid type.
-generics_typevartuple_concat.py:51:22 Incompatible parameter type [6]: In call `prefix_tuple`, for argument `y`, expected `Tuple[]` but got `Tuple[bool, str]`. Expected has length 1, but actual has length 2.
-generics_typevartuple_concat.py:55:36 Invalid type [31]: Expression `tuple[(T, *Ts)]` is not a valid type.
-generics_typevartuple_concat.py:55:54 Invalid type [31]: Expression `tuple[(*Ts, T)]` is not a valid type.
-generics_typevartuple_concat.py:56:11 Unable to concatenate tuple [60]: Expected to unpack an iterable, but got `Variable[generics_typevartuple_concat.T]`.
-generics_typevartuple_concat.py:56:17 Incompatible parameter type [6]: In call `tuple.__getitem__`, for 1st positional argument, expected `typing_extensions.Literal[0]` but got `slice`.
+generics_typevartuple_concat.py:52:0 Assert type [70]: Expected `Tuple[int, bool, str]` but got `Tuple[typing_extensions.Literal[0], typing_extensions.Literal[True], typing_extensions.Literal['a']]`.
+generics_typevartuple_concat.py:56:4 Incompatible return type [7]: Expected `typing.Tuple[*generics_typevartuple_concat.Ts, Variable[T]]` but got `typing.Tuple[*Tuple[object, ...], object]`.
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 22: Unexpected errors ['generics_typevartuple_concat.py:22:12 Invalid type [31]: Expression `typing.Generic[(*Ts)]` is not a valid type.']
-Line 26: Unexpected errors ['generics_typevartuple_concat.py:26:22 Invalid type [31]: Expression `generics_typevartuple_concat.Array[(*Shape)]` is not a valid type.', 'generics_typevartuple_concat.py:26:22 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.', 'generics_typevartuple_concat.py:26:40 Invalid type [31]: Expression `generics_typevartuple_concat.Array[(generics_typevartuple_concat.Batch, *Shape)]` is not a valid type.', 'generics_typevartuple_concat.py:26:40 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.']
-Line 30: Unexpected errors ['generics_typevartuple_concat.py:30:22 Invalid type [31]: Expression `generics_typevartuple_concat.Array[(generics_typevartuple_concat.Batch, *Shape)]` is not a valid type.', 'generics_typevartuple_concat.py:30:22 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.', 'generics_typevartuple_concat.py:30:47 Invalid type [31]: Expression `generics_typevartuple_concat.Array[(*Shape)]` is not a valid type.', 'generics_typevartuple_concat.py:30:47 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.']
-Line 34: Unexpected errors ['generics_typevartuple_concat.py:34:26 Invalid type [31]: Expression `generics_typevartuple_concat.Array[(*Shape)]` is not a valid type.', 'generics_typevartuple_concat.py:34:26 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.', 'generics_typevartuple_concat.py:34:44 Invalid type [31]: Expression `generics_typevartuple_concat.Array[(generics_typevartuple_concat.Batch, *Shape, generics_typevartuple_concat.Channels)]` is not a valid type.', 'generics_typevartuple_concat.py:34:44 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.']
-Line 38: Unexpected errors ['generics_typevartuple_concat.py:38:13 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.']
-Line 47: Unexpected errors ['generics_typevartuple_concat.py:47:26 Invalid type [31]: Expression `tuple[(*Ts)]` is not a valid type.', 'generics_typevartuple_concat.py:47:41 Invalid type [31]: Expression `tuple[(T, *Ts)]` is not a valid type.']
-Line 51: Unexpected errors ['generics_typevartuple_concat.py:51:22 Incompatible parameter type [6]: In call `prefix_tuple`, for argument `y`, expected `Tuple[]` but got `Tuple[bool, str]`. Expected has length 1, but actual has length 2.']
-Line 55: Unexpected errors ['generics_typevartuple_concat.py:55:36 Invalid type [31]: Expression `tuple[(T, *Ts)]` is not a valid type.', 'generics_typevartuple_concat.py:55:54 Invalid type [31]: Expression `tuple[(*Ts, T)]` is not a valid type.']
-Line 56: Unexpected errors ['generics_typevartuple_concat.py:56:11 Unable to concatenate tuple [60]: Expected to unpack an iterable, but got `Variable[generics_typevartuple_concat.T]`.', 'generics_typevartuple_concat.py:56:17 Incompatible parameter type [6]: In call `tuple.__getitem__`, for 1st positional argument, expected `typing_extensions.Literal[0]` but got `slice`.']
+Line 52: Unexpected errors ["generics_typevartuple_concat.py:52:0 Assert type [70]: Expected `Tuple[int, bool, str]` but got `Tuple[typing_extensions.Literal[0], typing_extensions.Literal[True], typing_extensions.Literal['a']]`."]
+Line 56: Unexpected errors ['generics_typevartuple_concat.py:56:4 Incompatible return type [7]: Expected `typing.Tuple[*generics_typevartuple_concat.Ts, Variable[T]]` but got `typing.Tuple[*Tuple[object, ...], object]`.']
 """

--- a/conformance/results/pyre/generics_typevartuple_overloads.toml
+++ b/conformance/results/pyre/generics_typevartuple_overloads.toml
@@ -3,18 +3,11 @@ notes = """
 Does not support star expressions for `Unpack`.
 """
 output = """
-generics_typevartuple_overloads.py:16:12 Invalid type [31]: Expression `typing.Generic[(*Shape)]` is not a valid type.
-generics_typevartuple_overloads.py:18:24 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.
-generics_typevartuple_overloads.py:18:50 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.
-generics_typevartuple_overloads.py:22:24 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.
-generics_typevartuple_overloads.py:22:57 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.
-generics_typevartuple_overloads.py:29:13 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.
-generics_typevartuple_overloads.py:29:37 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.
+generics_typevartuple_overloads.py:18:4 Incompatible overload [43]: The implementation of `Array.transpose` does not accept all possible arguments of overload defined on line `18`.
+generics_typevartuple_overloads.py:22:4 Incompatible overload [43]: The implementation of `Array.transpose` does not accept all possible arguments of overload defined on line `22`.
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 16: Unexpected errors ['generics_typevartuple_overloads.py:16:12 Invalid type [31]: Expression `typing.Generic[(*Shape)]` is not a valid type.']
-Line 18: Unexpected errors ['generics_typevartuple_overloads.py:18:24 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.', 'generics_typevartuple_overloads.py:18:50 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.']
-Line 22: Unexpected errors ['generics_typevartuple_overloads.py:22:24 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.', 'generics_typevartuple_overloads.py:22:57 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.']
-Line 29: Unexpected errors ['generics_typevartuple_overloads.py:29:13 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.', 'generics_typevartuple_overloads.py:29:37 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.']
+Line 18: Unexpected errors ['generics_typevartuple_overloads.py:18:4 Incompatible overload [43]: The implementation of `Array.transpose` does not accept all possible arguments of overload defined on line `18`.']
+Line 22: Unexpected errors ['generics_typevartuple_overloads.py:22:4 Incompatible overload [43]: The implementation of `Array.transpose` does not accept all possible arguments of overload defined on line `22`.']
 """

--- a/conformance/results/pyre/generics_typevartuple_specialization.toml
+++ b/conformance/results/pyre/generics_typevartuple_specialization.toml
@@ -3,78 +3,33 @@ notes = """
 Does not support star expressions for `Unpack`.
 """
 output = """
-generics_typevartuple_specialization.py:16:12 Invalid type [31]: Expression `typing.Generic[(*Ts)]` is not a valid type.
-generics_typevartuple_specialization.py:24:26 Invalid type [31]: Expression `generics_typevartuple_specialization.Array[(*tuple[(typing.Any, ...)])]` is not a valid type.
-generics_typevartuple_specialization.py:24:26 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.
-generics_typevartuple_specialization.py:28:13 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.
-generics_typevartuple_specialization.py:33:13 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.
-generics_typevartuple_specialization.py:41:11 Undefined attribute [16]: `tuple` has no attribute `__getitem__`.
-generics_typevartuple_specialization.py:45:13 Undefined or invalid type [11]: Annotation `IntTuple` is not defined as a type.
-generics_typevartuple_specialization.py:45:39 Undefined or invalid type [11]: Annotation `NamedArray` is not defined as a type.
-generics_typevartuple_specialization.py:47:19 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.
-generics_typevartuple_specialization.py:59:13 Invalid type [31]: Expression `typing.Generic[(DType, *Shape)]` is not a valid type.
-generics_typevartuple_specialization.py:59:13 Invalid type variable [34]: The current class isn't generic with respect to the type variable `Variable[DType]`. To reference the type variable, you can modify the class to inherit from `typing.Generic[DType]`.
-generics_typevartuple_specialization.py:63:20 Incompatible parameter type [6]: In call `typing.GenericMeta.__getitem__`, for 1st positional argument, expected `Tuple[]` but got `typing.Tuple[Type[float], *Tuple[typing.Any, ...]]`.
-generics_typevartuple_specialization.py:64:0 Invalid type parameters [24]: Non-generic type `Array2` cannot take parameters.
-generics_typevartuple_specialization.py:68:4 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Array2[]` but got `Array2`.
-generics_typevartuple_specialization.py:68:19 Invalid type parameters [24]: Non-generic type `Array2` cannot take parameters.
-generics_typevartuple_specialization.py:69:4 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Array2[]` but got `Array2`.
-generics_typevartuple_specialization.py:69:19 Invalid type parameters [24]: Non-generic type `Array2` cannot take parameters.
-generics_typevartuple_specialization.py:72:38 Undefined or invalid type [11]: Annotation `FloatArray` is not defined as a type.
-generics_typevartuple_specialization.py:92:13 Undefined or invalid type [11]: Annotation `VariadicTuple` is not defined as a type.
-generics_typevartuple_specialization.py:95:19 Invalid type [31]: Expression `tuple[(typing.Any, *tuple[(typing.Any, ...)])]` is not a valid type.
-generics_typevartuple_specialization.py:108:0 Undefined attribute [16]: `typing.Tuple` has no attribute `__getitem__`.
-generics_typevartuple_specialization.py:121:12 Unable to concatenate tuple [60]: Concatenation not yet support for multiple variadic tuples: `*Ts, *Ts`.
-generics_typevartuple_specialization.py:122:12 Unable to concatenate tuple [60]: Concatenation not yet support for multiple variadic tuples: `*Ts, *tuple[(int, ...)]`.
-generics_typevartuple_specialization.py:127:4 Undefined or invalid type [11]: Annotation `TA7` is not defined as a type.
-generics_typevartuple_specialization.py:130:13 Invalid type [31]: Expression `TA7[(*Ts, T1, T2)]` is not a valid type.
-generics_typevartuple_specialization.py:130:13 Invalid type variable [34]: The type variable `Variable[T1]` isn't present in the function's parameters.
-generics_typevartuple_specialization.py:130:13 Invalid type variable [34]: The type variable `Variable[T2]` isn't present in the function's parameters.
-generics_typevartuple_specialization.py:130:34 Invalid type [31]: Expression `tuple[(tuple[(*Ts)], T1, T2)]` is not a valid type.
-generics_typevartuple_specialization.py:130:34 Invalid type variable [34]: The type variable `Variable[T1]` isn't present in the function's parameters.
-generics_typevartuple_specialization.py:130:34 Invalid type variable [34]: The type variable `Variable[T2]` isn't present in the function's parameters.
-generics_typevartuple_specialization.py:143:13 Invalid type [31]: Expression `TA8[(T1, *Ts, T2, T3)]` is not a valid type.
-generics_typevartuple_specialization.py:143:13 Invalid type variable [34]: The type variable `Variable[T1]` isn't present in the function's parameters.
-generics_typevartuple_specialization.py:143:13 Invalid type variable [34]: The type variable `Variable[T2]` isn't present in the function's parameters.
-generics_typevartuple_specialization.py:143:13 Invalid type variable [34]: The type variable `Variable[T3]` isn't present in the function's parameters.
-generics_typevartuple_specialization.py:143:13 Undefined or invalid type [11]: Annotation `TA8` is not defined as a type.
-generics_typevartuple_specialization.py:143:38 Invalid type [31]: Expression `tuple[(tuple[(*Ts)], T1, T2, T3)]` is not a valid type.
-generics_typevartuple_specialization.py:143:38 Invalid type variable [34]: The type variable `Variable[T1]` isn't present in the function's parameters.
-generics_typevartuple_specialization.py:143:38 Invalid type variable [34]: The type variable `Variable[T2]` isn't present in the function's parameters.
-generics_typevartuple_specialization.py:143:38 Invalid type variable [34]: The type variable `Variable[T3]` isn't present in the function's parameters.
-generics_typevartuple_specialization.py:156:14 Undefined or invalid type [11]: Annotation `TA10` is not defined as a type.
-generics_typevartuple_specialization.py:156:23 Invalid type [31]: Expression `TA9[(*tuple[(int, ...)], str)]` is not a valid type.
-generics_typevartuple_specialization.py:156:23 Undefined or invalid type [11]: Annotation `TA9` is not defined as a type.
-generics_typevartuple_specialization.py:156:54 Invalid type [31]: Expression `TA9[(*tuple[(int, ...)], str)]` is not a valid type.
-generics_typevartuple_specialization.py:157:19 Invalid type [31]: Expression `tuple[(*tuple[(int, ...)], int)]` is not a valid type.
-generics_typevartuple_specialization.py:158:19 Invalid type [31]: Expression `tuple[(*tuple[(int, ...)], str)]` is not a valid type.
-generics_typevartuple_specialization.py:159:19 Invalid type [31]: Expression `tuple[(*tuple[(int, ...)], str)]` is not a valid type.
+generics_typevartuple_specialization.py:29:21 Incompatible parameter type [6]: In call `takes_any_array1`, for 1st positional argument, expected `Array[]` but got `Array[Height, Width]`.
+generics_typevartuple_specialization.py:34:21 Incompatible parameter type [6]: In call `takes_any_array1`, for 1st positional argument, expected `Array[]` but got `Array[Time, Height, Width]`.
+generics_typevartuple_specialization.py:121:0 Invalid type [31]: Expression `tuple[(T1, *Ts, T2, *Ts)]` is not a valid type.
+generics_typevartuple_specialization.py:122:0 Invalid type [31]: Expression `tuple[(T1, *Ts, T2, *tuple[(int, ...)])]` is not a valid type.
+generics_typevartuple_specialization.py:127:4 Invalid type variable [34]: The type variable `Variable[T1]` can only be used to annotate generic classes or functions.
+generics_typevartuple_specialization.py:127:4 Invalid type variable [34]: The type variable `Variable[T2]` can only be used to annotate generic classes or functions.
+generics_typevartuple_specialization.py:127:4 Invalid type variable [34]: The type variable `Ts` can only be used to annotate generic classes or functions.
+generics_typevartuple_specialization.py:136:4 Assert type [70]: Expected `Tuple[Tuple[str], bool, float]` but got `Tuple[Tuple[float], str, bool]`.
+generics_typevartuple_specialization.py:137:4 Assert type [70]: Expected `Tuple[Tuple[str, bool], float, int]` but got `Tuple[Tuple[float, int], str, bool]`.
+generics_typevartuple_specialization.py:148:4 Assert type [70]: Expected `Tuple[Tuple[], str, bool, float]` but got `Tuple[Tuple[], float, str, bool]`.
+generics_typevartuple_specialization.py:149:4 Assert type [70]: Expected `Tuple[Tuple[bool], str, float, int]` but got `Tuple[Tuple[int], float, str, bool]`.
+generics_typevartuple_specialization.py:157:4 Assert type [70]: Expected `typing.Tuple[*Tuple[int, ...], int]` but got `typing.Tuple[*Tuple[typing.Any, ...], typing.Any]`.
+generics_typevartuple_specialization.py:158:4 Assert type [70]: Expected `typing.Tuple[*Tuple[int, ...], str]` but got `typing.Tuple[*generics_typevartuple_specialization.Ts, Variable[T1]]`.
+generics_typevartuple_specialization.py:159:4 Assert type [70]: Expected `typing.Tuple[*Tuple[int, ...], str]` but got `typing.Tuple[*generics_typevartuple_specialization.Ts, Variable[T1]]`.
 """
 conformance_automated = "Fail"
 errors_diff = """
 Line 109: Expected 1 errors
 Line 110: Expected 1 errors
 Line 163: Expected 1 errors
-Line 16: Unexpected errors ['generics_typevartuple_specialization.py:16:12 Invalid type [31]: Expression `typing.Generic[(*Ts)]` is not a valid type.']
-Line 24: Unexpected errors ['generics_typevartuple_specialization.py:24:26 Invalid type [31]: Expression `generics_typevartuple_specialization.Array[(*tuple[(typing.Any, ...)])]` is not a valid type.', 'generics_typevartuple_specialization.py:24:26 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.']
-Line 28: Unexpected errors ['generics_typevartuple_specialization.py:28:13 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.']
-Line 33: Unexpected errors ['generics_typevartuple_specialization.py:33:13 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.']
-Line 41: Unexpected errors ['generics_typevartuple_specialization.py:41:11 Undefined attribute [16]: `tuple` has no attribute `__getitem__`.']
-Line 45: Unexpected errors ['generics_typevartuple_specialization.py:45:13 Undefined or invalid type [11]: Annotation `IntTuple` is not defined as a type.', 'generics_typevartuple_specialization.py:45:39 Undefined or invalid type [11]: Annotation `NamedArray` is not defined as a type.']
-Line 47: Unexpected errors ['generics_typevartuple_specialization.py:47:19 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.']
-Line 59: Unexpected errors ['generics_typevartuple_specialization.py:59:13 Invalid type [31]: Expression `typing.Generic[(DType, *Shape)]` is not a valid type.', "generics_typevartuple_specialization.py:59:13 Invalid type variable [34]: The current class isn't generic with respect to the type variable `Variable[DType]`. To reference the type variable, you can modify the class to inherit from `typing.Generic[DType]`."]
-Line 63: Unexpected errors ['generics_typevartuple_specialization.py:63:20 Incompatible parameter type [6]: In call `typing.GenericMeta.__getitem__`, for 1st positional argument, expected `Tuple[]` but got `typing.Tuple[Type[float], *Tuple[typing.Any, ...]]`.']
-Line 64: Unexpected errors ['generics_typevartuple_specialization.py:64:0 Invalid type parameters [24]: Non-generic type `Array2` cannot take parameters.']
-Line 68: Unexpected errors ['generics_typevartuple_specialization.py:68:4 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Array2[]` but got `Array2`.', 'generics_typevartuple_specialization.py:68:19 Invalid type parameters [24]: Non-generic type `Array2` cannot take parameters.']
-Line 69: Unexpected errors ['generics_typevartuple_specialization.py:69:4 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Array2[]` but got `Array2`.', 'generics_typevartuple_specialization.py:69:19 Invalid type parameters [24]: Non-generic type `Array2` cannot take parameters.']
-Line 72: Unexpected errors ['generics_typevartuple_specialization.py:72:38 Undefined or invalid type [11]: Annotation `FloatArray` is not defined as a type.']
-Line 92: Unexpected errors ['generics_typevartuple_specialization.py:92:13 Undefined or invalid type [11]: Annotation `VariadicTuple` is not defined as a type.']
-Line 95: Unexpected errors ['generics_typevartuple_specialization.py:95:19 Invalid type [31]: Expression `tuple[(typing.Any, *tuple[(typing.Any, ...)])]` is not a valid type.']
-Line 108: Unexpected errors ['generics_typevartuple_specialization.py:108:0 Undefined attribute [16]: `typing.Tuple` has no attribute `__getitem__`.']
-Line 130: Unexpected errors ['generics_typevartuple_specialization.py:130:13 Invalid type [31]: Expression `TA7[(*Ts, T1, T2)]` is not a valid type.', "generics_typevartuple_specialization.py:130:13 Invalid type variable [34]: The type variable `Variable[T1]` isn't present in the function's parameters.", "generics_typevartuple_specialization.py:130:13 Invalid type variable [34]: The type variable `Variable[T2]` isn't present in the function's parameters.", 'generics_typevartuple_specialization.py:130:34 Invalid type [31]: Expression `tuple[(tuple[(*Ts)], T1, T2)]` is not a valid type.', "generics_typevartuple_specialization.py:130:34 Invalid type variable [34]: The type variable `Variable[T1]` isn't present in the function's parameters.", "generics_typevartuple_specialization.py:130:34 Invalid type variable [34]: The type variable `Variable[T2]` isn't present in the function's parameters."]
-Line 143: Unexpected errors ['generics_typevartuple_specialization.py:143:13 Invalid type [31]: Expression `TA8[(T1, *Ts, T2, T3)]` is not a valid type.', "generics_typevartuple_specialization.py:143:13 Invalid type variable [34]: The type variable `Variable[T1]` isn't present in the function's parameters.", "generics_typevartuple_specialization.py:143:13 Invalid type variable [34]: The type variable `Variable[T2]` isn't present in the function's parameters.", "generics_typevartuple_specialization.py:143:13 Invalid type variable [34]: The type variable `Variable[T3]` isn't present in the function's parameters.", 'generics_typevartuple_specialization.py:143:13 Undefined or invalid type [11]: Annotation `TA8` is not defined as a type.', 'generics_typevartuple_specialization.py:143:38 Invalid type [31]: Expression `tuple[(tuple[(*Ts)], T1, T2, T3)]` is not a valid type.', "generics_typevartuple_specialization.py:143:38 Invalid type variable [34]: The type variable `Variable[T1]` isn't present in the function's parameters.", "generics_typevartuple_specialization.py:143:38 Invalid type variable [34]: The type variable `Variable[T2]` isn't present in the function's parameters.", "generics_typevartuple_specialization.py:143:38 Invalid type variable [34]: The type variable `Variable[T3]` isn't present in the function's parameters."]
-Line 156: Unexpected errors ['generics_typevartuple_specialization.py:156:14 Undefined or invalid type [11]: Annotation `TA10` is not defined as a type.', 'generics_typevartuple_specialization.py:156:23 Invalid type [31]: Expression `TA9[(*tuple[(int, ...)], str)]` is not a valid type.', 'generics_typevartuple_specialization.py:156:23 Undefined or invalid type [11]: Annotation `TA9` is not defined as a type.', 'generics_typevartuple_specialization.py:156:54 Invalid type [31]: Expression `TA9[(*tuple[(int, ...)], str)]` is not a valid type.']
-Line 157: Unexpected errors ['generics_typevartuple_specialization.py:157:19 Invalid type [31]: Expression `tuple[(*tuple[(int, ...)], int)]` is not a valid type.']
-Line 158: Unexpected errors ['generics_typevartuple_specialization.py:158:19 Invalid type [31]: Expression `tuple[(*tuple[(int, ...)], str)]` is not a valid type.']
-Line 159: Unexpected errors ['generics_typevartuple_specialization.py:159:19 Invalid type [31]: Expression `tuple[(*tuple[(int, ...)], str)]` is not a valid type.']
+Line 29: Unexpected errors ['generics_typevartuple_specialization.py:29:21 Incompatible parameter type [6]: In call `takes_any_array1`, for 1st positional argument, expected `Array[]` but got `Array[Height, Width]`.']
+Line 34: Unexpected errors ['generics_typevartuple_specialization.py:34:21 Incompatible parameter type [6]: In call `takes_any_array1`, for 1st positional argument, expected `Array[]` but got `Array[Time, Height, Width]`.']
+Line 136: Unexpected errors ['generics_typevartuple_specialization.py:136:4 Assert type [70]: Expected `Tuple[Tuple[str], bool, float]` but got `Tuple[Tuple[float], str, bool]`.']
+Line 137: Unexpected errors ['generics_typevartuple_specialization.py:137:4 Assert type [70]: Expected `Tuple[Tuple[str, bool], float, int]` but got `Tuple[Tuple[float, int], str, bool]`.']
+Line 148: Unexpected errors ['generics_typevartuple_specialization.py:148:4 Assert type [70]: Expected `Tuple[Tuple[], str, bool, float]` but got `Tuple[Tuple[], float, str, bool]`.']
+Line 149: Unexpected errors ['generics_typevartuple_specialization.py:149:4 Assert type [70]: Expected `Tuple[Tuple[bool], str, float, int]` but got `Tuple[Tuple[int], float, str, bool]`.']
+Line 157: Unexpected errors ['generics_typevartuple_specialization.py:157:4 Assert type [70]: Expected `typing.Tuple[*Tuple[int, ...], int]` but got `typing.Tuple[*Tuple[typing.Any, ...], typing.Any]`.']
+Line 158: Unexpected errors ['generics_typevartuple_specialization.py:158:4 Assert type [70]: Expected `typing.Tuple[*Tuple[int, ...], str]` but got `typing.Tuple[*generics_typevartuple_specialization.Ts, Variable[T1]]`.']
+Line 159: Unexpected errors ['generics_typevartuple_specialization.py:159:4 Assert type [70]: Expected `typing.Tuple[*Tuple[int, ...], str]` but got `typing.Tuple[*generics_typevartuple_specialization.Ts, Variable[T1]]`.']
 """

--- a/conformance/results/pyre/generics_typevartuple_unpack.toml
+++ b/conformance/results/pyre/generics_typevartuple_unpack.toml
@@ -1,27 +1,9 @@
-conformant = "Unsupported"
+conformant = "Pass"
 notes = """
-Does not support star expressions for `Unpack`.
 """
 output = """
-generics_typevartuple_unpack.py:17:12 Invalid type [31]: Expression `typing.Generic[(*Ts)]` is not a valid type.
-generics_typevartuple_unpack.py:21:30 Invalid type [31]: Expression `generics_typevartuple_unpack.Array[(generics_typevartuple_unpack.Batch, *tuple[(typing.Any, ...)], generics_typevartuple_unpack.Channels)]` is not a valid type.
-generics_typevartuple_unpack.py:21:30 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.
-generics_typevartuple_unpack.py:26:7 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.
-generics_typevartuple_unpack.py:26:49 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.
-generics_typevartuple_unpack.py:26:76 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.
-generics_typevartuple_unpack.py:36:29 Invalid type [31]: Expression `generics_typevartuple_unpack.Array[(generics_typevartuple_unpack.Batch, *Shape)]` is not a valid type.
-generics_typevartuple_unpack.py:36:29 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.
-generics_typevartuple_unpack.py:40:28 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.
-generics_typevartuple_unpack.py:44:13 Invalid type [31]: Expression `generics_typevartuple_unpack.Array[(*tuple[(typing.Any, ...)])]` is not a valid type.
-generics_typevartuple_unpack.py:44:13 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.
+generics_typevartuple_unpack.py:30:27 Incompatible parameter type [6]: In call `process_batch_channels`, for 1st positional argument, expected `Array[Batch, *Tuple[typing.Any, ...], Channels]` but got `Array[Batch]`.
 """
-conformance_automated = "Fail"
+conformance_automated = "Pass"
 errors_diff = """
-Line 30: Expected 1 errors
-Line 17: Unexpected errors ['generics_typevartuple_unpack.py:17:12 Invalid type [31]: Expression `typing.Generic[(*Ts)]` is not a valid type.']
-Line 21: Unexpected errors ['generics_typevartuple_unpack.py:21:30 Invalid type [31]: Expression `generics_typevartuple_unpack.Array[(generics_typevartuple_unpack.Batch, *tuple[(typing.Any, ...)], generics_typevartuple_unpack.Channels)]` is not a valid type.', 'generics_typevartuple_unpack.py:21:30 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.']
-Line 26: Unexpected errors ['generics_typevartuple_unpack.py:26:7 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.', 'generics_typevartuple_unpack.py:26:49 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.', 'generics_typevartuple_unpack.py:26:76 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.']
-Line 36: Unexpected errors ['generics_typevartuple_unpack.py:36:29 Invalid type [31]: Expression `generics_typevartuple_unpack.Array[(generics_typevartuple_unpack.Batch, *Shape)]` is not a valid type.', 'generics_typevartuple_unpack.py:36:29 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.']
-Line 40: Unexpected errors ['generics_typevartuple_unpack.py:40:28 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.']
-Line 44: Unexpected errors ['generics_typevartuple_unpack.py:44:13 Invalid type [31]: Expression `generics_typevartuple_unpack.Array[(*tuple[(typing.Any, ...)])]` is not a valid type.', 'generics_typevartuple_unpack.py:44:13 Invalid type parameters [24]: Non-generic type `Array` cannot take parameters.']
 """

--- a/conformance/results/pyre/generics_upper_bound.toml
+++ b/conformance/results/pyre/generics_upper_bound.toml
@@ -4,11 +4,11 @@ False positives on valid type expression (`list[T]`) in `bound`.
 Does not complain when bound is used alongside type constraints.
 """
 output = """
-generics_upper_bound.py:24:37 Undefined attribute [16]: `list` has no attribute `__getitem__`.
 generics_upper_bound.py:51:7 Incompatible parameter type [6]: In call `longer`, for 1st positional argument, expected `Variable[ST (bound to Sized)]` but got `int`.
 generics_upper_bound.py:51:10 Incompatible parameter type [6]: In call `longer`, for 2nd positional argument, expected `Variable[ST (bound to Sized)]` but got `int`.
 """
 conformance_automated = "Fail"
 errors_diff = """
+Line 24: Expected 1 errors
 Line 56: Expected 1 errors
 """

--- a/conformance/results/pyre/generics_variance.toml
+++ b/conformance/results/pyre/generics_variance.toml
@@ -4,8 +4,8 @@ Does not reject a TypeVar that is defined as both covariant and contravariant.
 Does not reject use of class-scoped TypeVar used in a base class when variance is incompatible.
 """
 output = """
-generics_variance.py:77:0 Invalid type variance [46]: The type variable `Variable[T_co](covariant)` is incompatible with parent class type variable `Variable[T]` because subclasses cannot use more permissive type variables than their superclasses.
-generics_variance.py:81:0 Invalid type variance [46]: The type variable `Variable[T_contra](contravariant)` is incompatible with parent class type variable `Variable[T]` because subclasses cannot use more permissive type variables than their superclasses.
+generics_variance.py:77:0 Invalid type variance [46]: The type variable `Variable[T_co](covariant)` is incompatible with parent class type variable `Variable[T](invariant)` because subclasses cannot use more permissive type variables than their superclasses.
+generics_variance.py:81:0 Invalid type variance [46]: The type variable `Variable[T_contra](contravariant)` is incompatible with parent class type variable `Variable[T](invariant)` because subclasses cannot use more permissive type variables than their superclasses.
 generics_variance.py:93:0 Invalid type variance [46]: The type variable `Variable[T_contra](contravariant)` is incompatible with parent class type variable `Variable[T_co](covariant)` because subclasses cannot use more permissive type variables than their superclasses.
 generics_variance.py:105:0 Invalid type variance [46]: The type variable `Variable[T_co](covariant)` is incompatible with parent class type variable `Variable[T_contra](contravariant)` because subclasses cannot use more permissive type variables than their superclasses.
 generics_variance.py:125:0 Invalid type variance [46]: The type variable `Variable[T_co](covariant)` is incompatible with parent class type variable `Variable[T_contra](contravariant)` because subclasses cannot use more permissive type variables than their superclasses.

--- a/conformance/results/pyre/generics_variance_inference.toml
+++ b/conformance/results/pyre/generics_variance_inference.toml
@@ -1,17 +1,36 @@
-conformant = "Unsupported"
+conformant = "Partial"
 notes = """
-Type parameter syntax not yet support.
+Does not properly handle mixing legacy and PEP695 syntax.
+False negative about a type variable not being present in the function's parameters.
 """
 output = """
-generics_variance_inference.py:15:13 Parsing failure [404]: invalid syntax
+generics_variance_inference.py:24:4 Incompatible variable type [9]: v1 is declared to have type `ClassA[int, int, int]` but is used as type `ClassA[float, int, int]`.
+generics_variance_inference.py:25:4 Incompatible variable type [9]: v2 is declared to have type `ClassA[float, float, int]` but is used as type `ClassA[float, int, int]`.
+generics_variance_inference.py:28:4 Incompatible variable type [9]: v4 is declared to have type `ClassA[int, int, int]` but is used as type `ClassA[int, float, float]`.
+generics_variance_inference.py:33:41 Invalid type variable [34]: The type variable `Variable[T]` isn't present in the function's parameters.
+generics_variance_inference.py:36:26 Invalid type variable [34]: The type variable `Variable[T]` isn't present in the function's parameters.
+generics_variance_inference.py:48:0 Incompatible variable type [9]: vco2_1 is declared to have type `ShouldBeCovariant2[float]` but is used as type `ShouldBeCovariant2[int]`.
+generics_variance_inference.py:49:0 Incompatible variable type [9]: vco2_2 is declared to have type `ShouldBeCovariant2[int]` but is used as type `ShouldBeCovariant2[float]`.
+generics_variance_inference.py:53:25 Invalid type variable [34]: The type variable `Variable[T]` isn't present in the function's parameters.
+generics_variance_inference.py:63:7 Invalid type variable [34]: The current class isn't generic with respect to the type variable `Variable[T]`. To reference the type variable, you can modify the class to inherit from `typing.Generic[T]`.
+generics_variance_inference.py:75:19 Invalid type variable [34]: The type variable `Variable[T]` isn't present in the function's parameters.
+generics_variance_inference.py:88:23 Invalid type variable [34]: The type variable `Variable[T]` isn't present in the function's parameters.
+generics_variance_inference.py:104:27 Invalid type variable [34]: The type variable `Variable[T]` isn't present in the function's parameters.
+generics_variance_inference.py:119:0 Incompatible variable type [9]: vinv3_1 is declared to have type `ShouldBeInvariant3[float, str]` but is used as type `ShouldBeInvariant3[int, str]`.
+generics_variance_inference.py:120:0 Incompatible variable type [9]: vinv3_2 is declared to have type `ShouldBeInvariant3[int, str]` but is used as type `ShouldBeInvariant3[float, str]`.
+generics_variance_inference.py:121:0 Incompatible variable type [9]: vinv3_3 is declared to have type `ShouldBeInvariant3[str, float]` but is used as type `ShouldBeInvariant3[str, int]`.
+generics_variance_inference.py:122:0 Incompatible variable type [9]: vinv3_4 is declared to have type `ShouldBeInvariant3[str, int]` but is used as type `ShouldBeInvariant3[str, float]`.
+generics_variance_inference.py:127:7 Invalid type variable [34]: The current class isn't generic with respect to the type variable `Variable[T]`. To reference the type variable, you can modify the class to inherit from `typing.Generic[T]`.
+generics_variance_inference.py:169:0 Incompatible variable type [9]: a1 is declared to have type `ShouldBeInvariant6[int]` but is used as type `ShouldBeInvariant6[float]`.
+generics_variance_inference.py:170:0 Incompatible variable type [9]: a2 is declared to have type `ShouldBeInvariant6[float]` but is used as type `ShouldBeInvariant6[int]`.
+generics_variance_inference.py:181:0 Incompatible variable type [9]: b1 is declared to have type `ShouldBeCovariant6[int]` but is used as type `ShouldBeCovariant6[float]`.
+generics_variance_inference.py:182:0 Incompatible variable type [9]: b2 is declared to have type `ShouldBeCovariant6[float]` but is used as type `ShouldBeCovariant6[int]`.
+generics_variance_inference.py:193:0 Incompatible variable type [9]: c1 is declared to have type `ShouldBeContravariant2[int]` but is used as type `ShouldBeContravariant2[float]`.
+generics_variance_inference.py:194:0 Incompatible variable type [9]: c2 is declared to have type `ShouldBeContravariant2[float]` but is used as type `ShouldBeContravariant2[int]`.
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 24: Expected 1 errors
-Line 25: Expected 1 errors
-Line 28: Expected 1 errors
 Line 41: Expected 1 errors
-Line 49: Expected 1 errors
 Line 58: Expected 1 errors
 Line 67: Expected 1 errors
 Line 80: Expected 1 errors
@@ -19,16 +38,18 @@ Line 96: Expected 1 errors
 Line 97: Expected 1 errors
 Line 111: Expected 1 errors
 Line 112: Expected 1 errors
-Line 119: Expected 1 errors
-Line 120: Expected 1 errors
-Line 121: Expected 1 errors
-Line 122: Expected 1 errors
 Line 130: Expected 1 errors
 Line 138: Expected 1 errors
 Line 149: Expected 1 errors
-Line 169: Expected 1 errors
-Line 170: Expected 1 errors
-Line 181: Expected 1 errors
-Line 194: Expected 1 errors
-Line 15: Unexpected errors ['generics_variance_inference.py:15:13 Parsing failure [404]: invalid syntax']
+Line 33: Unexpected errors ["generics_variance_inference.py:33:41 Invalid type variable [34]: The type variable `Variable[T]` isn't present in the function's parameters."]
+Line 36: Unexpected errors ["generics_variance_inference.py:36:26 Invalid type variable [34]: The type variable `Variable[T]` isn't present in the function's parameters."]
+Line 48: Unexpected errors ['generics_variance_inference.py:48:0 Incompatible variable type [9]: vco2_1 is declared to have type `ShouldBeCovariant2[float]` but is used as type `ShouldBeCovariant2[int]`.']
+Line 53: Unexpected errors ["generics_variance_inference.py:53:25 Invalid type variable [34]: The type variable `Variable[T]` isn't present in the function's parameters."]
+Line 63: Unexpected errors ["generics_variance_inference.py:63:7 Invalid type variable [34]: The current class isn't generic with respect to the type variable `Variable[T]`. To reference the type variable, you can modify the class to inherit from `typing.Generic[T]`."]
+Line 75: Unexpected errors ["generics_variance_inference.py:75:19 Invalid type variable [34]: The type variable `Variable[T]` isn't present in the function's parameters."]
+Line 88: Unexpected errors ["generics_variance_inference.py:88:23 Invalid type variable [34]: The type variable `Variable[T]` isn't present in the function's parameters."]
+Line 104: Unexpected errors ["generics_variance_inference.py:104:27 Invalid type variable [34]: The type variable `Variable[T]` isn't present in the function's parameters."]
+Line 127: Unexpected errors ["generics_variance_inference.py:127:7 Invalid type variable [34]: The current class isn't generic with respect to the type variable `Variable[T]`. To reference the type variable, you can modify the class to inherit from `typing.Generic[T]`."]
+Line 182: Unexpected errors ['generics_variance_inference.py:182:0 Incompatible variable type [9]: b2 is declared to have type `ShouldBeCovariant6[float]` but is used as type `ShouldBeCovariant6[int]`.']
+Line 193: Unexpected errors ['generics_variance_inference.py:193:0 Incompatible variable type [9]: c1 is declared to have type `ShouldBeContravariant2[int]` but is used as type `ShouldBeContravariant2[float]`.']
 """

--- a/conformance/results/pyre/historical_positional.toml
+++ b/conformance/results/pyre/historical_positional.toml
@@ -1,19 +1,12 @@
-conformant = "Partial"
+conformant = "Pass"
 notes = """
-Does not reject positional-only parameter after non-positional-only parameter.
-Incorrectly applies legacy positional-only rules when explicit *args are used.
-Incorrectly applies legacy positional-only rules when PEP 570 syntax is used.
 """
 output = """
 historical_positional.py:18:0 Unexpected keyword [28]: Unexpected keyword argument `__x` to call `f1`.
-historical_positional.py:32:0 Unexpected keyword [28]: Unexpected keyword argument `__y` to call `f3`.
+historical_positional.py:26:15 Invalid positional-only parameter [69]: Positional-only parameters cannot appear after parameters that accept keyword arguments.
+historical_positional.py:38:25 Invalid positional-only parameter [69]: Positional-only parameters cannot appear after parameters that accept keyword arguments.
 historical_positional.py:43:0 Unexpected keyword [28]: Unexpected keyword argument `__x` to call `A.m1`.
-historical_positional.py:53:0 Unexpected keyword [28]: Unexpected keyword argument `__y` to call `f4`.
 """
-conformance_automated = "Fail"
+conformance_automated = "Pass"
 errors_diff = """
-Line 26: Expected 1 errors
-Line 38: Expected 1 errors
-Line 32: Unexpected errors ['historical_positional.py:32:0 Unexpected keyword [28]: Unexpected keyword argument `__y` to call `f3`.']
-Line 53: Unexpected errors ['historical_positional.py:53:0 Unexpected keyword [28]: Unexpected keyword argument `__y` to call `f4`.']
 """

--- a/conformance/results/pyre/literals_interactions.toml
+++ b/conformance/results/pyre/literals_interactions.toml
@@ -6,17 +6,13 @@ Does not narrow type of `x` with `x in Literal` type guard pattern.
 Does not narrow type of `x` with `x == Literal` type guard pattern.
 """
 output = """
-literals_interactions.py:93:8 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `str` but got `Union[Status, str]`.
-literals_interactions.py:106:34 Incompatible parameter type [6]: In call `expects_bad_status`, for 1st positional argument, expected `Union[typing_extensions.Literal['ABORTED'], typing_extensions.Literal['MALFORMED']]` but got `str`.
-literals_interactions.py:109:31 Non-literal string [62]: In call `expects_pending_status`, for 1st positional argument, expected `LiteralString` but got `str`. Ensure only a string literal or a `LiteralString` is used.
+literals_interactions.py:15:4 Invalid tuple index [73]: Index 5 is out of bounds for concrete tuple with 3 members.
+literals_interactions.py:16:4 Invalid tuple index [73]: Index -5 is out of bounds for concrete tuple with 3 members.
+literals_interactions.py:17:4 Invalid tuple index [73]: Index 4 is out of bounds for concrete tuple with 3 members.
+literals_interactions.py:18:4 Invalid tuple index [73]: Index -4 is out of bounds for concrete tuple with 3 members.
+literals_interactions.py:93:8 Assert type [70]: Expected `str` but got `Union[Status, str]`.
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 15: Expected 1 errors
-Line 16: Expected 1 errors
-Line 17: Expected 1 errors
-Line 18: Expected 1 errors
-Line 93: Unexpected errors ['literals_interactions.py:93:8 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `str` but got `Union[Status, str]`.']
-Line 106: Unexpected errors ["literals_interactions.py:106:34 Incompatible parameter type [6]: In call `expects_bad_status`, for 1st positional argument, expected `Union[typing_extensions.Literal['ABORTED'], typing_extensions.Literal['MALFORMED']]` but got `str`."]
-Line 109: Unexpected errors ['literals_interactions.py:109:31 Non-literal string [62]: In call `expects_pending_status`, for 1st positional argument, expected `LiteralString` but got `str`. Ensure only a string literal or a `LiteralString` is used.']
+Line 93: Unexpected errors ['literals_interactions.py:93:8 Assert type [70]: Expected `str` but got `Union[Status, str]`.']
 """

--- a/conformance/results/pyre/literals_literalstring.toml
+++ b/conformance/results/pyre/literals_literalstring.toml
@@ -7,7 +7,7 @@ literals_literalstring.py:36:11 Invalid type [31]: Expression `LiteralString` is
 literals_literalstring.py:36:11 Undefined or invalid type [11]: Annotation `typing` is not defined as a type.
 literals_literalstring.py:37:13 Invalid type [31]: Expression `LiteralString` is not a literal value.
 literals_literalstring.py:43:4 Incompatible variable type [9]: x2 is declared to have type `typing_extensions.Literal['']` but is used as type `typing_extensions.Literal['two']`.
-literals_literalstring.py:52:4 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `typing_extensions.LiteralString` but got `str`.
+literals_literalstring.py:52:4 Assert type [70]: Expected `typing_extensions.LiteralString` but got `str`.
 literals_literalstring.py:66:4 Incompatible variable type [9]: x1 is declared to have type `typing_extensions.LiteralString` but is used as type `str`.
 literals_literalstring.py:74:4 Incompatible variable type [9]: x3 is declared to have type `typing_extensions.LiteralString` but is used as type `typing_extensions.Literal[3]`.
 literals_literalstring.py:75:4 Incompatible variable type [9]: x4 is declared to have type `typing_extensions.LiteralString` but is used as type `typing_extensions.Literal[b'test']`.
@@ -17,5 +17,5 @@ literals_literalstring.py:171:4 Incompatible variable type [9]: x1 is declared t
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 52: Unexpected errors ['literals_literalstring.py:52:4 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `typing_extensions.LiteralString` but got `str`.']
+Line 52: Unexpected errors ['literals_literalstring.py:52:4 Assert type [70]: Expected `typing_extensions.LiteralString` but got `str`.']
 """

--- a/conformance/results/pyre/literals_parameterizations.toml
+++ b/conformance/results/pyre/literals_parameterizations.toml
@@ -11,7 +11,6 @@ literals_parameterizations.py:33:0 Invalid type [31]: Expression `ReadOnlyMode` 
 literals_parameterizations.py:33:0 Invalid type [31]: Expression `WriteAndTruncateMode` is not a literal value.
 literals_parameterizations.py:33:0 Invalid type [31]: Expression `WriteNoTruncateMode` is not a literal value.
 literals_parameterizations.py:33:0 Undefined or invalid type [11]: Annotation `` is not defined as a type.
-literals_parameterizations.py:35:8 Invalid type [31]: Expression `typing.Literal[(typing.Literal[(typing.Literal[(1, 2, 3)], "foo")], 5, None)]` is not a valid type.
 literals_parameterizations.py:41:6 Invalid type [31]: Expression `typing.Literal[3 + 4]` is not a valid type.
 literals_parameterizations.py:42:6 Invalid type [31]: Expression `typing.Literal["foo".replace("o", "b")]` is not a valid type.
 literals_parameterizations.py:43:6 Invalid type [31]: Expression `typing.Literal[4 + 3.000000j]` is not a valid type.
@@ -33,5 +32,4 @@ errors_diff = """
 Line 46: Expected 1 errors
 Line 60: Expected 1 errors
 Line 33: Unexpected errors ['literals_parameterizations.py:33:0 Invalid type [31]: Expression `AppendMode` is not a literal value.', 'literals_parameterizations.py:33:0 Invalid type [31]: Expression `ReadOnlyMode` is not a literal value.', 'literals_parameterizations.py:33:0 Invalid type [31]: Expression `WriteAndTruncateMode` is not a literal value.', 'literals_parameterizations.py:33:0 Invalid type [31]: Expression `WriteNoTruncateMode` is not a literal value.', 'literals_parameterizations.py:33:0 Undefined or invalid type [11]: Annotation `` is not defined as a type.']
-Line 35: Unexpected errors ['literals_parameterizations.py:35:8 Invalid type [31]: Expression `typing.Literal[(typing.Literal[(typing.Literal[(1, 2, 3)], "foo")], 5, None)]` is not a valid type.']
 """

--- a/conformance/results/pyre/namedtuples_define_class.toml
+++ b/conformance/results/pyre/namedtuples_define_class.toml
@@ -8,39 +8,19 @@ Incorrectly rejects assignment of named tuple to a tuple with compatible type.
 Does not reject attempt to use NamedTuple with multiple inheritance.
 """
 output = """
-namedtuples_define_class.py:23:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `typing.Any`.
-namedtuples_define_class.py:24:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `typing.Any`.
-namedtuples_define_class.py:25:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `str` but got `typing.Any`.
-namedtuples_define_class.py:26:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `str` but got `typing.Any`.
-namedtuples_define_class.py:27:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `typing.Any`.
-namedtuples_define_class.py:28:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `typing.Any`.
-namedtuples_define_class.py:29:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Tuple[int, int]` but got `typing.Tuple[typing.Any, ...]`.
-namedtuples_define_class.py:30:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Tuple[int, int, str]` but got `typing.Tuple[typing.Any, ...]`.
+namedtuples_define_class.py:32:6 Invalid tuple index [73]: Index 3 is out of bounds for concrete tuple with 3 members.
+namedtuples_define_class.py:33:6 Invalid tuple index [73]: Index -4 is out of bounds for concrete tuple with 3 members.
 namedtuples_define_class.py:44:5 Missing argument [20]: Call `Point.__init__` expects argument `y`.
 namedtuples_define_class.py:45:5 Missing argument [20]: Call `Point.__init__` expects argument `y`.
 namedtuples_define_class.py:46:14 Incompatible parameter type [6]: In call `Point.__init__`, for 2nd positional argument, expected `int` but got `str`.
 namedtuples_define_class.py:47:17 Incompatible parameter type [6]: In call `Point.__init__`, for argument `units`, expected `str` but got `int`.
 namedtuples_define_class.py:48:5 Too many arguments [19]: Call `Point.__init__` expects 3 positional arguments, 4 were provided.
 namedtuples_define_class.py:49:6 Unexpected keyword [28]: Unexpected keyword argument `other` to call `Point.__init__`.
-namedtuples_define_class.py:73:0 Incompatible variable type [9]: Unable to unpack `PointWithName`, expected a tuple.
+namedtuples_define_class.py:59:4 Missing named tuple default [74]: Named tuple field without default value may not be preceded by a field with default value.
 namedtuples_define_class.py:79:4 Invalid assignment [41]: Cannot reassign final attribute `x`.
-namedtuples_define_class.py:95:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `float` but got `typing.Any`.
 namedtuples_define_class.py:98:18 Incompatible parameter type [6]: In call `Property.__init__`, for 2nd positional argument, expected `str` but got `float`.
+namedtuples_define_class.py:105:23 Invalid inheritance [39]: If NamedTuple is included as a base class, the class may not extend anything else besides Generic.
 """
-conformance_automated = "Fail"
+conformance_automated = "Pass"
 errors_diff = """
-Line 32: Expected 1 errors
-Line 33: Expected 1 errors
-Line 59: Expected 1 errors
-Line 105: Expected 1 errors
-Line 23: Unexpected errors ['namedtuples_define_class.py:23:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `typing.Any`.']
-Line 24: Unexpected errors ['namedtuples_define_class.py:24:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `typing.Any`.']
-Line 25: Unexpected errors ['namedtuples_define_class.py:25:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `str` but got `typing.Any`.']
-Line 26: Unexpected errors ['namedtuples_define_class.py:26:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `str` but got `typing.Any`.']
-Line 27: Unexpected errors ['namedtuples_define_class.py:27:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `typing.Any`.']
-Line 28: Unexpected errors ['namedtuples_define_class.py:28:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `typing.Any`.']
-Line 29: Unexpected errors ['namedtuples_define_class.py:29:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Tuple[int, int]` but got `typing.Tuple[typing.Any, ...]`.']
-Line 30: Unexpected errors ['namedtuples_define_class.py:30:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Tuple[int, int, str]` but got `typing.Tuple[typing.Any, ...]`.']
-Line 73: Unexpected errors ['namedtuples_define_class.py:73:0 Incompatible variable type [9]: Unable to unpack `PointWithName`, expected a tuple.']
-Line 95: Unexpected errors ['namedtuples_define_class.py:95:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `float` but got `typing.Any`.']
 """

--- a/conformance/results/pyre/namedtuples_define_functional.toml
+++ b/conformance/results/pyre/namedtuples_define_functional.toml
@@ -1,8 +1,5 @@
-conformant = "Partial"
+conformant = "Pass"
 notes = """
-Does not handle illegal named tuple names the same as runtime.
-Does not handle defined fields correctly when extra flags like `rename` or `default` are used.
-Does not support defaults in functional form.
 """
 output = """
 namedtuples_define_functional.py:16:7 Missing argument [20]: Call `Point1.__init__` expects argument `y`.
@@ -14,24 +11,9 @@ namedtuples_define_functional.py:37:7 Too many arguments [19]: Call `Point5.__in
 namedtuples_define_functional.py:42:17 Incompatible parameter type [6]: In call `Point6.__init__`, for 2nd positional argument, expected `int` but got `str`.
 namedtuples_define_functional.py:43:14 Incompatible parameter type [6]: In call `Point6.__init__`, for argument `x`, expected `int` but got `float`.
 namedtuples_define_functional.py:52:0 Duplicate parameter [65]: Duplicate parameter name `a`.
-namedtuples_define_functional.py:54:47 Invalid type [31]: Expression `False` is not a valid type.
-namedtuples_define_functional.py:54:47 Invalid type [31]: Expression `False` is not a valid type.
-namedtuples_define_functional.py:54:47 Invalid type [31]: Expression `typing.Final[False]` is not a valid type.
-namedtuples_define_functional.py:56:47 Invalid type [31]: Expression `True` is not a valid type.
-namedtuples_define_functional.py:56:47 Invalid type [31]: Expression `True` is not a valid type.
-namedtuples_define_functional.py:56:47 Invalid type [31]: Expression `typing.Final[True]` is not a valid type.
-namedtuples_define_functional.py:57:0 Unexpected keyword [28]: Unexpected keyword argument `abc` to call `NT4.__init__`.
-namedtuples_define_functional.py:63:42 Invalid type [31]: Expression `typing.Final[(1, 2)]` is not a valid type.
-namedtuples_define_functional.py:63:42 Invalid type [31]: Expression `(1, 2)` is not a valid type.
-namedtuples_define_functional.py:63:42 Invalid type [31]: Expression `(1, 2)` is not a valid type.
-namedtuples_define_functional.py:63:42 Invalid type parameters [24]: Generic type `typing.Final` expects 1 type parameter, received 2.
-namedtuples_define_functional.py:65:0 Too many arguments [19]: Call `NT5.__init__` expects 1 positional argument, 3 were provided.
-namedtuples_define_functional.py:66:0 Missing argument [20]: Call `NT5.__init__` expects argument `defaults`.
+namedtuples_define_functional.py:52:0 Duplicate parameter [65]: Duplicate parameter name `a`.
+namedtuples_define_functional.py:66:0 Missing argument [20]: Call `NT5.__init__` expects argument `a`.
 """
-conformance_automated = "Fail"
+conformance_automated = "Pass"
 errors_diff = """
-Line 56: Unexpected errors ['namedtuples_define_functional.py:56:47 Invalid type [31]: Expression `True` is not a valid type.', 'namedtuples_define_functional.py:56:47 Invalid type [31]: Expression `True` is not a valid type.', 'namedtuples_define_functional.py:56:47 Invalid type [31]: Expression `typing.Final[True]` is not a valid type.']
-Line 57: Unexpected errors ['namedtuples_define_functional.py:57:0 Unexpected keyword [28]: Unexpected keyword argument `abc` to call `NT4.__init__`.']
-Line 63: Unexpected errors ['namedtuples_define_functional.py:63:42 Invalid type [31]: Expression `typing.Final[(1, 2)]` is not a valid type.', 'namedtuples_define_functional.py:63:42 Invalid type [31]: Expression `(1, 2)` is not a valid type.', 'namedtuples_define_functional.py:63:42 Invalid type [31]: Expression `(1, 2)` is not a valid type.', 'namedtuples_define_functional.py:63:42 Invalid type parameters [24]: Generic type `typing.Final` expects 1 type parameter, received 2.']
-Line 65: Unexpected errors ['namedtuples_define_functional.py:65:0 Too many arguments [19]: Call `NT5.__init__` expects 1 positional argument, 3 were provided.']
 """

--- a/conformance/results/pyre/namedtuples_type_compat.toml
+++ b/conformance/results/pyre/namedtuples_type_compat.toml
@@ -1,17 +1,10 @@
-conformant = "Unsupported"
+conformant = "Pass"
 notes = """
-Rejects valid type compatibility between named tuple and tuple.
 """
 output = """
-namedtuples_type_compat.py:20:0 Incompatible variable type [9]: Unable to unpack `Point`, expected a tuple.
-namedtuples_type_compat.py:21:0 Incompatible variable type [9]: Unable to unpack `Point`, expected a tuple.
 namedtuples_type_compat.py:22:0 Incompatible variable type [9]: Unable to unpack `Point`, expected a tuple.
 namedtuples_type_compat.py:23:0 Incompatible variable type [9]: Unable to unpack `Point`, expected a tuple.
-namedtuples_type_compat.py:27:0 Incompatible variable type [9]: Unable to unpack `Point`, expected a tuple.
 """
-conformance_automated = "Fail"
+conformance_automated = "Pass"
 errors_diff = """
-Line 20: Unexpected errors ['namedtuples_type_compat.py:20:0 Incompatible variable type [9]: Unable to unpack `Point`, expected a tuple.']
-Line 21: Unexpected errors ['namedtuples_type_compat.py:21:0 Incompatible variable type [9]: Unable to unpack `Point`, expected a tuple.']
-Line 27: Unexpected errors ['namedtuples_type_compat.py:27:0 Incompatible variable type [9]: Unable to unpack `Point`, expected a tuple.']
 """

--- a/conformance/results/pyre/namedtuples_usage.toml
+++ b/conformance/results/pyre/namedtuples_usage.toml
@@ -1,35 +1,16 @@
 conformant = "Partial"
 notes = """
-Does not report out-of-range index access with named tuple instance.
-Does not reject attempt to delete named tuple field by name.
-Does not reject attempt to delete named tuple field by index.
-Incorrectly handles subclasses of named tuples that add more attributes.
-Does not handle unpacking of named tuples.
 """
 output = """
-namedtuples_usage.py:27:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `typing.Any`.
-namedtuples_usage.py:28:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `typing.Any`.
-namedtuples_usage.py:29:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `str` but got `typing.Any`.
-namedtuples_usage.py:30:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `str` but got `typing.Any`.
-namedtuples_usage.py:31:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `typing.Any`.
-namedtuples_usage.py:32:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `typing.Any`.
+namedtuples_usage.py:34:6 Invalid tuple index [73]: Index 3 is out of bounds for concrete tuple with 3 members.
+namedtuples_usage.py:35:6 Invalid tuple index [73]: Index -4 is out of bounds for concrete tuple with 3 members.
 namedtuples_usage.py:40:0 Invalid assignment [41]: Cannot reassign final attribute `p.x`.
 namedtuples_usage.py:41:0 Undefined attribute [16]: `Point` has no attribute `__setitem__`.
+namedtuples_usage.py:42:0 Unable to delete tuple member [72]: Tuples are immutable, so their members may not be deleted.
+namedtuples_usage.py:43:0 Unable to delete tuple member [72]: Tuples are immutable, so their members may not be deleted.
 namedtuples_usage.py:52:0 Unable to unpack [23]: Unable to unpack 3 values, 2 were expected.
 namedtuples_usage.py:53:0 Unable to unpack [23]: Unable to unpack 3 values, 4 were expected.
-namedtuples_usage.py:61:0 Unable to unpack [23]: Unable to unpack 0 values, 3 were expected.
 """
-conformance_automated = "Fail"
+conformance_automated = "Pass"
 errors_diff = """
-Line 34: Expected 1 errors
-Line 35: Expected 1 errors
-Line 42: Expected 1 errors
-Line 43: Expected 1 errors
-Line 27: Unexpected errors ['namedtuples_usage.py:27:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `typing.Any`.']
-Line 28: Unexpected errors ['namedtuples_usage.py:28:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `typing.Any`.']
-Line 29: Unexpected errors ['namedtuples_usage.py:29:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `str` but got `typing.Any`.']
-Line 30: Unexpected errors ['namedtuples_usage.py:30:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `str` but got `typing.Any`.']
-Line 31: Unexpected errors ['namedtuples_usage.py:31:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `typing.Any`.']
-Line 32: Unexpected errors ['namedtuples_usage.py:32:0 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `typing.Any`.']
-Line 61: Unexpected errors ['namedtuples_usage.py:61:0 Unable to unpack [23]: Unable to unpack 0 values, 3 were expected.']
 """

--- a/conformance/results/pyre/narrowing_typeguard.toml
+++ b/conformance/results/pyre/narrowing_typeguard.toml
@@ -1,15 +1,12 @@
-conformant = "Partial"
+conformant = "Pass"
 notes = """
-Does not reject TypeGuard method with too few parameters.
 """
 output = """
+narrowing_typeguard.py:102:22 Invalid type guard [68]: User-defined type guard functions or methods must have at least one input parameter.
+narrowing_typeguard.py:107:21 Invalid type guard [68]: User-defined type guard functions or methods must have at least one input parameter.
 narrowing_typeguard.py:128:19 Incompatible parameter type [6]: In call `takes_callable_str`, for 1st positional argument, expected `typing.Callable[[object], str]` but got `typing.Callable(simple_typeguard)[[Named(val, object)], TypeGuard[int]]`.
 narrowing_typeguard.py:148:25 Incompatible parameter type [6]: In call `takes_callable_str_proto`, for 1st positional argument, expected `CallableStrProto` but got `typing.Callable(simple_typeguard)[[Named(val, object)], TypeGuard[int]]`.
-narrowing_typeguard.py:167:20 Incompatible parameter type [6]: In call `takes_int_typeguard`, for 1st positional argument, expected `typing.Callable[[object], TypeGuard[int]]` but got `typing.Callable(bool_typeguard)[[Named(val, object)], TypeGuard[bool]]`.
 """
-conformance_automated = "Fail"
+conformance_automated = "Pass"
 errors_diff = """
-Line 102: Expected 1 errors
-Line 107: Expected 1 errors
-Line 167: Unexpected errors ['narrowing_typeguard.py:167:20 Incompatible parameter type [6]: In call `takes_int_typeguard`, for 1st positional argument, expected `typing.Callable[[object], TypeGuard[int]]` but got `typing.Callable(bool_typeguard)[[Named(val, object)], TypeGuard[bool]]`.']
 """

--- a/conformance/results/pyre/narrowing_typeis.toml
+++ b/conformance/results/pyre/narrowing_typeis.toml
@@ -1,39 +1,15 @@
-conformant = "Unsupported"
+conformant = "Pass"
 output = """
-narrowing_typeis.py:9:0 Undefined import [21]: Could not find a name `TypeIs` defined in module `typing_extensions`.
-narrowing_typeis.py:14:48 Undefined or invalid type [11]: Annotation `TypeIs` is not defined as a type.
-narrowing_typeis.py:19:8 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Tuple[str, str]` but got `typing.Tuple[str, ...]`.
-narrowing_typeis.py:35:17 Incompatible awaitable type [12]: Expected an awaitable but got `typing.Union[typing.Awaitable[int], int]`.
-narrowing_typeis.py:38:8 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `Union[Awaitable[int], int]`.
-narrowing_typeis.py:72:8 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `object`.
-narrowing_typeis.py:76:8 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `object`.
-narrowing_typeis.py:80:8 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `object`.
-narrowing_typeis.py:84:8 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `object`.
-narrowing_typeis.py:88:8 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `object`.
-narrowing_typeis.py:92:8 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `B` but got `object`.
-narrowing_typeis.py:96:8 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `B` but got `object`.
+narrowing_typeis.py:105:22 Invalid type guard [68]: User-defined type guard functions or methods must have at least one input parameter.
+narrowing_typeis.py:110:21 Invalid type guard [68]: User-defined type guard functions or methods must have at least one input parameter.
+narrowing_typeis.py:132:19 Incompatible parameter type [6]: In call `takes_callable_str`, for 1st positional argument, expected `typing.Callable[[object], str]` but got `typing.Callable(simple_typeguard)[[Named(val, object)], TypeIs[int]]`.
+narrowing_typeis.py:152:25 Incompatible parameter type [6]: In call `takes_callable_str_proto`, for 1st positional argument, expected `CallableStrProto` but got `typing.Callable(simple_typeguard)[[Named(val, object)], TypeIs[int]]`.
+narrowing_typeis.py:169:16 Incompatible parameter type [6]: In call `takes_typeguard`, for 1st positional argument, expected `typing.Callable[[object], TypeGuard[int]]` but got `typing.Callable(is_int_typeis)[[Named(val, object)], TypeIs[int]]`.
+narrowing_typeis.py:170:13 Incompatible parameter type [6]: In call `takes_typeis`, for 1st positional argument, expected `typing.Callable[[object], TypeIs[int]]` but got `typing.Callable(is_int_typeguard)[[Named(val, object)], TypeGuard[int]]`.
+narrowing_typeis.py:191:17 Incompatible parameter type [6]: In call `takes_int_typeis`, for 1st positional argument, expected `typing.Callable[[object], TypeIs[int]]` but got `typing.Callable(bool_typeis)[[Named(val, object)], TypeIs[bool]]`.
+narrowing_typeis.py:195:26 Invalid type guard [68]: The narrowed type str of this type guard is not a subtype of the first positional parameter type int.
+narrowing_typeis.py:199:44 Invalid type guard [68]: The narrowed type typing.List[int] of this type guard is not a subtype of the first positional parameter type typing.List[object].
 """
-conformance_automated = "Fail"
+conformance_automated = "Pass"
 errors_diff = """
-Line 105: Expected 1 errors
-Line 110: Expected 1 errors
-Line 132: Expected 1 errors
-Line 152: Expected 1 errors
-Line 169: Expected 1 errors
-Line 170: Expected 1 errors
-Line 191: Expected 1 errors
-Line 195: Expected 1 errors
-Line 199: Expected 1 errors
-Line 9: Unexpected errors ['narrowing_typeis.py:9:0 Undefined import [21]: Could not find a name `TypeIs` defined in module `typing_extensions`.']
-Line 14: Unexpected errors ['narrowing_typeis.py:14:48 Undefined or invalid type [11]: Annotation `TypeIs` is not defined as a type.']
-Line 19: Unexpected errors ['narrowing_typeis.py:19:8 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Tuple[str, str]` but got `typing.Tuple[str, ...]`.']
-Line 35: Unexpected errors ['narrowing_typeis.py:35:17 Incompatible awaitable type [12]: Expected an awaitable but got `typing.Union[typing.Awaitable[int], int]`.']
-Line 38: Unexpected errors ['narrowing_typeis.py:38:8 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `Union[Awaitable[int], int]`.']
-Line 72: Unexpected errors ['narrowing_typeis.py:72:8 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `object`.']
-Line 76: Unexpected errors ['narrowing_typeis.py:76:8 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `object`.']
-Line 80: Unexpected errors ['narrowing_typeis.py:80:8 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `object`.']
-Line 84: Unexpected errors ['narrowing_typeis.py:84:8 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `object`.']
-Line 88: Unexpected errors ['narrowing_typeis.py:88:8 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `int` but got `object`.']
-Line 92: Unexpected errors ['narrowing_typeis.py:92:8 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `B` but got `object`.']
-Line 96: Unexpected errors ['narrowing_typeis.py:96:8 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `B` but got `object`.']
 """

--- a/conformance/results/pyre/overloads_basic.toml
+++ b/conformance/results/pyre/overloads_basic.toml
@@ -1,12 +1,11 @@
-conformant = "Partial"
+conformant = "Pass"
 notes = """
-Does not reject a function with a single @overload signature.
 """
 output = """
 overloads_basic.py:37:2 Incompatible parameter type [6]: In call `Bytes.__getitem__`, for 1st positional argument, expected `int` but got `str`.
+overloads_basic.py:63:0 Incompatible overload [43]: At least two overload signatures must be present.
 overloads_basic.py:75:0 Missing overload implementation [42]: Overloaded function `func2` must have an implementation.
 """
-conformance_automated = "Fail"
+conformance_automated = "Pass"
 errors_diff = """
-Lines 62, 63: Expected error (tag 'func1')
 """

--- a/conformance/results/pyre/protocols_generic.toml
+++ b/conformance/results/pyre/protocols_generic.toml
@@ -5,6 +5,7 @@ Does not detect protocol mismatch when method-scoped TypeVar is used in protocol
 """
 output = """
 protocols_generic.py:40:0 Incompatible variable type [9]: p2 is declared to have type `Proto1[int, str]` but is used as type `Concrete1`.
+protocols_generic.py:44:29 Invalid inheritance [39]: Subscripted Protocol and Generic may not appear in the same base class list
 protocols_generic.py:56:4 Incompatible variable type [9]: v2 is declared to have type `Box[int]` but is used as type `Box[float]`.
 protocols_generic.py:66:4 Incompatible variable type [9]: v2 is declared to have type `Sender[float]` but is used as type `Sender[int]`.
 protocols_generic.py:74:4 Incompatible variable type [9]: v1 is declared to have type `AttrProto[float]` but is used as type `AttrProto[int]`.
@@ -13,7 +14,6 @@ protocols_generic.py:146:0 Incompatible variable type [9]: hp3 is declared to ha
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 44: Expected 1 errors
 Line 145: Expected 1 errors
 Line 147: Expected 1 errors
 """

--- a/conformance/results/pyre/protocols_merging.toml
+++ b/conformance/results/pyre/protocols_merging.toml
@@ -1,15 +1,14 @@
-conformant = "Partial"
+conformant = "Pass"
 notes = """
-Does not reject a protocol class that derives from a non-protocol class.
 """
 output = """
 protocols_merging.py:52:0 Incompatible variable type [9]: s6 is declared to have type `SizedAndClosable1` but is used as type `SCConcrete2`.
 protocols_merging.py:53:0 Incompatible variable type [9]: s7 is declared to have type `SizedAndClosable2` but is used as type `SCConcrete2`.
 protocols_merging.py:54:0 Incompatible variable type [9]: s8 is declared to have type `SizedAndClosable3` but is used as type `SCConcrete2`.
+protocols_merging.py:67:15 Invalid inheritance [39]: If Protocol is included as a base class, all other base classes must be protocols or Generic.
 protocols_merging.py:82:4 Invalid class instantiation [45]: Cannot instantiate abstract class `SizedAndClosable4` with abstract method `close`.
 protocols_merging.py:83:0 Incompatible variable type [9]: y is declared to have type `SizedAndClosable4` but is used as type `SCConcrete1`.
 """
-conformance_automated = "Fail"
+conformance_automated = "Pass"
 errors_diff = """
-Line 67: Expected 1 errors
 """

--- a/conformance/results/pyre/qualifiers_annotated.toml
+++ b/conformance/results/pyre/qualifiers_annotated.toml
@@ -16,19 +16,19 @@ qualifiers_annotated.py:51:6 Invalid type [31]: Expression `typing.Annotated[(Tr
 qualifiers_annotated.py:52:7 Invalid type [31]: Expression `typing.Annotated[(1, "")]` is not a valid type.
 qualifiers_annotated.py:53:7 Invalid type [31]: Expression `typing.Annotated[(list or set, "")]` is not a valid type.
 qualifiers_annotated.py:54:7 Invalid type [31]: Expression `typing.Annotated[(f"{"int"}", "")]` is not a valid type.
-qualifiers_annotated.py:76:33 Incompatible parameter type [6]: In call `typing.GenericMeta.__getitem__`, for 1st positional argument, expected `Tuple[]` but got `Tuple[Type[int], str]`. Expected has length 0, but actual has length 2.
+qualifiers_annotated.py:64:7 Invalid type parameters [24]: Generic type `Annotated` expects at least 2 type parameters, received 1.
 qualifiers_annotated.py:77:0 Incompatible variable type [9]: not_type2 is declared to have type `Type[typing.Any]` but is used as type `TypeAlias`.
-qualifiers_annotated.py:84:16 Incompatible parameter type [6]: In call `typing.GenericMeta.__getitem__`, for 1st positional argument, expected `Tuple[]` but got `Tuple[Type[str], str]`. Expected has length 0, but actual has length 2.
 qualifiers_annotated.py:85:6 Incompatible parameter type [6]: In call `func4`, for 1st positional argument, expected `Type[Variable[T]]` but got `TypeAlias`.
-qualifiers_annotated.py:92:10 Incompatible parameter type [6]: In call `typing.GenericMeta.__getitem__`, for 1st positional argument, expected `Tuple[]` but got `Tuple[Type[int], str]`. Expected has length 0, but actual has length 2.
+qualifiers_annotated.py:91:0 Invalid class instantiation [45]: `Annotated` cannot be instantiated.
 qualifiers_annotated.py:93:0 Call error [29]: `TypeAlias` is not a function.
 qualifiers_annotated.py:105:4 Undefined attribute [16]: `typing.Type` has no attribute `a`.
 qualifiers_annotated.py:106:4 Undefined attribute [16]: `typing.Type` has no attribute `b`.
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 64: Expected 1 errors
-Line 91: Expected 1 errors
+Line 76: Expected 1 errors
+Line 84: Expected 1 errors
+Line 92: Expected 1 errors
 Line 105: Unexpected errors ['qualifiers_annotated.py:105:4 Undefined attribute [16]: `typing.Type` has no attribute `a`.']
 Line 106: Unexpected errors ['qualifiers_annotated.py:106:4 Undefined attribute [16]: `typing.Type` has no attribute `b`.']
 """

--- a/conformance/results/pyre/specialtypes_any.toml
+++ b/conformance/results/pyre/specialtypes_any.toml
@@ -1,15 +1,8 @@
-conformant = "Partial"
+conformant = "Pass"
 notes = """
-Does not support Any as a base class.
 """
 output = """
-specialtypes_any.py:81:13 Invalid inheritance [39]: `typing.Any` is not a valid parent class.
-specialtypes_any.py:87:12 Undefined attribute [16]: `ClassA` has no attribute `method2`.
-specialtypes_any.py:88:12 Undefined attribute [16]: `ClassA` has no attribute `method3`.
 """
-conformance_automated = "Fail"
+conformance_automated = "Pass"
 errors_diff = """
-Line 81: Unexpected errors ['specialtypes_any.py:81:13 Invalid inheritance [39]: `typing.Any` is not a valid parent class.']
-Line 87: Unexpected errors ['specialtypes_any.py:87:12 Undefined attribute [16]: `ClassA` has no attribute `method2`.']
-Line 88: Unexpected errors ['specialtypes_any.py:88:12 Undefined attribute [16]: `ClassA` has no attribute `method3`.']
 """

--- a/conformance/results/pyre/specialtypes_never.toml
+++ b/conformance/results/pyre/specialtypes_never.toml
@@ -3,7 +3,7 @@ notes = """
 Does not treat Never as compatible with all other types.
 """
 output = """
-specialtypes_never.py:21:8 Incompatible return type [7]: Function declared non-returnable, but got `None`.
+specialtypes_never.py:19:21 Incompatible return type [7]: Function declared non-returnable, but got implicit return value of `None`.
 specialtypes_never.py:68:4 Incompatible variable type [9]: v1 is declared to have type `int` but is used as type `Never`.
 specialtypes_never.py:69:4 Incompatible variable type [9]: v2 is declared to have type `str` but is used as type `Never`.
 specialtypes_never.py:70:4 Incompatible variable type [9]: v3 is declared to have type `List[str]` but is used as type `Never`.
@@ -14,8 +14,6 @@ specialtypes_never.py:105:4 Incompatible return type [7]: Expected `ClassC[Varia
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 19: Expected 1 errors
-Line 21: Unexpected errors ['specialtypes_never.py:21:8 Incompatible return type [7]: Function declared non-returnable, but got `None`.']
 Line 68: Unexpected errors ['specialtypes_never.py:68:4 Incompatible variable type [9]: v1 is declared to have type `int` but is used as type `Never`.']
 Line 69: Unexpected errors ['specialtypes_never.py:69:4 Incompatible variable type [9]: v2 is declared to have type `str` but is used as type `Never`.']
 Line 70: Unexpected errors ['specialtypes_never.py:70:4 Incompatible variable type [9]: v3 is declared to have type `List[str]` but is used as type `Never`.']

--- a/conformance/results/pyre/specialtypes_type.toml
+++ b/conformance/results/pyre/specialtypes_type.toml
@@ -9,6 +9,14 @@ Reports type incompatibility between `type` and `Callable[..., Any]`.
 output = """
 specialtypes_type.py:56:6 Incompatible parameter type [6]: In call `func4`, for 1st positional argument, expected `Type[Union[BasicUser, ProUser]]` but got `Type[TeamUser]`.
 specialtypes_type.py:76:11 Invalid type parameters [24]: Generic type `type` expects 1 type parameter, received 2, use `typing.Type[<base type>]` to avoid runtime subscripting errors.
+specialtypes_type.py:98:4 Assert type [70]: Expected `typing.Tuple[Type[typing.Any], ...]` but got `unknown`.
+specialtypes_type.py:99:4 Assert type [70]: Expected `typing.Any` but got `unknown`.
+specialtypes_type.py:102:4 Assert type [70]: Expected `typing.Tuple[Type[typing.Any], ...]` but got `unknown`.
+specialtypes_type.py:103:4 Assert type [70]: Expected `typing.Any` but got `unknown`.
+specialtypes_type.py:106:4 Assert type [70]: Expected `typing.Tuple[Type[typing.Any], ...]` but got `unknown`.
+specialtypes_type.py:107:4 Assert type [70]: Expected `typing.Any` but got `unknown`.
+specialtypes_type.py:110:4 Assert type [70]: Expected `typing.Tuple[Type[typing.Any], ...]` but got `unknown`.
+specialtypes_type.py:111:4 Assert type [70]: Expected `typing.Any` but got `unknown`.
 specialtypes_type.py:117:4 Undefined attribute [16]: `object` has no attribute `unknown`.
 specialtypes_type.py:143:0 Undefined attribute [16]: `TypeAlias` has no attribute `unknown`.
 specialtypes_type.py:165:4 Incompatible variable type [9]: x1 is declared to have type `typing.Callable[..., typing.Any]` but is used as type `Type[typing.Any]`.
@@ -21,6 +29,14 @@ Line 120: Expected 1 errors
 Line 144: Expected 1 errors
 Line 145: Expected 1 errors
 Line 146: Expected 1 errors
+Line 98: Unexpected errors ['specialtypes_type.py:98:4 Assert type [70]: Expected `typing.Tuple[Type[typing.Any], ...]` but got `unknown`.']
+Line 99: Unexpected errors ['specialtypes_type.py:99:4 Assert type [70]: Expected `typing.Any` but got `unknown`.']
+Line 102: Unexpected errors ['specialtypes_type.py:102:4 Assert type [70]: Expected `typing.Tuple[Type[typing.Any], ...]` but got `unknown`.']
+Line 103: Unexpected errors ['specialtypes_type.py:103:4 Assert type [70]: Expected `typing.Any` but got `unknown`.']
+Line 106: Unexpected errors ['specialtypes_type.py:106:4 Assert type [70]: Expected `typing.Tuple[Type[typing.Any], ...]` but got `unknown`.']
+Line 107: Unexpected errors ['specialtypes_type.py:107:4 Assert type [70]: Expected `typing.Any` but got `unknown`.']
+Line 110: Unexpected errors ['specialtypes_type.py:110:4 Assert type [70]: Expected `typing.Tuple[Type[typing.Any], ...]` but got `unknown`.']
+Line 111: Unexpected errors ['specialtypes_type.py:111:4 Assert type [70]: Expected `typing.Any` but got `unknown`.']
 Line 165: Unexpected errors ['specialtypes_type.py:165:4 Incompatible variable type [9]: x1 is declared to have type `typing.Callable[..., typing.Any]` but is used as type `Type[typing.Any]`.']
 Line 166: Unexpected errors ['specialtypes_type.py:166:4 Incompatible variable type [9]: x2 is declared to have type `typing.Callable[[int, int], int]` but is used as type `Type[typing.Any]`.']
 """

--- a/conformance/results/pyre/tuples_type_compat.toml
+++ b/conformance/results/pyre/tuples_type_compat.toml
@@ -7,55 +7,29 @@ Does not correctly evaluate `Sequence[Never]` for `tuple[()]`.
 """
 output = """
 tuples_type_compat.py:15:4 Incompatible variable type [9]: v2 is declared to have type `Tuple[int, int]` but is used as type `Tuple[float, complex]`.
-tuples_type_compat.py:22:30 Invalid type [31]: Expression `tuple[(int, *tuple[(int, ...)])]` is not a valid type.
-tuples_type_compat.py:27:8 Invalid type [31]: Expression `tuple[(int, *tuple[(int, ...)])]` is not a valid type.
-tuples_type_compat.py:47:8 Invalid type [31]: Expression `tuple[(int, *tuple[(str, ...)])]` is not a valid type.
 tuples_type_compat.py:55:21 Undefined or invalid type [11]: Annotation `SomeType` is not defined as a type.
-tuples_type_compat.py:71:15 Invalid type [31]: Expression `typing.Union[(tuple[int], tuple[(str, str)], tuple[(int, *tuple[(str, ...)], int)])]` is not a valid type.
-tuples_type_compat.py:91:15 Invalid type [31]: Expression `typing.Union[(tuple[int], tuple[(str, str)], tuple[(int, *tuple[(str, ...)], int)])]` is not a valid type.
-tuples_type_compat.py:95:12 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Tuple[int]` but got `Union[Tuple[int], Tuple[str, str]]`.
-tuples_type_compat.py:99:12 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Union[Tuple[int, int], Tuple[str, str]]` but got `Union[Tuple[int], Tuple[str, str]]`.
-tuples_type_compat.py:103:12 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Tuple[int, str, int]` but got `Union[Tuple[int], Tuple[str, str]]`.
-tuples_type_compat.py:115:12 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Tuple[Union[int, str], str]` but got `Tuple[Union[int, str], Union[int, str]]`.
-tuples_type_compat.py:117:12 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Tuple[Union[int, str], int]` but got `Tuple[Union[int, str], Union[int, str]]`.
-tuples_type_compat.py:134:39 Invalid type [31]: Expression `tuple[(int, *tuple[(str, ...)])]` is not a valid type.
-tuples_type_compat.py:139:4 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Sequence[Union[int, str]]` but got `Sequence[Variable[T]]`.
-tuples_type_compat.py:140:4 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Sequence[Never]` but got `Sequence[Variable[T]]`.
-tuples_type_compat.py:143:4 Invalid type [31]: Expression `tuple[(int, *tuple[str])]` is not a valid type.
-tuples_type_compat.py:144:0 Incompatible variable type [9]: t1 is declared to have type `Tuple[typing_extensions.Literal[1], typing_extensions.Literal['']]` but is used as type `Tuple[typing_extensions.Literal[1], typing_extensions.Literal[''], typing_extensions.Literal['']]`.
-tuples_type_compat.py:146:0 Incompatible variable type [9]: t2 is declared to have type `Tuple[int, unknown]` but is used as type `Tuple[int]`.
-tuples_type_compat.py:146:4 Invalid type [31]: Expression `tuple[(int, *tuple[(str, ...)])]` is not a valid type.
-tuples_type_compat.py:147:0 Incompatible variable type [9]: t2 is declared to have type `Tuple[typing_extensions.Literal[1]]` but is used as type `Tuple[typing_extensions.Literal[1], typing_extensions.Literal['']]`.
-tuples_type_compat.py:148:0 Incompatible variable type [9]: t2 is declared to have type `Tuple[typing_extensions.Literal[1]]` but is used as type `Tuple[typing_extensions.Literal[1], typing_extensions.Literal[''], typing_extensions.Literal['']]`.
-tuples_type_compat.py:149:0 Incompatible variable type [9]: t2 is declared to have type `Tuple[typing_extensions.Literal[1]]` but is used as type `Tuple[typing_extensions.Literal[1], typing_extensions.Literal[1], typing_extensions.Literal['']]`.
-tuples_type_compat.py:150:0 Incompatible variable type [9]: t2 is declared to have type `Tuple[typing_extensions.Literal[1]]` but is used as type `Tuple[typing_extensions.Literal[1], typing_extensions.Literal[''], typing_extensions.Literal[1]]`.
-tuples_type_compat.py:153:0 Incompatible variable type [9]: t3 is declared to have type `Tuple[int, unknown, int]` but is used as type `Tuple[int, int]`.
-tuples_type_compat.py:153:4 Invalid type [31]: Expression `tuple[(int, *tuple[(str, ...)], int)]` is not a valid type.
-tuples_type_compat.py:154:0 Incompatible variable type [9]: t3 is declared to have type `Tuple[typing_extensions.Literal[1], typing_extensions.Literal[2]]` but is used as type `Tuple[typing_extensions.Literal[1], typing_extensions.Literal[''], typing_extensions.Literal[2]]`.
-tuples_type_compat.py:155:0 Incompatible variable type [9]: t3 is declared to have type `Tuple[typing_extensions.Literal[1], typing_extensions.Literal[2]]` but is used as type `Tuple[typing_extensions.Literal[1], typing_extensions.Literal[''], typing_extensions.Literal[''], typing_extensions.Literal[2]]`.
-tuples_type_compat.py:156:0 Incompatible variable type [9]: t3 is declared to have type `Tuple[typing_extensions.Literal[1], typing_extensions.Literal[2]]` but is used as type `Tuple[typing_extensions.Literal[1], typing_extensions.Literal[''], typing_extensions.Literal['']]`.
-tuples_type_compat.py:157:0 Incompatible variable type [9]: t3 is declared to have type `Tuple[typing_extensions.Literal[1], typing_extensions.Literal[2]]` but is used as type `Tuple[typing_extensions.Literal[1], typing_extensions.Literal[''], typing_extensions.Literal[''], float]`.
-tuples_type_compat.py:159:0 Incompatible variable type [9]: t4 is declared to have type `Tuple[unknown, int]` but is used as type `Tuple[int]`.
-tuples_type_compat.py:159:4 Invalid type [31]: Expression `tuple[(*tuple[(str, ...)], int)]` is not a valid type.
-tuples_type_compat.py:160:0 Incompatible variable type [9]: t4 is declared to have type `Tuple[typing_extensions.Literal[1]]` but is used as type `Tuple[typing_extensions.Literal[''], typing_extensions.Literal[1]]`.
-tuples_type_compat.py:161:0 Incompatible variable type [9]: t4 is declared to have type `Tuple[typing_extensions.Literal[1]]` but is used as type `Tuple[typing_extensions.Literal[''], typing_extensions.Literal[''], typing_extensions.Literal[1]]`.
-tuples_type_compat.py:162:0 Incompatible variable type [9]: t4 is declared to have type `Tuple[typing_extensions.Literal[1]]` but is used as type `Tuple[typing_extensions.Literal[1], typing_extensions.Literal[''], typing_extensions.Literal[1]]`.
-tuples_type_compat.py:163:0 Incompatible variable type [9]: t4 is declared to have type `Tuple[typing_extensions.Literal[1]]` but is used as type `Tuple[typing_extensions.Literal[''], typing_extensions.Literal[''], float]`.
-tuples_type_compat.py:167:4 Incompatible variable type [9]: t1 is declared to have type `Tuple[str, str, unknown]` but is used as type `Tuple[str, str]`.
-tuples_type_compat.py:167:8 Invalid type [31]: Expression `tuple[(str, str, *tuple[(int, ...)])]` is not a valid type.
-tuples_type_compat.py:168:4 Incompatible variable type [9]: t2 is declared to have type `Tuple[str, str, unknown]` but is used as type `Tuple[str, str]`.
-tuples_type_compat.py:168:8 Invalid type [31]: Expression `tuple[(str, str, *tuple[int])]` is not a valid type.
-tuples_type_compat.py:169:8 Invalid type [31]: Expression `tuple[(str, *tuple[(str, ...)])]` is not a valid type.
-tuples_type_compat.py:170:4 Incompatible variable type [9]: t4 is declared to have type `Tuple[str, str, unknown]` but is used as type `Tuple[str, str]`.
-tuples_type_compat.py:170:8 Invalid type [31]: Expression `tuple[(str, str, *tuple[(str, ...)])]` is not a valid type.
-tuples_type_compat.py:171:4 Incompatible variable type [9]: t5 is declared to have type `Tuple[str, str, str, unknown]` but is used as type `Tuple[str, str]`.
-tuples_type_compat.py:171:8 Invalid type [31]: Expression `tuple[(str, str, str, *tuple[(str, ...)])]` is not a valid type.
-tuples_type_compat.py:172:4 Incompatible variable type [9]: t6 is declared to have type `Tuple[str, unknown, str]` but is used as type `Tuple[str, str]`.
-tuples_type_compat.py:172:8 Invalid type [31]: Expression `tuple[(str, *tuple[(int, ...)], str)]` is not a valid type.
-tuples_type_compat.py:173:8 Invalid type [31]: Expression `tuple[(*tuple[(str, ...)], str)]` is not a valid type.
-tuples_type_compat.py:174:8 Invalid type [31]: Expression `tuple[(*tuple[(str, ...)], str)]` is not a valid type.
-tuples_type_compat.py:175:4 Incompatible variable type [9]: t9 is declared to have type `Tuple[unknown, str, str, str]` but is used as type `Tuple[str, str]`.
-tuples_type_compat.py:175:8 Invalid type [31]: Expression `tuple[(*tuple[(str, ...)], str, str, str)]` is not a valid type.
+tuples_type_compat.py:72:11 Incompatible parameter type [6]: In call `len`, for 1st positional argument, expected `pyre_extensions.PyreReadOnly[Sized]` but got `Union[Tuple[int], Tuple[str, str], typing.Tuple[int, *Tuple[str, ...], int]]`.
+tuples_type_compat.py:74:8 Assert type [70]: Expected `Tuple[int]` but got `Union[Tuple[int], Tuple[str, str], typing.Tuple[int, *Tuple[str, ...], int]]`.
+tuples_type_compat.py:76:11 Incompatible parameter type [6]: In call `len`, for 1st positional argument, expected `pyre_extensions.PyreReadOnly[Sized]` but got `Union[Tuple[int], Tuple[str, str], typing.Tuple[int, *Tuple[str, ...], int]]`.
+tuples_type_compat.py:78:8 Assert type [70]: Expected `Union[Tuple[int, int], Tuple[str, str]]` but got `Union[Tuple[int], Tuple[str, str], typing.Tuple[int, *Tuple[str, ...], int]]`.
+tuples_type_compat.py:80:11 Incompatible parameter type [6]: In call `len`, for 1st positional argument, expected `pyre_extensions.PyreReadOnly[Sized]` but got `Union[Tuple[int], Tuple[str, str], typing.Tuple[int, *Tuple[str, ...], int]]`.
+tuples_type_compat.py:82:8 Assert type [70]: Expected `Tuple[int, str, int]` but got `Union[Tuple[int], Tuple[str, str], typing.Tuple[int, *Tuple[str, ...], int]]`.
+tuples_type_compat.py:95:12 Assert type [70]: Expected `Tuple[int]` but got `Union[Tuple[int], Tuple[str, str], typing.Tuple[int, *Tuple[str, ...], int]]`.
+tuples_type_compat.py:99:12 Assert type [70]: Expected `Union[Tuple[int, int], Tuple[str, str]]` but got `Union[Tuple[int], Tuple[str, str], typing.Tuple[int, *Tuple[str, ...], int]]`.
+tuples_type_compat.py:103:12 Assert type [70]: Expected `Tuple[int, str, int]` but got `Union[Tuple[int], Tuple[str, str], typing.Tuple[int, *Tuple[str, ...], int]]`.
+tuples_type_compat.py:115:12 Assert type [70]: Expected `Tuple[Union[int, str], str]` but got `Tuple[Union[int, str], Union[int, str]]`.
+tuples_type_compat.py:117:12 Assert type [70]: Expected `Tuple[Union[int, str], int]` but got `Tuple[Union[int, str], Union[int, str]]`.
+tuples_type_compat.py:140:4 Assert type [70]: Expected `Sequence[Never]` but got `Sequence[Variable[T]]`.
+tuples_type_compat.py:144:0 Incompatible variable type [9]: t1 is declared to have type `Tuple[int, str]` but is used as type `Tuple[int, str, str]`.
+tuples_type_compat.py:149:0 Incompatible variable type [9]: t2 is declared to have type `typing.Tuple[int, *Tuple[str, ...]]` but is used as type `Tuple[int, int, str]`.
+tuples_type_compat.py:150:0 Incompatible variable type [9]: t2 is declared to have type `typing.Tuple[int, *Tuple[str, ...]]` but is used as type `Tuple[int, str, int]`.
+tuples_type_compat.py:156:0 Incompatible variable type [9]: t3 is declared to have type `typing.Tuple[int, *Tuple[str, ...], int]` but is used as type `Tuple[int, str, str]`.
+tuples_type_compat.py:157:0 Incompatible variable type [9]: t3 is declared to have type `typing.Tuple[int, *Tuple[str, ...], int]` but is used as type `Tuple[int, str, str, float]`.
+tuples_type_compat.py:162:0 Incompatible variable type [9]: t4 is declared to have type `typing.Tuple[*Tuple[str, ...], int]` but is used as type `Tuple[int, str, int]`.
+tuples_type_compat.py:163:0 Incompatible variable type [9]: t4 is declared to have type `typing.Tuple[*Tuple[str, ...], int]` but is used as type `Tuple[str, str, float]`.
+tuples_type_compat.py:168:4 Incompatible variable type [9]: t2 is declared to have type `Tuple[str, str, int]` but is used as type `Tuple[str, str]`.
+tuples_type_compat.py:171:4 Incompatible variable type [9]: t5 is declared to have type `typing.Tuple[str, str, str, *Tuple[str, ...]]` but is used as type `Tuple[str, str]`.
+tuples_type_compat.py:175:4 Incompatible variable type [9]: t9 is declared to have type `typing.Tuple[*Tuple[str, ...], str, str, str]` but is used as type `Tuple[str, str]`.
 """
 conformance_automated = "Fail"
 errors_diff = """
@@ -64,34 +38,17 @@ Line 32: Expected 1 errors
 Line 33: Expected 1 errors
 Line 43: Expected 1 errors
 Line 62: Expected 1 errors
-Line 22: Unexpected errors ['tuples_type_compat.py:22:30 Invalid type [31]: Expression `tuple[(int, *tuple[(int, ...)])]` is not a valid type.']
-Line 27: Unexpected errors ['tuples_type_compat.py:27:8 Invalid type [31]: Expression `tuple[(int, *tuple[(int, ...)])]` is not a valid type.']
-Line 47: Unexpected errors ['tuples_type_compat.py:47:8 Invalid type [31]: Expression `tuple[(int, *tuple[(str, ...)])]` is not a valid type.']
 Line 55: Unexpected errors ['tuples_type_compat.py:55:21 Undefined or invalid type [11]: Annotation `SomeType` is not defined as a type.']
-Line 71: Unexpected errors ['tuples_type_compat.py:71:15 Invalid type [31]: Expression `typing.Union[(tuple[int], tuple[(str, str)], tuple[(int, *tuple[(str, ...)], int)])]` is not a valid type.']
-Line 91: Unexpected errors ['tuples_type_compat.py:91:15 Invalid type [31]: Expression `typing.Union[(tuple[int], tuple[(str, str)], tuple[(int, *tuple[(str, ...)], int)])]` is not a valid type.']
-Line 95: Unexpected errors ['tuples_type_compat.py:95:12 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Tuple[int]` but got `Union[Tuple[int], Tuple[str, str]]`.']
-Line 99: Unexpected errors ['tuples_type_compat.py:99:12 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Union[Tuple[int, int], Tuple[str, str]]` but got `Union[Tuple[int], Tuple[str, str]]`.']
-Line 103: Unexpected errors ['tuples_type_compat.py:103:12 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Tuple[int, str, int]` but got `Union[Tuple[int], Tuple[str, str]]`.']
-Line 115: Unexpected errors ['tuples_type_compat.py:115:12 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Tuple[Union[int, str], str]` but got `Tuple[Union[int, str], Union[int, str]]`.']
-Line 117: Unexpected errors ['tuples_type_compat.py:117:12 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Tuple[Union[int, str], int]` but got `Tuple[Union[int, str], Union[int, str]]`.']
-Line 134: Unexpected errors ['tuples_type_compat.py:134:39 Invalid type [31]: Expression `tuple[(int, *tuple[(str, ...)])]` is not a valid type.']
-Line 139: Unexpected errors ['tuples_type_compat.py:139:4 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Sequence[Union[int, str]]` but got `Sequence[Variable[T]]`.']
-Line 140: Unexpected errors ['tuples_type_compat.py:140:4 Incompatible parameter type [6]: In call `assert_type`, for 1st positional argument, expected `Sequence[Never]` but got `Sequence[Variable[T]]`.']
-Line 143: Unexpected errors ['tuples_type_compat.py:143:4 Invalid type [31]: Expression `tuple[(int, *tuple[str])]` is not a valid type.']
-Line 146: Unexpected errors ['tuples_type_compat.py:146:0 Incompatible variable type [9]: t2 is declared to have type `Tuple[int, unknown]` but is used as type `Tuple[int]`.', 'tuples_type_compat.py:146:4 Invalid type [31]: Expression `tuple[(int, *tuple[(str, ...)])]` is not a valid type.']
-Line 147: Unexpected errors ["tuples_type_compat.py:147:0 Incompatible variable type [9]: t2 is declared to have type `Tuple[typing_extensions.Literal[1]]` but is used as type `Tuple[typing_extensions.Literal[1], typing_extensions.Literal['']]`."]
-Line 148: Unexpected errors ["tuples_type_compat.py:148:0 Incompatible variable type [9]: t2 is declared to have type `Tuple[typing_extensions.Literal[1]]` but is used as type `Tuple[typing_extensions.Literal[1], typing_extensions.Literal[''], typing_extensions.Literal['']]`."]
-Line 153: Unexpected errors ['tuples_type_compat.py:153:0 Incompatible variable type [9]: t3 is declared to have type `Tuple[int, unknown, int]` but is used as type `Tuple[int, int]`.', 'tuples_type_compat.py:153:4 Invalid type [31]: Expression `tuple[(int, *tuple[(str, ...)], int)]` is not a valid type.']
-Line 154: Unexpected errors ["tuples_type_compat.py:154:0 Incompatible variable type [9]: t3 is declared to have type `Tuple[typing_extensions.Literal[1], typing_extensions.Literal[2]]` but is used as type `Tuple[typing_extensions.Literal[1], typing_extensions.Literal[''], typing_extensions.Literal[2]]`."]
-Line 155: Unexpected errors ["tuples_type_compat.py:155:0 Incompatible variable type [9]: t3 is declared to have type `Tuple[typing_extensions.Literal[1], typing_extensions.Literal[2]]` but is used as type `Tuple[typing_extensions.Literal[1], typing_extensions.Literal[''], typing_extensions.Literal[''], typing_extensions.Literal[2]]`."]
-Line 159: Unexpected errors ['tuples_type_compat.py:159:0 Incompatible variable type [9]: t4 is declared to have type `Tuple[unknown, int]` but is used as type `Tuple[int]`.', 'tuples_type_compat.py:159:4 Invalid type [31]: Expression `tuple[(*tuple[(str, ...)], int)]` is not a valid type.']
-Line 160: Unexpected errors ["tuples_type_compat.py:160:0 Incompatible variable type [9]: t4 is declared to have type `Tuple[typing_extensions.Literal[1]]` but is used as type `Tuple[typing_extensions.Literal[''], typing_extensions.Literal[1]]`."]
-Line 161: Unexpected errors ["tuples_type_compat.py:161:0 Incompatible variable type [9]: t4 is declared to have type `Tuple[typing_extensions.Literal[1]]` but is used as type `Tuple[typing_extensions.Literal[''], typing_extensions.Literal[''], typing_extensions.Literal[1]]`."]
-Line 167: Unexpected errors ['tuples_type_compat.py:167:4 Incompatible variable type [9]: t1 is declared to have type `Tuple[str, str, unknown]` but is used as type `Tuple[str, str]`.', 'tuples_type_compat.py:167:8 Invalid type [31]: Expression `tuple[(str, str, *tuple[(int, ...)])]` is not a valid type.']
-Line 169: Unexpected errors ['tuples_type_compat.py:169:8 Invalid type [31]: Expression `tuple[(str, *tuple[(str, ...)])]` is not a valid type.']
-Line 170: Unexpected errors ['tuples_type_compat.py:170:4 Incompatible variable type [9]: t4 is declared to have type `Tuple[str, str, unknown]` but is used as type `Tuple[str, str]`.', 'tuples_type_compat.py:170:8 Invalid type [31]: Expression `tuple[(str, str, *tuple[(str, ...)])]` is not a valid type.']
-Line 172: Unexpected errors ['tuples_type_compat.py:172:4 Incompatible variable type [9]: t6 is declared to have type `Tuple[str, unknown, str]` but is used as type `Tuple[str, str]`.', 'tuples_type_compat.py:172:8 Invalid type [31]: Expression `tuple[(str, *tuple[(int, ...)], str)]` is not a valid type.']
-Line 173: Unexpected errors ['tuples_type_compat.py:173:8 Invalid type [31]: Expression `tuple[(*tuple[(str, ...)], str)]` is not a valid type.']
-Line 174: Unexpected errors ['tuples_type_compat.py:174:8 Invalid type [31]: Expression `tuple[(*tuple[(str, ...)], str)]` is not a valid type.']
+Line 72: Unexpected errors ['tuples_type_compat.py:72:11 Incompatible parameter type [6]: In call `len`, for 1st positional argument, expected `pyre_extensions.PyreReadOnly[Sized]` but got `Union[Tuple[int], Tuple[str, str], typing.Tuple[int, *Tuple[str, ...], int]]`.']
+Line 74: Unexpected errors ['tuples_type_compat.py:74:8 Assert type [70]: Expected `Tuple[int]` but got `Union[Tuple[int], Tuple[str, str], typing.Tuple[int, *Tuple[str, ...], int]]`.']
+Line 76: Unexpected errors ['tuples_type_compat.py:76:11 Incompatible parameter type [6]: In call `len`, for 1st positional argument, expected `pyre_extensions.PyreReadOnly[Sized]` but got `Union[Tuple[int], Tuple[str, str], typing.Tuple[int, *Tuple[str, ...], int]]`.']
+Line 78: Unexpected errors ['tuples_type_compat.py:78:8 Assert type [70]: Expected `Union[Tuple[int, int], Tuple[str, str]]` but got `Union[Tuple[int], Tuple[str, str], typing.Tuple[int, *Tuple[str, ...], int]]`.']
+Line 80: Unexpected errors ['tuples_type_compat.py:80:11 Incompatible parameter type [6]: In call `len`, for 1st positional argument, expected `pyre_extensions.PyreReadOnly[Sized]` but got `Union[Tuple[int], Tuple[str, str], typing.Tuple[int, *Tuple[str, ...], int]]`.']
+Line 82: Unexpected errors ['tuples_type_compat.py:82:8 Assert type [70]: Expected `Tuple[int, str, int]` but got `Union[Tuple[int], Tuple[str, str], typing.Tuple[int, *Tuple[str, ...], int]]`.']
+Line 95: Unexpected errors ['tuples_type_compat.py:95:12 Assert type [70]: Expected `Tuple[int]` but got `Union[Tuple[int], Tuple[str, str], typing.Tuple[int, *Tuple[str, ...], int]]`.']
+Line 99: Unexpected errors ['tuples_type_compat.py:99:12 Assert type [70]: Expected `Union[Tuple[int, int], Tuple[str, str]]` but got `Union[Tuple[int], Tuple[str, str], typing.Tuple[int, *Tuple[str, ...], int]]`.']
+Line 103: Unexpected errors ['tuples_type_compat.py:103:12 Assert type [70]: Expected `Tuple[int, str, int]` but got `Union[Tuple[int], Tuple[str, str], typing.Tuple[int, *Tuple[str, ...], int]]`.']
+Line 115: Unexpected errors ['tuples_type_compat.py:115:12 Assert type [70]: Expected `Tuple[Union[int, str], str]` but got `Tuple[Union[int, str], Union[int, str]]`.']
+Line 117: Unexpected errors ['tuples_type_compat.py:117:12 Assert type [70]: Expected `Tuple[Union[int, str], int]` but got `Tuple[Union[int, str], Union[int, str]]`.']
+Line 140: Unexpected errors ['tuples_type_compat.py:140:4 Assert type [70]: Expected `Sequence[Never]` but got `Sequence[Variable[T]]`.']
 """

--- a/conformance/results/pyre/tuples_unpacked.toml
+++ b/conformance/results/pyre/tuples_unpacked.toml
@@ -1,34 +1,13 @@
-conformant = "Partial"
+conformant = "Pass"
 notes = """
-Does not understand star syntax for `Unpack`.
 """
 output = """
-tuples_unpacked.py:16:13 Invalid type [31]: Expression `tuple[(int, *tuple[(bool, bool)], str)]` is not a valid type.
-tuples_unpacked.py:18:19 Invalid type [31]: Expression `tuple[(*tuple[(int, bool)], bool, str)]` is not a valid type.
-tuples_unpacked.py:19:19 Invalid type [31]: Expression `tuple[(int, bool, *tuple[(bool, str)])]` is not a valid type.
-tuples_unpacked.py:25:13 Invalid type [31]: Expression `tuple[(int, *tuple[(bool, ...)], str)]` is not a valid type.
-tuples_unpacked.py:31:4 Invalid type [31]: Expression `tuple[(*tuple[int], *tuple[int])]` is not a valid type.
-tuples_unpacked.py:33:4 Invalid type [31]: Expression `tuple[(*tuple[(int, ...)], *tuple[int])]` is not a valid type.
-tuples_unpacked.py:38:4 Invalid type [31]: Expression `tuple[(*tuple[str], *tuple[str])]` is not a valid type.
-tuples_unpacked.py:39:4 Invalid type [31]: Expression `tuple[(*tuple[(str, *tuple[(str, ...)])])]` is not a valid type.
 tuples_unpacked.py:40:4 Invalid type [31]: Expression `tuple[(*tuple[(str, ...)], *tuple[(int, ...)])]` is not a valid type.
 tuples_unpacked.py:41:4 Invalid type [31]: Expression `tuple[(*tuple[(str, *tuple[(str, ...)])], *tuple[(int, ...)])]` is not a valid type.
-tuples_unpacked.py:49:13 Invalid type [31]: Expression `tuple[(*Ts)]` is not a valid type.
-tuples_unpacked.py:50:8 Invalid type [31]: Expression `tuple[(*tuple[str], *Ts)]` is not a valid type.
 tuples_unpacked.py:51:8 Invalid type [31]: Expression `tuple[(*tuple[(str, ...)], *Ts)]` is not a valid type.
 tuples_unpacked.py:59:5 Invalid type [31]: Expression `tuple[(typing.Unpack[tuple[(str, ...)]], typing.Unpack[tuple[(int, ...)]])]` is not a valid type.
 tuples_unpacked.py:60:5 Invalid type [31]: Expression `tuple[(typing.Unpack[tuple[(str, typing.Unpack[tuple[(str, ...)]])]], typing.Unpack[tuple[(int, ...)]])]` is not a valid type.
 """
-conformance_automated = "Fail"
+conformance_automated = "Pass"
 errors_diff = """
-Line 16: Unexpected errors ['tuples_unpacked.py:16:13 Invalid type [31]: Expression `tuple[(int, *tuple[(bool, bool)], str)]` is not a valid type.']
-Line 18: Unexpected errors ['tuples_unpacked.py:18:19 Invalid type [31]: Expression `tuple[(*tuple[(int, bool)], bool, str)]` is not a valid type.']
-Line 19: Unexpected errors ['tuples_unpacked.py:19:19 Invalid type [31]: Expression `tuple[(int, bool, *tuple[(bool, str)])]` is not a valid type.']
-Line 25: Unexpected errors ['tuples_unpacked.py:25:13 Invalid type [31]: Expression `tuple[(int, *tuple[(bool, ...)], str)]` is not a valid type.']
-Line 31: Unexpected errors ['tuples_unpacked.py:31:4 Invalid type [31]: Expression `tuple[(*tuple[int], *tuple[int])]` is not a valid type.']
-Line 33: Unexpected errors ['tuples_unpacked.py:33:4 Invalid type [31]: Expression `tuple[(*tuple[(int, ...)], *tuple[int])]` is not a valid type.']
-Line 38: Unexpected errors ['tuples_unpacked.py:38:4 Invalid type [31]: Expression `tuple[(*tuple[str], *tuple[str])]` is not a valid type.']
-Line 39: Unexpected errors ['tuples_unpacked.py:39:4 Invalid type [31]: Expression `tuple[(*tuple[(str, *tuple[(str, ...)])])]` is not a valid type.']
-Line 49: Unexpected errors ['tuples_unpacked.py:49:13 Invalid type [31]: Expression `tuple[(*Ts)]` is not a valid type.']
-Line 50: Unexpected errors ['tuples_unpacked.py:50:8 Invalid type [31]: Expression `tuple[(*tuple[str], *Ts)]` is not a valid type.']
 """

--- a/conformance/results/pyre/typeddicts_class_syntax.toml
+++ b/conformance/results/pyre/typeddicts_class_syntax.toml
@@ -6,7 +6,7 @@ Does not report when other keyword argument is provided.
 Does not support generic TypedDict class.
 """
 output = """
-typeddicts_class_syntax.py:59:11 Invalid type variable [34]: The current class isn't generic with respect to the type variable `Variable[T]`. To reference the type variable, you can modify the class to inherit from `typing.Generic[T]`.
+typeddicts_class_syntax.py:49:0 Unexpected keyword [28]: Unexpected keyword argument `other` to call `object.__init_subclass__`.
 """
 conformance_automated = "Fail"
 errors_diff = """
@@ -14,6 +14,4 @@ Line 29: Expected 1 errors
 Line 33: Expected 1 errors
 Line 38: Expected 1 errors
 Line 44: Expected 1 errors
-Line 49: Expected 1 errors
-Line 59: Unexpected errors ["typeddicts_class_syntax.py:59:11 Invalid type variable [34]: The current class isn't generic with respect to the type variable `Variable[T]`. To reference the type variable, you can modify the class to inherit from `typing.Generic[T]`."]
 """

--- a/conformance/results/pyre/typeddicts_inheritance.toml
+++ b/conformance/results/pyre/typeddicts_inheritance.toml
@@ -1,12 +1,11 @@
-conformant = "Partial"
+conformant = "Pass"
 notes = """
-Does not reject TypedDict class that inherits from non-TypedDict class.
 """
 output = """
+typeddicts_inheritance.py:44:30 Invalid inheritance [39]: `NonTypedDict` is not a valid parent class for a typed dictionary. Expected a typed dictionary or typing.Generic.
 typeddicts_inheritance.py:54:0 Inconsistent override [15]: `x` overrides attribute defined in `X1` inconsistently. Type `int` is not a subtype of the overridden attribute `str`.
 typeddicts_inheritance.py:65:0 Invalid inheritance [39]: Field `x` has type `int` in base class `X2` and type `str` in base class `Y2`.
 """
-conformance_automated = "Fail"
+conformance_automated = "Pass"
 errors_diff = """
-Line 44: Expected 1 errors
 """

--- a/conformance/results/pyre/typeddicts_operations.toml
+++ b/conformance/results/pyre/typeddicts_operations.toml
@@ -1,6 +1,5 @@
-conformant = "Partial"
+conformant = "Pass"
 notes = """
-Does not reject `del` of required key.
 """
 output = """
 typeddicts_operations.py:22:16 Invalid TypedDict operation [54]: Expected `str` to be assigned to `Movie` field `name` but got `int`.
@@ -11,11 +10,10 @@ typeddicts_operations.py:28:8 TypedDict initialization error [55]: Missing requi
 typeddicts_operations.py:29:8 TypedDict initialization error [55]: Expected type `int` for `Movie` field `year` but got `float`.
 typeddicts_operations.py:32:8 TypedDict initialization error [55]: TypedDict `Movie` has no field `other`.
 typeddicts_operations.py:37:4 Incompatible variable type [9]: movie is declared to have type `Movie` but is used as type `Dict[str, Union[int, str]]`.
-typeddicts_operations.py:44:10 TypedDict accessed with a missing key [27]: TypedDict `Movie` has no key `other`.
 typeddicts_operations.py:47:0 Undefined attribute [16]: `Movie` has no attribute `clear`.
+typeddicts_operations.py:49:0 Invalid TypedDict operation [54]: Cannot delete required field `name` from TypedDict `Movie`.
 typeddicts_operations.py:62:0 Undefined attribute [16]: `MovieOptional` has no attribute `clear`.
 """
-conformance_automated = "Fail"
+conformance_automated = "Pass"
 errors_diff = """
-Line 49: Expected 1 errors
 """

--- a/conformance/results/pyre/typeddicts_readonly.toml
+++ b/conformance/results/pyre/typeddicts_readonly.toml
@@ -1,14 +1,12 @@
-conformant = "Unsupported"
+conformant = "Pass"
 output = """
-typeddicts_readonly.py:18:13 Undefined or invalid type [11]: Annotation `ReadOnly` is not defined as a type.
+typeddicts_readonly.py:24:16 Invalid TypedDict operation [54]: Cannot write to `Band` read-only field `members`.
+typeddicts_readonly.py:36:16 Invalid TypedDict operation [54]: Cannot write to `Band2` read-only field `members`.
+typeddicts_readonly.py:50:14 Invalid TypedDict operation [54]: Cannot write to `Movie1` read-only field `title`.
+typeddicts_readonly.py:51:13 Invalid TypedDict operation [54]: Cannot write to `Movie1` read-only field `year`.
+typeddicts_readonly.py:60:14 Invalid TypedDict operation [54]: Cannot write to `Movie2` read-only field `title`.
+typeddicts_readonly.py:61:13 Invalid TypedDict operation [54]: Cannot write to `Movie2` read-only field `year`.
 """
-conformance_automated = "Fail"
+conformance_automated = "Pass"
 errors_diff = """
-Line 24: Expected 1 errors
-Line 36: Expected 1 errors
-Line 50: Expected 1 errors
-Line 51: Expected 1 errors
-Line 60: Expected 1 errors
-Line 61: Expected 1 errors
-Line 18: Unexpected errors ['typeddicts_readonly.py:18:13 Undefined or invalid type [11]: Annotation `ReadOnly` is not defined as a type.']
 """

--- a/conformance/results/pyre/typeddicts_readonly_consistency.toml
+++ b/conformance/results/pyre/typeddicts_readonly_consistency.toml
@@ -1,21 +1,13 @@
-conformant = "Unsupported"
+conformant = "Pass"
 output = """
-typeddicts_readonly_consistency.py:30:7 Undefined or invalid type [11]: Annotation `ReadOnly` is not defined as a type.
 typeddicts_readonly_consistency.py:37:4 Incompatible variable type [9]: v3 is declared to have type `B1` but is used as type `A1`.
 typeddicts_readonly_consistency.py:38:4 Incompatible variable type [9]: v4 is declared to have type `B1` but is used as type `C1`.
 typeddicts_readonly_consistency.py:40:4 Incompatible variable type [9]: v5 is declared to have type `C1` but is used as type `A1`.
-typeddicts_readonly_consistency.py:41:4 Incompatible variable type [9]: v6 is declared to have type `C1` but is used as type `B1`.
-typeddicts_readonly_consistency.py:78:4 Incompatible variable type [9]: v1 is declared to have type `A2` but is used as type `B2`.
-typeddicts_readonly_consistency.py:79:4 Incompatible variable type [9]: v2 is declared to have type `A2` but is used as type `C2`.
 typeddicts_readonly_consistency.py:81:4 Incompatible variable type [9]: v3 is declared to have type `B2` but is used as type `A2`.
 typeddicts_readonly_consistency.py:82:4 Incompatible variable type [9]: v4 is declared to have type `B2` but is used as type `C2`.
 typeddicts_readonly_consistency.py:84:4 Incompatible variable type [9]: v5 is declared to have type `C2` but is used as type `A2`.
 typeddicts_readonly_consistency.py:85:4 Incompatible variable type [9]: v6 is declared to have type `C2` but is used as type `B2`.
 """
-conformance_automated = "Fail"
+conformance_automated = "Pass"
 errors_diff = """
-Line 30: Unexpected errors ['typeddicts_readonly_consistency.py:30:7 Undefined or invalid type [11]: Annotation `ReadOnly` is not defined as a type.']
-Line 41: Unexpected errors ['typeddicts_readonly_consistency.py:41:4 Incompatible variable type [9]: v6 is declared to have type `C1` but is used as type `B1`.']
-Line 78: Unexpected errors ['typeddicts_readonly_consistency.py:78:4 Incompatible variable type [9]: v1 is declared to have type `A2` but is used as type `B2`.']
-Line 79: Unexpected errors ['typeddicts_readonly_consistency.py:79:4 Incompatible variable type [9]: v2 is declared to have type `A2` but is used as type `C2`.']
 """

--- a/conformance/results/pyre/typeddicts_readonly_inheritance.toml
+++ b/conformance/results/pyre/typeddicts_readonly_inheritance.toml
@@ -1,27 +1,27 @@
 conformant = "Unsupported"
 output = """
-typeddicts_readonly_inheritance.py:15:10 Undefined or invalid type [11]: Annotation `ReadOnly` is not defined as a type.
-typeddicts_readonly_inheritance.py:18:0 Inconsistent override [15]: `name` overrides attribute defined in `NamedDict` inconsistently. Type `str` is not a subtype of the overridden attribute `unknown`.
+typeddicts_readonly_inheritance.py:36:13 Invalid TypedDict operation [54]: Cannot write to `Album2` read-only field `name`.
+typeddicts_readonly_inheritance.py:47:0 Inconsistent override [15]: `alt` overrides attribute defined in `AlbumCollection` inconsistently. Type `typing.List[str]` is not a subtype of the overridden attribute `typing.List[typing.Union[int, str]]`.
 typeddicts_readonly_inheritance.py:65:18 TypedDict initialization error [55]: Missing required field `name` for TypedDict `RequiredName`.
-typeddicts_readonly_inheritance.py:75:0 Inconsistent override [15]: `ident` overrides attribute defined in `OptionalIdent` inconsistently. Type `str` is not a subtype of the overridden attribute `unknown`.
 typeddicts_readonly_inheritance.py:82:13 Invalid TypedDict operation [54]: Expected `str` to be assigned to `User` field `ident` but got `int`.
 typeddicts_readonly_inheritance.py:83:4 TypedDict initialization error [55]: Expected type `str` for `User` field `ident` but got `int`.
 typeddicts_readonly_inheritance.py:84:4 TypedDict initialization error [55]: Missing required field `ident` for TypedDict `User`.
-typeddicts_readonly_inheritance.py:93:0 Inconsistent override [15]: `a` overrides attribute defined in `F1` inconsistently. Type `unknown` is not a subtype of the overridden attribute `int`.
+typeddicts_readonly_inheritance.py:93:0 Inconsistent override [15]: `a` overrides attribute defined in `F1` inconsistently. Type `int` is not a subtype of the overridden attribute `int`.
 typeddicts_readonly_inheritance.py:97:0 Inconsistent override [15]: `a` overrides attribute defined in `F1` inconsistently. Type `int` is not a subtype of the overridden attribute `int`.
+typeddicts_readonly_inheritance.py:105:0 Inconsistent override [15]: `c` overrides attribute defined in `F1` inconsistently. Type `int` is not a subtype of the overridden attribute `int`.
 typeddicts_readonly_inheritance.py:119:0 Invalid inheritance [39]: Field `x` has type `int` in base class `TD_A1` and type `float` in base class `TD_A2`.
+typeddicts_readonly_inheritance.py:119:0 Invalid inheritance [39]: Field `y` has type `int` in base class `TD_A1` and type `float` in base class `TD_A2`.
+typeddicts_readonly_inheritance.py:132:0 Invalid inheritance [39]: `y` is a required field in base class `TD_B1` and a non-required field in base class `TD_B2` (because of `total=False`).
+typeddicts_readonly_inheritance.py:132:0 Invalid inheritance [39]: `x` is a required field in base class `TD_B2` and a non-required field in base class `TD_B1` (because of `total=False`).
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 36: Expected 1 errors
 Line 50: Expected 1 errors
 Line 94: Expected 1 errors
 Line 98: Expected 1 errors
 Line 106: Expected 1 errors
-Line 132: Expected 1 errors
-Line 15: Unexpected errors ['typeddicts_readonly_inheritance.py:15:10 Undefined or invalid type [11]: Annotation `ReadOnly` is not defined as a type.']
-Line 18: Unexpected errors ['typeddicts_readonly_inheritance.py:18:0 Inconsistent override [15]: `name` overrides attribute defined in `NamedDict` inconsistently. Type `str` is not a subtype of the overridden attribute `unknown`.']
-Line 75: Unexpected errors ['typeddicts_readonly_inheritance.py:75:0 Inconsistent override [15]: `ident` overrides attribute defined in `OptionalIdent` inconsistently. Type `str` is not a subtype of the overridden attribute `unknown`.']
-Line 93: Unexpected errors ['typeddicts_readonly_inheritance.py:93:0 Inconsistent override [15]: `a` overrides attribute defined in `F1` inconsistently. Type `unknown` is not a subtype of the overridden attribute `int`.']
+Line 47: Unexpected errors ['typeddicts_readonly_inheritance.py:47:0 Inconsistent override [15]: `alt` overrides attribute defined in `AlbumCollection` inconsistently. Type `typing.List[str]` is not a subtype of the overridden attribute `typing.List[typing.Union[int, str]]`.']
+Line 93: Unexpected errors ['typeddicts_readonly_inheritance.py:93:0 Inconsistent override [15]: `a` overrides attribute defined in `F1` inconsistently. Type `int` is not a subtype of the overridden attribute `int`.']
 Line 97: Unexpected errors ['typeddicts_readonly_inheritance.py:97:0 Inconsistent override [15]: `a` overrides attribute defined in `F1` inconsistently. Type `int` is not a subtype of the overridden attribute `int`.']
+Line 105: Unexpected errors ['typeddicts_readonly_inheritance.py:105:0 Inconsistent override [15]: `c` overrides attribute defined in `F1` inconsistently. Type `int` is not a subtype of the overridden attribute `int`.']
 """

--- a/conformance/results/pyre/typeddicts_readonly_kwargs.toml
+++ b/conformance/results/pyre/typeddicts_readonly_kwargs.toml
@@ -1,11 +1,7 @@
-conformant = "Unsupported"
+conformant = "Pass"
 output = """
-typeddicts_readonly_kwargs.py:24:10 Undefined or invalid type [11]: Annotation `ReadOnly` is not defined as a type.
-typeddicts_readonly_kwargs.py:29:33 Undefined or invalid type [11]: Annotation `Unpack` is not defined as a type.
+typeddicts_readonly_kwargs.py:33:21 Invalid TypedDict operation [54]: Cannot write to `ReadOnlyArgs` read-only field `key1`.
 """
-conformance_automated = "Fail"
+conformance_automated = "Pass"
 errors_diff = """
-Line 33: Expected 1 errors
-Line 24: Unexpected errors ['typeddicts_readonly_kwargs.py:24:10 Undefined or invalid type [11]: Annotation `ReadOnly` is not defined as a type.']
-Line 29: Unexpected errors ['typeddicts_readonly_kwargs.py:29:33 Undefined or invalid type [11]: Annotation `Unpack` is not defined as a type.']
 """

--- a/conformance/results/pyre/typeddicts_readonly_update.toml
+++ b/conformance/results/pyre/typeddicts_readonly_update.toml
@@ -1,11 +1,7 @@
-conformant = "Unsupported"
+conformant = "Pass"
 output = """
-typeddicts_readonly_update.py:17:7 Undefined or invalid type [11]: Annotation `ReadOnly` is not defined as a type.
-typeddicts_readonly_update.py:34:13 Incompatible parameter type [6]: In call `TypedDictionary.update`, for 1st positional argument, expected `A` but got `B`.
+typeddicts_readonly_update.py:23:10 Incompatible parameter type [6]: In call `TypedDictionary.update`, for 1st positional argument, cannot update read-only fields of `A`.
 """
-conformance_automated = "Fail"
+conformance_automated = "Pass"
 errors_diff = """
-Line 23: Expected 1 errors
-Line 17: Unexpected errors ['typeddicts_readonly_update.py:17:7 Undefined or invalid type [11]: Annotation `ReadOnly` is not defined as a type.']
-Line 34: Unexpected errors ['typeddicts_readonly_update.py:34:13 Incompatible parameter type [6]: In call `TypedDictionary.update`, for 1st positional argument, expected `A` but got `B`.']
 """

--- a/conformance/results/pyre/typeddicts_required.toml
+++ b/conformance/results/pyre/typeddicts_required.toml
@@ -8,8 +8,6 @@ Incorrectly generates "attribute not initialized" errors for TypedDict fields.
 """
 output = """
 typeddicts_required.py:15:8 Incompatible attribute type [8]: Attribute `x` declared in class `NotTypedDict` has type `Required[int]` but is used as type `int`.
-typeddicts_required.py:74:62 Undefined or invalid type [11]: Annotation `RecursiveMovie` is not defined as a type.
-typeddicts_required.py:77:24 TypedDict initialization error [55]: Expected type `unknown` for `RecursiveMovie` field `predecessor` but got `typing.Dict[str, str]`.
 """
 conformance_automated = "Fail"
 errors_diff = """
@@ -18,6 +16,4 @@ Line 19: Expected 1 errors
 Line 62: Expected 1 errors
 Line 63: Expected 1 errors
 Line 15: Unexpected errors ['typeddicts_required.py:15:8 Incompatible attribute type [8]: Attribute `x` declared in class `NotTypedDict` has type `Required[int]` but is used as type `int`.']
-Line 74: Unexpected errors ['typeddicts_required.py:74:62 Undefined or invalid type [11]: Annotation `RecursiveMovie` is not defined as a type.']
-Line 77: Unexpected errors ['typeddicts_required.py:77:24 TypedDict initialization error [55]: Expected type `unknown` for `RecursiveMovie` field `predecessor` but got `typing.Dict[str, str]`.']
 """

--- a/conformance/results/pyre/typeddicts_usage.toml
+++ b/conformance/results/pyre/typeddicts_usage.toml
@@ -1,4 +1,4 @@
-conformant = "Partial"
+conformant = "Pass"
 notes = """
 Does not report errant use of TypedDict in `isinstance` call.
 Does not reject use of TypedDict as TypeVar bound.
@@ -7,9 +7,9 @@ output = """
 typeddicts_usage.py:23:6 TypedDict accessed with a missing key [27]: TypedDict `Movie` has no key `director`.
 typeddicts_usage.py:24:16 Invalid TypedDict operation [54]: Expected `int` to be assigned to `Movie` field `year` but got `str`.
 typeddicts_usage.py:28:16 TypedDict initialization error [55]: Missing required field `name` for TypedDict `Movie`.
+typeddicts_usage.py:35:21 TypedDict used in isinstance [71]: TypedDict classes may not be used for instance checks.
+typeddicts_usage.py:40:0 Undefined or invalid type [11]: Annotation `TypedDict` is not defined as a type.
 """
-conformance_automated = "Fail"
+conformance_automated = "Pass"
 errors_diff = """
-Line 35: Expected 1 errors
-Line 40: Expected 1 errors
 """

--- a/conformance/results/pyre/version.toml
+++ b/conformance/results/pyre/version.toml
@@ -1,2 +1,2 @@
-version = "pyre 0.9.22"
-test_duration = 4.4
+version = "pyre 0.9.23"
+test_duration = 9.1

--- a/conformance/results/pyright/version.toml
+++ b/conformance/results/pyright/version.toml
@@ -1,2 +1,2 @@
 version = "pyright 1.1.386"
-test_duration = 1.2
+test_duration = 2.0

--- a/conformance/results/pytype/specialtypes_never.toml
+++ b/conformance/results/pytype/specialtypes_never.toml
@@ -8,11 +8,10 @@ specialtypes_never.py:11:8: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in <mod
 T_co = TypeVar("T_co", covariant=True)
        \u001b[1m\u001b[31m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
 
-specialtypes_never.py:21:8: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in func1: bad return type [bad-return-type]
+specialtypes_never.py:21:5: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in func1: bad return type [bad-return-type]
 
-        sys.exit(1)       \u001b[1m\u001b[31m~~~~~~~~~~~\u001b[39m\u001b[0m
         sys.exit(1)
-\u001b[1m\u001b[31m~~~~~~~~~~~~~\u001b[39m\u001b[0m
+    \u001b[1m\u001b[31m~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
 
 specialtypes_never.py:68:5: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in func6: Type annotation for v1 does not match type of assignment [annotation-type-mismatch]
 
@@ -40,7 +39,7 @@ errors_diff = """
 Line 19: Expected 1 errors
 Line 105: Expected 1 errors
 Line 11: Unexpected errors ['specialtypes_never.py:11:8: \\x1b[1m\\x1b[31merror\\x1b[39m\\x1b[0m: in <module>: argument "covariant" to TypeVar not supported yet [not-supported-yet]']
-Line 21: Unexpected errors ['specialtypes_never.py:21:8: \\x1b[1m\\x1b[31merror\\x1b[39m\\x1b[0m: in func1: bad return type [bad-return-type]']
+Line 21: Unexpected errors ['specialtypes_never.py:21:5: \\x1b[1m\\x1b[31merror\\x1b[39m\\x1b[0m: in func1: bad return type [bad-return-type]']
 Line 68: Unexpected errors ['specialtypes_never.py:68:5: \\x1b[1m\\x1b[31merror\\x1b[39m\\x1b[0m: in func6: Type annotation for v1 does not match type of assignment [annotation-type-mismatch]']
 Line 69: Unexpected errors ['specialtypes_never.py:69:5: \\x1b[1m\\x1b[31merror\\x1b[39m\\x1b[0m: in func6: Type annotation for v2 does not match type of assignment [annotation-type-mismatch]']
 Line 70: Unexpected errors ['specialtypes_never.py:70:5: \\x1b[1m\\x1b[31merror\\x1b[39m\\x1b[0m: in func6: Type annotation for v3 does not match type of assignment [annotation-type-mismatch]']

--- a/conformance/results/pytype/version.toml
+++ b/conformance/results/pytype/version.toml
@@ -1,2 +1,2 @@
 version = "pytype 2024.10.11"
-test_duration = 33.1
+test_duration = 50.2

--- a/conformance/results/results.html
+++ b/conformance/results/results.html
@@ -159,16 +159,16 @@
         <div class="table_container"><table><tbody>
 <tr><th class="col1">&nbsp;</th>
 <th class='tc-header'><div class='tc-name'>mypy 1.13.0</div>
-<div class='tc-time'>1.5sec</div>
+<div class='tc-time'>2.7sec</div>
 </th>
 <th class='tc-header'><div class='tc-name'>pyright 1.1.386</div>
-<div class='tc-time'>1.2sec</div>
+<div class='tc-time'>2.0sec</div>
 </th>
-<th class='tc-header'><div class='tc-name'>pyre 0.9.22</div>
-<div class='tc-time'>4.4sec</div>
+<th class='tc-header'><div class='tc-name'>pyre 0.9.23</div>
+<div class='tc-time'>9.1sec</div>
 </th>
 <th class='tc-header'><div class='tc-name'>pytype 2024.10.11</div>
-<div class='tc-time'>33.1sec</div>
+<div class='tc-time'>50.2sec</div>
 </th>
 </tr>
 <tr><th class="column" colspan="5">
@@ -210,7 +210,7 @@
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;specialtypes_any</th>
 <th class="column col2 conformant">Pass</th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not support Any as a base class.</p></span></div></th>
+<th class="column col2 conformant">Pass</th>
 <th class="column col2 conformant">Pass</th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;specialtypes_never</th>
@@ -297,13 +297,13 @@
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;generics_scoping</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>False negative on generic class nested within generic class with same type variable.</p></span></div></th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>False negative on generic class nested within generic function with same type variable.</p><p>False negative on generic class nested within generic class with same type variable.</p></span></div></th>
+<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>False negative on generic class nested within generic function with same type variable.</p><p>False negative on generic class nested within generic class with same type variable.</p><p>False negative on assert_type uses.</p></span></div></th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Fails to reject type alias within generic class that uses class's type variable.</p><p>Fails to reject unbound type variable in constructor call in global scope.</p></span></div></th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;generics_self_advanced</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not infer the type of an unannotated `self` parameter to be type `Self`.</p><p>Does not retain `Self` when calling method that returns `Self`.</p><p>Does not infer the type of an unannotated `cls` parameter to be type `type[Self]`.</p><p>Does not retain `Self` when accessing attribute through `type[Self]`.</p></span></div></th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not handle use of `Self` within class body correctly.</p></span></div></th>
+<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not handle use of `Self` within class body correctly.</p><p>False negatives on assert_type uses.</p></span></div></th>
 <th class="column col2 not-conformant"><div class="hover-text">Unsupported<span class="tooltip-text" id="bottom"><p>Does not understand `Self` type.</p></span></div></th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;generics_self_attributes</th>
@@ -333,55 +333,55 @@
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;generics_syntax_compatibility</th>
 <th class="column col2 conformant">Pass</th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 not-conformant"><div class="hover-text">Unsupported<span class="tooltip-text" id="bottom"><p>Type parameter syntax not yet support.</p></span></div></th>
+<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>False negative on mixing legacy and PEP695 syntax.</p><p>Does not detect mixing legacy and PEP695 syntax in methods.</p></span></div></th>
 <th class="column col2 not-conformant"><div class="hover-text">Unsupported<span class="tooltip-text" id="bottom"><p>Type parameter syntax not yet support.</p></span></div></th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;generics_syntax_declarations</th>
 <th class="column col2 conformant">Pass</th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 not-conformant"><div class="hover-text">Unsupported<span class="tooltip-text" id="bottom"><p>Type parameter syntax not yet support.</p></span></div></th>
+<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not detect incorrect use of legacy style syntax mixed with PEP695 syntax.</p><p>False negatives due to assert_type use.</p></span></div></th>
 <th class="column col2 not-conformant"><div class="hover-text">Unsupported<span class="tooltip-text" id="bottom"><p>Type parameter syntax not yet support.</p></span></div></th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;generics_syntax_infer_variance</th>
 <th class="column col2 not-conformant"><div class="hover-text">Unsupported<span class="tooltip-text" id="bottom"><p>Type parameter syntax not yet support.</p></span></div></th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 not-conformant"><div class="hover-text">Unsupported<span class="tooltip-text" id="bottom"><p>Type parameter syntax not yet support.</p></span></div></th>
+<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Incorrectly determines that a class cannot be instantiated with __getitem__.</p><p>Incorrectly handles mixing legacy and PEP695 syntax.</p></span></div></th>
 <th class="column col2 not-conformant"><div class="hover-text">Unsupported<span class="tooltip-text" id="bottom"><p>Type parameter syntax not yet support.</p></span></div></th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;generics_syntax_scoping</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not following runtime scoping rules for type parameters in all cases.</p></span></div></th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 not-conformant"><div class="hover-text">Unsupported<span class="tooltip-text" id="bottom"><p>Type parameter syntax not yet support.</p></span></div></th>
+<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not properly handle mixing legacy syntax with PEP695 syntax.</p></span></div></th>
 <th class="column col2 not-conformant"><div class="hover-text">Unsupported<span class="tooltip-text" id="bottom"><p>Type parameter syntax not yet support.</p></span></div></th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;generics_type_erasure</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Infers Node[Never] instead of Node[Any] when argument is not provided.</p><p>False negative on instance attribute access on type(node).</p></span></div></th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not erase unspecified type variables to `Any` prior to `assert_type` handling.</p><p>False negatives on instance attribute access on the type.</p><p>Does not infer type of `DefaultDict` with explicit type parameters on constructor.</p></span></div></th>
+<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not erase unspecified type variables to `Any` prior to `assert_type` handling.</p><p>False negatives on instance attribute access on the type.</p><p>Does not infer type of `DefaultDict` with explicit type parameters on constructor.</p><p>False negatives on assert_type uses.</p></span></div></th>
 <th class="column col2 not-conformant">Unsupported</th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;generics_typevartuple_args</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not enforce that tuples captured by TypeVarTuple are same type.</p></span></div></th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 not-conformant"><div class="hover-text">Unsupported<span class="tooltip-text" id="bottom"><p>Does not support star expressions for `Unpack`.</p></span></div></th>
+<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not property handle TypeVarTuple.</p></span></div></th>
 <th class="column col2 not-conformant"><div class="hover-text">Unsupported<span class="tooltip-text" id="bottom"><p>Does not support TypeVarTuple.</p></span></div></th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;generics_typevartuple_basic</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not enforce that tuples captured by TypeVarTuple are same length.</p><p>Does not enforce that tuples captured by TypeVarTuple are same type.</p></span></div></th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 not-conformant"><div class="hover-text">Unsupported<span class="tooltip-text" id="bottom"><p>Does not support TypeVarTuple.</p></span></div></th>
+<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not support TypeVarTuple.</p><p>False negatives due to assert_type.</p></span></div></th>
 <th class="column col2 not-conformant"><div class="hover-text">Unsupported<span class="tooltip-text" id="bottom"><p>Does not support TypeVarTuple.</p></span></div></th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;generics_typevartuple_callable</th>
 <th class="column col2 conformant">Pass</th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 not-conformant"><div class="hover-text">Unsupported<span class="tooltip-text" id="bottom"><p>Does not support TypeVarTuple.</p></span></div></th>
+<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>False negatives due to assert_type.</p></span></div></th>
 <th class="column col2 not-conformant"><div class="hover-text">Unsupported<span class="tooltip-text" id="bottom"><p>Does not support TypeVarTuple.</p></span></div></th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;generics_typevartuple_concat</th>
 <th class="column col2 conformant">Pass</th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 not-conformant"><div class="hover-text">Unsupported<span class="tooltip-text" id="bottom"><p>Does not support TypeVarTuple.</p></span></div></th>
+<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>False negatives due to assert_type.</p><p>False compatability error message.</p></span></div></th>
 <th class="column col2 not-conformant"><div class="hover-text">Unsupported<span class="tooltip-text" id="bottom"><p>Does not support TypeVarTuple.</p></span></div></th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;generics_typevartuple_overloads</th>
@@ -399,7 +399,7 @@
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;generics_typevartuple_unpack</th>
 <th class="column col2 conformant">Pass</th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 not-conformant"><div class="hover-text">Unsupported<span class="tooltip-text" id="bottom"><p>Does not support star expressions for `Unpack`.</p></span></div></th>
+<th class="column col2 conformant">Pass</th>
 <th class="column col2 not-conformant"><div class="hover-text">Unsupported<span class="tooltip-text" id="bottom"><p>Does not support TypeVarTuple.</p></span></div></th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;generics_upper_bound</th>
@@ -417,7 +417,7 @@
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;generics_variance_inference</th>
 <th class="column col2 conformant">Pass</th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 not-conformant"><div class="hover-text">Unsupported<span class="tooltip-text" id="bottom"><p>Type parameter syntax not yet support.</p></span></div></th>
+<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not properly handle mixing legacy and PEP695 syntax.</p><p>False negative about a type variable not being present in the function's parameters.</p></span></div></th>
 <th class="column col2 not-conformant"><div class="hover-text">Unsupported<span class="tooltip-text" id="bottom"><p>Type parameter syntax not yet support.</p></span></div></th>
 </tr>
 <tr><th class="column" colspan="5">
@@ -453,7 +453,7 @@
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;classes_override</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not handle case where parent class derives from Any.</p></span></div></th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not allow Any as a base class, leading to false positives.</p></span></div></th>
+<th class="column col2 conformant">Pass</th>
 <th class="column col2 not-conformant"><div class="hover-text">Unsupported<span class="tooltip-text" id="bottom"><p>Does not yet support the @override decorator.</p></span></div></th>
 </tr>
 <tr><th class="column" colspan="5">
@@ -486,7 +486,7 @@
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;aliases_type_statement</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not reject type alias defined in function scope.</p></span></div></th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 not-conformant"><div class="hover-text">Unsupported<span class="tooltip-text" id="bottom"><p>Does not support `type` statement.</p></span></div></th>
+<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not complain when a type alias cannot be used as a base class.</p><p>Does not complain when a type alias cannot be used as a function.</p><p>Does not complain when a type statement definition combines new and old TypeVars.</p><p>Does not complain when a type statement definition uses old TypeVars.</p><p>Does not properly support recursive aliases.</p></span></div></th>
 <th class="column col2 not-conformant"><div class="hover-text">Unsupported<span class="tooltip-text" id="bottom"><p>Does not support `type` statement.</p></span></div></th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;aliases_typealiastype</th>
@@ -558,7 +558,7 @@
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;protocols_merging</th>
 <th class="column col2 conformant">Pass</th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not reject a protocol class that derives from a non-protocol class.</p></span></div></th>
+<th class="column col2 conformant">Pass</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not reject a protocol class that derives from a non-protocol class.</p><p>Does not report attempt to instantiate abstract class downgraded from protocol class.</p></span></div></th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;protocols_modules</th>
@@ -609,7 +609,7 @@
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;callables_kwargs</th>
 <th class="column col2 conformant">Pass</th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 not-conformant"><div class="hover-text">Unsupported<span class="tooltip-text" id="bottom"><p>Does not understand Unpack in the context of **kwargs annotation.</p></span></div></th>
+<th class="column col2 conformant">Pass</th>
 <th class="column col2 not-conformant"><div class="hover-text">Unsupported<span class="tooltip-text" id="bottom"><p>Does not understand Unpack in the context of **kwargs annotation.</p></span></div></th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;callables_protocol</th>
@@ -630,7 +630,7 @@
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;constructors_call_init</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not report errors during binding to self parameter of __init__ method.</p><p>Does not reject use of class-scoped type variables in annotation of self parameter in __init__ method.</p></span></div></th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not infer type of Self for self parameter of __init__ method.</p><p>Does not report errors during binding to self parameter of __init__ method.</p><p>Does not reject use of class-scoped type variables in annotation of self parameter in __init__ method.</p></span></div></th>
+<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not infer type of Self for self parameter of __init__ method.</p><p>Does not report errors during binding to self parameter of __init__ method.</p><p>Does not reject use of class-scoped type variables in annotation of self parameter in __init__ method.</p><p>Incorrectly raises Incompatible overload type errors.</p><p>Incorrectly raises compatibility type errors.</p></span></div></th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not report errors during binding to self parameter of __init__ method.</p><p>Does not infer type of Self for self parameter of __init__ method.</p><p>Rejects valid type annotation for self parameter in __init__ method.</p><p>Does not support function-scoped TypeVars in self annotation in __init__ method.</p><p>Does not reject use of class-scoped type variables in annotation of self parameter in __init__ method.</p></span></div></th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;constructors_call_metaclass</th>
@@ -642,7 +642,7 @@
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;constructors_call_new</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not support __new__ return type that is not a subclass of the class being constructed.</p><p>Does not skip evaluation of __init__ based on __new__ return type.</p><p>Does not report errors during binding to cls parameter of __new__ method.</p></span></div></th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not support __new__ return type that is not a subclass of the class being constructed.</p><p>Does not report errors during binding to cls parameter of __new__ method.</p></span></div></th>
+<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not support __new__ return type that is not a subclass of the class being constructed.</p><p>Does not report errors during binding to cls parameter of __new__ method.</p><p>Incorrectly raises compatibility type errors.</p></span></div></th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not honor explicit specialization of generic class when used in constructor call.</p><p>Does not support __new__ return type that is not a subclass of the class being constructed.</p><p>Does not skip evaluation of __init__ based on __new__ return type.</p></span></div></th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;constructors_call_type</th>
@@ -654,7 +654,7 @@
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;constructors_callable</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not generate a union type for __new__ and __init__ when converting class to callable.</p><p>Does not ignore __init__ based on __new__ return type when converting class to callable.</p><p>Does not support __new__ return type that is different from class being constructed.</p></span></div></th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not generate a union type for __new__ and __init__ when converting class to callable.</p><p>Does not ignore __init__ based on __new__ return type when converting class to callable.</p><p>Does not support __new__ return type that is different from class being constructed.</p><p>Does not use annotated type of self in __init__ method to generate return type of callable.</p></span></div></th>
+<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not generate a union type for __new__ and __init__ when converting class to callable.</p><p>Does not ignore __init__ based on __new__ return type when converting class to callable.</p><p>Does not support __new__ return type that is different from class being constructed.</p><p>Does not use annotated type of self in __init__ method to generate return type of callable.</p><p>Incorrectly raises incompatibility type errors.</p></span></div></th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not generate a union type for __new__ and __init__ when converting class to callable.</p><p>Does not ignore __init__ based on __new__ return type when converting class to callable.</p><p>Does not support __new__ return type that is different from class being constructed.</p><p>Does not use annotated type of self in __init__ method to generate return type of callable.</p></span></div></th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;constructors_consistency</th>
@@ -669,7 +669,7 @@
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;overloads_basic</th>
 <th class="column col2 conformant">Pass</th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not reject a function with a single @overload signature.</p></span></div></th>
+<th class="column col2 conformant">Pass</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not reject a function with a single @overload signature.</p><p>Does not reject a function with @overload signature but no implementation.</p></span></div></th>
 </tr>
 <tr><th class="column" colspan="5">
@@ -678,7 +678,7 @@
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;exceptions_context_managers</th>
 <th class="column col2 conformant">Pass</th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 not-conformant"><div class="hover-text">Unsupported<span class="tooltip-text" id="bottom"><p>Does not understand context manager exception rules.</p></span></div></th>
+<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>assert_type causes failures.</p></span></div></th>
 <th class="column col2 not-conformant"><div class="hover-text">Unsupported<span class="tooltip-text" id="bottom"><p>Does not support code flow analysis.</p></span></div></th>
 </tr>
 <tr><th class="column" colspan="5">
@@ -687,7 +687,7 @@
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dataclasses_descriptors</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not correctly evaluate type of descriptor access.</p></span></div></th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Incorrectly generates error when calling constructor of dataclass with descriptor.</p></span></div></th>
+<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Incorrectly generates error when calling constructor of dataclass with descriptor.</p><p>Incorrectly raises incompatibility type errors.</p></span></div></th>
 <th class="column col2 not-conformant"><div class="hover-text">Unsupported<span class="tooltip-text" id="bottom"><p>Does not understand descriptor objects in dataclass.</p></span></div></th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dataclasses_final</th>
@@ -771,7 +771,7 @@
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dataclasses_usage</th>
 <th class="column col2 conformant"><div class="hover-text">Pass*<span class="tooltip-text" id="bottom"><p>Does not detect unannotated usage of `dataclasses.field()`.</p></span></div></th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not report error when field with no default follows field with default.</p><p>Complains on `assert_type` when used for bound methods vs `Callable`.</p><p>Does not understand `__dataclass_fields__`.</p></span></div></th>
+<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not report error when field with no default follows field with default.</p><p>Complains on `assert_type` when used for bound methods vs `Callable`.</p><p>Does not understand `__dataclass_fields__`.</p><p>Incorrectly raises incompatibility type errors.</p></span></div></th>
 <th class="column col2 conformant">Pass</th>
 </tr>
 <tr><th class="column" colspan="5">
@@ -798,25 +798,25 @@
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;typeddicts_inheritance</th>
 <th class="column col2 conformant">Pass</th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not reject TypedDict class that inherits from non-TypedDict class.</p></span></div></th>
+<th class="column col2 conformant">Pass</th>
 <th class="column col2 conformant">Pass</th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;typeddicts_operations</th>
 <th class="column col2 conformant">Pass</th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not reject `del` of required key.</p></span></div></th>
+<th class="column col2 conformant">Pass</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not report type violation with TypedDict value assignment.</p><p>Does not report reference to unknown key in TypedDict.</p><p>Does not reject `clear` method on TypedDict with required keys.</p><p>Does not reject delete operation for required key in TypedDict.</p></span></div></th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;typeddicts_readonly</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Incorrectly rejects NotRequired directive when used in an Annotated annotation.</p></span></div></th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 not-conformant">Unsupported</th>
+<th class="column col2 conformant">Pass</th>
 <th class="column col2 not-conformant">Unsupported</th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;typeddicts_readonly_consistency</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Incorrectly rejects assignment of required item to not-required read-only item.</p></span></div></th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 not-conformant">Unsupported</th>
+<th class="column col2 conformant">Pass</th>
 <th class="column col2 not-conformant">Unsupported</th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;typeddicts_readonly_inheritance</th>
@@ -828,13 +828,13 @@
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;typeddicts_readonly_kwargs</th>
 <th class="column col2 conformant">Pass</th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 not-conformant">Unsupported</th>
+<th class="column col2 conformant">Pass</th>
 <th class="column col2 not-conformant">Unsupported</th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;typeddicts_readonly_update</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Incorrectly allows update of ReadOnly item.</p><p>Incorrectly rejects update involving an item with Never type.</p></span></div></th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 not-conformant">Unsupported</th>
+<th class="column col2 conformant">Pass</th>
 <th class="column col2 not-conformant">Unsupported</th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;typeddicts_required</th>
@@ -852,7 +852,7 @@
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;typeddicts_usage</th>
 <th class="column col2 conformant">Pass</th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not report errant use of TypedDict in `isinstance` call.</p><p>Does not reject use of TypedDict as TypeVar bound.</p></span></div></th>
+<th class="column col2 conformant"><div class="hover-text">Pass*<span class="tooltip-text" id="bottom"><p>Does not report errant use of TypedDict in `isinstance` call.</p><p>Does not reject use of TypedDict as TypeVar bound.</p></span></div></th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not report errant use of TypedDict in `isinstance` call.</p><p>Does not reject use of TypedDict as TypeVar bound.</p></span></div></th>
 </tr>
 <tr><th class="column" colspan="5">
@@ -873,7 +873,7 @@
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tuples_unpacked</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>"More than one unpack" error is missing a line number.</p></span></div></th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not understand star syntax for `Unpack`.</p></span></div></th>
+<th class="column col2 conformant">Pass</th>
 <th class="column col2 not-conformant"><div class="hover-text">Unsupported<span class="tooltip-text" id="bottom"><p>Does not support `typing.Unpack`.</p><p>Does not support unpacked tuples within a tuple type form.</p></span></div></th>
 </tr>
 <tr><th class="column" colspan="5">
@@ -888,19 +888,19 @@
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;namedtuples_define_functional</th>
 <th class="column col2 conformant">Pass</th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not handle illegal named tuple names the same as runtime.</p><p>Does not handle defined fields correctly when extra flags like `rename` or `default` are used.</p><p>Does not support defaults in functional form.</p></span></div></th>
+<th class="column col2 conformant">Pass</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not handle illegal named tuple names the same as runtime.</p><p>Does not support defaults in functional form.</p></span></div></th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;namedtuples_type_compat</th>
 <th class="column col2 conformant">Pass</th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 not-conformant"><div class="hover-text">Unsupported<span class="tooltip-text" id="bottom"><p>Rejects valid type compatibility between named tuple and tuple.</p></span></div></th>
+<th class="column col2 conformant">Pass</th>
 <th class="column col2 conformant">Pass</th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;namedtuples_usage</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not reject attempt to delete named tuple field by name.</p></span></div></th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not report out-of-range index access with named tuple instance.</p><p>Does not reject attempt to delete named tuple field by name.</p><p>Does not reject attempt to delete named tuple field by index.</p><p>Incorrectly handles subclasses of named tuples that add more attributes.</p><p>Does not handle unpacking of named tuples.</p></span></div></th>
+<th class="column col2 partially-conformant">Partial</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Incorrectly rejects valid index of named tuple instance when using a negative index.</p><p>Does not report out-of-range index access with named tuple instance.</p><p>Does not reject attempt to overwrite named tuple entry by name.</p><p>Does not reject attempt to delete named tuple entry by name.</p></span></div></th>
 </tr>
 <tr><th class="column" colspan="5">
@@ -909,19 +909,19 @@
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enums_behaviors</th>
 <th class="column col2 conformant">Pass</th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not enforce that Enum classes are implicitly final.</p></span></div></th>
+<th class="column col2 conformant">Pass</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not enforce that Enum classes are implicitly final.</p></span></div></th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enums_definition</th>
 <th class="column col2 conformant">Pass</th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not support custom Enum classes based on EnumType metaclass.</p><p>Does not support some functional forms for Enum class definitions (optional).</p></span></div></th>
+<th class="column col2 conformant">Pass</th>
 <th class="column col2 conformant"><div class="hover-text">Pass*<span class="tooltip-text" id="bottom"><p>Does not support some functional forms for Enum class definitions (optional).</p></span></div></th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enums_expansion</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Improperly applies narrowing to Flag subclass.</p></span></div></th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 conformant"><div class="hover-text">Pass*<span class="tooltip-text" id="bottom"><p>Does not perform type narrowing based on enum literal expansion (optional).</p></span></div></th>
+<th class="column col2 conformant">Pass</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Improperly applies narrowing to Flag subclass.</p></span></div></th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enums_member_names</th>
@@ -933,7 +933,7 @@
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enums_member_values</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not enforce declared type of `_value_`.</p><p>Does not enforce assigned tuple types for enum members (optional).</p></span></div></th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not enforce declared type of `_value_`.</p><p>Does not enforce assigned tuple types for enum members (optional).</p><p>Does not evaluate literal types for enum member values (optional).</p><p>Does not evaluate literal types for auto values (optional).</p></span></div></th>
+<th class="column col2 conformant">Pass</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not enforce declared type of `_value_`.</p><p>Does not correctly enforce assigned tuple types for enum members (optional).</p><p>Does not evaluate literal types for enum member values (optional).</p><p>Does not evaluate literal types for auto values (optional).</p></span></div></th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enums_members</th>
@@ -948,13 +948,13 @@
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;narrowing_typeguard</th>
 <th class="column col2 conformant">Pass</th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not reject TypeGuard method with too few parameters.</p></span></div></th>
+<th class="column col2 conformant">Pass</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not reject TypeGuard method with too few parameters.</p></span></div></th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;narrowing_typeis</th>
 <th class="column col2 conformant">Pass</th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 not-conformant">Unsupported</th>
+<th class="column col2 conformant">Pass</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not narrow correctly on generic tuple type.</p><p>Does not reject covariant use of TypeIs.</p><p>Does not reject TypeIs where return type is not consistent with input type due to variance.</p></span></div></th>
 </tr>
 <tr><th class="column" colspan="5">
@@ -963,7 +963,7 @@
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;directives_assert_type</th>
 <th class="column col2 conformant">Pass</th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 conformant"><div class="hover-text">Pass*<span class="tooltip-text" id="bottom"><p>Does not weaken literal types in `assert_type`, which some (other) tests rely on.</p></span></div></th>
+<th class="column col2 conformant">Pass</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Incorrectly allows assert(x, int) where x is a Literal.</p></span></div></th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;directives_cast</th>
@@ -987,7 +987,7 @@
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;directives_reveal_type</th>
 <th class="column col2 conformant">Pass</th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Produces errors rather than warnings on `reveal_type`.</p></span></div></th>
+<th class="column col2 conformant">Pass</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not reject call to reveal_type with zero arguments.</p><p>Does not reject call to reveal_type with too many arguments.</p></span></div></th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;directives_type_checking</th>
@@ -1005,7 +1005,7 @@
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;directives_type_ignore_file1</th>
 <th class="column col2 conformant">Pass</th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 not-conformant"><div class="hover-text">Unsupported<span class="tooltip-text" id="bottom"><p>Does not support file-level `#type: ignore` comment.</p></span></div></th>
+<th class="column col2 conformant">Pass</th>
 <th class="column col2 conformant">Pass</th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;directives_type_ignore_file2</th>
@@ -1017,7 +1017,7 @@
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;directives_version_platform</th>
 <th class="column col2 conformant"><div class="hover-text">Pass*<span class="tooltip-text" id="bottom"><p>Does not understand three-element form of sys.version checks.</p><p>Does not understand os.name checks.</p></span></div></th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not support sys.platform checks.</p><p>Does not support os.name checks.</p></span></div></th>
+<th class="column col2 conformant">Pass</th>
 <th class="column col2 conformant"><div class="hover-text">Pass*<span class="tooltip-text" id="bottom"><p>Does not understand three-element form of sys.version checks.</p><p>Does not understand os.name checks.</p></span></div></th>
 </tr>
 <tr><th class="column" colspan="5">
@@ -1026,7 +1026,7 @@
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;historical_positional</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not reject positional-only parameter after non-positional-only parameter.</p><p>Treats keyword-only parameter as positional-only.</p><p>Applies legacy positional-only rules when PEP 570 syntax is used.</p></span></div></th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not reject positional-only parameter after non-positional-only parameter.</p><p>Incorrectly applies legacy positional-only rules when explicit *args are used.</p><p>Incorrectly applies legacy positional-only rules when PEP 570 syntax is used.</p></span></div></th>
+<th class="column col2 conformant">Pass</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not apply rules for pre-3.8 positional-only parameters in some cases.</p><p>Does not reject positional-only parameter after non-positional-only parameter.</p></span></div></th>
 </tr>
 </tbody></table></div>


### PR DESCRIPTION
The new pyre release includes PEP695 support, as well as various conformance improvements across the entire conformance suite.

This diff updates the results as well as the notes on each of the tests where the outputs changed.