### PR TITLE
Clarify some behavior around user-defined generic classes

### DIFF
--- a/docs/spec/generics.rst
+++ b/docs/spec/generics.rst
@@ -509,7 +509,8 @@ That ``Child`` definition is equivalent to::
   class Child(Parent1[T1, T3], Parent2[T2, T3], Generic[T1, T3, T2]):
       ...
 
-Type checkers may warn when the type variable order is inconsistent::
+A type checker should report an error when the type variable order is
+inconsistent::
 
   from typing import Generic, TypeVar
 
@@ -521,7 +522,7 @@ Type checkers may warn when the type variable order is inconsistent::
       ...
   class Parent(Grandparent[T1, T2]):
       ...
-  class Child(Parent[T1, T2], Grandparent[T2, T1]):   # Inconsistent order
+  class Child(Parent[T1, T2], Grandparent[T2, T1]):   # INVALID
       ...
 
 Abstract generic types

--- a/docs/spec/generics.rst
+++ b/docs/spec/generics.rst
@@ -93,11 +93,14 @@ This is equivalent to omitting the generic notation and just saying
 User-defined generic types
 --------------------------
 
-You can define a user-defined class as generic in three ways: by including a
-``Generic`` base class, by using the  new generic class syntax in Python 3.12
-and higher, or by including a ``Protocol`` base class parameterized with type
-variables. The third approach also marks the class as a protocol - see
-:ref:`generic protocols<generic-protocols>` for more information.
+There are several ways to define a user-defined class as generic:
+
+* Include a ``Generic`` base class.
+* Use the new generic class syntax in Python 3.12 and higher.
+* Include a `` Protocol`` base class parameterized with type variables. This
+  approach also marks the class as a protocol - see
+  :ref:`generic protocols<generic-protocols>` for more information.
+* Include a generic base class parameterized with type variables.
 
 Example using ``Generic``::
 

--- a/docs/spec/generics.rst
+++ b/docs/spec/generics.rst
@@ -477,7 +477,7 @@ Type checkers may warn when the type variable order is inconsistent::
 
   from typing import Generic, TypeVar
 
-  T1 = TypeVar('T2')
+  T1 = TypeVar('T1')
   T2 = TypeVar('T2')
   T3 = TypeVar('T3')
 

--- a/docs/spec/generics.rst
+++ b/docs/spec/generics.rst
@@ -166,8 +166,44 @@ thus invalid::
   class Pair(Generic[T, T]):   # INVALID
       ...
 
-When no ``Generic[T]`` or ``Protocol[T]`` base class is present, a defined
-class is generic if you subclass one or more other generic classes and
+All arguments to ``Generic`` or ``Protocol`` must be type variables::
+
+  from typing import Generic, Protocol
+
+  class Bad1(Generic[int]):   # INVALID
+      ...
+  class Bad2(Protocol[int]):   # INVALID
+      ...
+
+When a ``Generic`` or parameterized ``Protocol`` base class is present, all type
+parameters for the class must appear within the ``Generic`` or
+``Protocol`` type argument list, respectively. A type checker should report an
+error if a type variable that is not included in the type argument list appears
+elsewhere in the base class list::
+
+  from typing import Generic, Protocol, TypeVar
+  from collections.abc import Iterable
+
+  T = TypeVar('T')
+  S = TypeVar('S')
+
+  class Bad1(Iterable[T], Generic[S]):   # INVALID
+      ...
+  class Bad2(Iterable[T], Protocol[S]):   # INVALID
+      ...
+
+Note that the above rule does not apply to a bare ``Protocol`` base class. This
+is valid (see below)::
+
+  from typing import Protocol, TypeVar
+  from collections.abc import Iterator
+
+  T = TypeVar('T')
+
+  class MyIterator(Iterator[T], Protocol): ...
+
+When no ``Generic`` or parameterized ``Protocol`` base class is present, a
+defined class is generic if you subclass one or more other generic classes and
 specify type variables for their parameters. See :ref:`generic-base-classes`
 for details.
 

--- a/docs/spec/generics.rst
+++ b/docs/spec/generics.rst
@@ -128,7 +128,7 @@ Or, using the new generic class syntax::
   class LoggedVar[T]:
       # methods as in previous example
 
-This implicitly adds ``Generic[T]`` as a base class and type checkers
+This implicitly adds ``Generic[T]`` as a base class, and type checkers
 should treat the two definitions of ``LoggedVar`` largely equivalently (except
 for variance, see below).
 
@@ -450,7 +450,7 @@ Also consider the following example::
   class MyDict(Mapping[str, T]):
       ...
 
-In this case ``MyDict`` has a single parameter, ``T``.
+In this case ``MyDict`` has a single type parameter, ``T``.
 
 Type variables are applied to the defined class in the order in which
 they first appear in any generic base classes::

--- a/docs/spec/generics.rst
+++ b/docs/spec/generics.rst
@@ -93,9 +93,13 @@ This is equivalent to omitting the generic notation and just saying
 User-defined generic types
 --------------------------
 
-You can define a user-defined class as generic by including a ``Generic``
-base class, either explicitly or implicitly via the ``Protocol[T]``
-shorthand for :ref:`generic protocols<generic-protocols>`. Example::
+You can define a user-defined class as generic in three ways: by including a
+``Generic`` base class, by using the  new generic class syntax in Python 3.12
+and higher, or by including a ``Protocol`` base class parameterized with type
+variables. The third approach also marks the class as a protocol - see
+:ref:`generic protocols<generic-protocols>` for more information.
+
+Example using ``Generic``::
 
   from typing import TypeVar, Generic
   from logging import Logger
@@ -119,14 +123,14 @@ shorthand for :ref:`generic protocols<generic-protocols>`. Example::
       def log(self, message: str) -> None:
           self.logger.info('{}: {}'.format(self.name, message))
 
-Or, in Python 3.12 and higher, by using the new syntax for generic
-classes::
+Or, using the new generic class syntax::
 
   class LoggedVar[T]:
       # methods as in previous example
 
 This implicitly adds ``Generic[T]`` as a base class and type checkers
-should treat the two largely equivalently (except for variance, see below).
+should treat the two definitions of ``LoggedVar`` largely equivalently (except
+for variance, see below).
 
 ``Generic[T]`` as a base class defines that the class ``LoggedVar``
 takes a single type parameter ``T``. This also makes ``T`` valid as

--- a/docs/spec/protocol.rst
+++ b/docs/spec/protocol.rst
@@ -272,8 +272,15 @@ non-protocol generic types::
           ...
 
 ``Protocol[T, S, ...]`` is allowed as a shorthand for
-``Protocol, Generic[T, S, ...]``. It is an error to include both
-``Protocol[T, S, ...]`` and ``Generic[T, S, ...]`` in a class definition.
+``Protocol, Generic[T, S, ...]``. It is an error to combine
+``Protocol[T, S, ...]`` with ``Generic[T, S, ...]``, or with the new syntax for
+generic classes in Python 3.12 and above::
+
+  class Iterable(Protocol[T], Generic[T]):   # INVALID
+      ...
+
+  class Iterable[T](Protocol[T]):   # INVALID
+      ...
 
 User-defined generic protocols support explicitly declared variance.
 Type checkers will warn if the inferred variance is different from

--- a/docs/spec/protocol.rst
+++ b/docs/spec/protocol.rst
@@ -257,6 +257,7 @@ from regular ABCs, where abstractness is simply defined by having at least one
 abstract method being unimplemented. Protocol classes must be marked
 *explicitly*.
 
+.. _`generic-protocols`:
 
 Generic protocols
 ^^^^^^^^^^^^^^^^^
@@ -271,7 +272,8 @@ non-protocol generic types::
           ...
 
 ``Protocol[T, S, ...]`` is allowed as a shorthand for
-``Protocol, Generic[T, S, ...]``.
+``Protocol, Generic[T, S, ...]``. It is an error to include both
+``Protocol[T, S, ...]`` and ``Generic[T, S, ...]`` in a class definition.
 
 User-defined generic protocols support explicitly declared variance.
 Type checkers will warn if the inferred variance is different from


### PR DESCRIPTION
* `Protocol[T]` behaves like `Generic[T]` when defining a generic class.
* It's an error to include both `Generic[T]` and `Protocol[T]`.
* When `Generic[T]` is omitted, type variables are taken in order of first appearance in generic base classes.

Discussion: https://discuss.python.org/t/clarifying-the-rules-for-subclassing-generic-classes/69698.