### PR TITLE
Add content from typeshed/CONTRIBUTING.md

### DIFF
--- a/docs/guides/writing_stubs.rst
+++ b/docs/guides/writing_stubs.rst
@@ -93,7 +93,7 @@ Liskov substitutability or detecting problematic overloads.
 It may be instructive to examine `typeshed <https://github.com/python/typeshed/>`__'s
 `setup for testing stubs <https://github.com/python/typeshed/blob/main/tests/README.md>`__.
 
-To suppress type errors in stubs, use `# type: ignore` comments. Refer to the :ref:`type-checker-error-suppression` section of the style guide for
+To suppress type errors in stubs, use ``# type: ignore`` comments. Refer to the :ref:`type-checker-error-suppression` section of the style guide for
 error suppression formats specific to individual typecheckers.
 
 ..

--- a/docs/guides/writing_stubs.rst
+++ b/docs/guides/writing_stubs.rst
@@ -93,7 +93,7 @@ Liskov substitutability or detecting problematic overloads.
 It may be instructive to examine `typeshed <https://github.com/python/typeshed/>`__'s
 `setup for testing stubs <https://github.com/python/typeshed/blob/main/tests/README.md>`__.
 
-To suppress type errors on stubs, use a `# type: ignore` comment. Refer to the style guide for
+To suppress type errors in stubs, use `# type: ignore` comments. Refer to the style guide for
 error suppression formats specific to individual typecheckers.
 
 ..

--- a/docs/guides/writing_stubs.rst
+++ b/docs/guides/writing_stubs.rst
@@ -234,15 +234,7 @@ follow the following guidelines:
   can be left unannotated.
 * Do not use ``Any`` to mark unannotated or partially annotated values. Leave
   function parameters and return values unannotated. In all other cases, use
-  ``_typeshed.Incomplete``::
-
-    from _typeshed import Incomplete
-
-    field1: Incomplete
-    field2: dict[str, Incomplete]
-
-    def foo(x): ...
-
+  ``_typeshed.Incomplete``.
 * Partial classes should include a ``__getattr__()`` method marked with
   ``_typeshed.Incomplete`` (see example below).
 * Partial modules (i.e. modules that are missing some or all classes,
@@ -782,6 +774,7 @@ Using ``Any`` and ``object``
 
 When adding type hints, avoid using the ``Any`` type when possible. Reserve
 the use of ``Any`` for when:
+
 * the correct type cannot be expressed in the current type system; and
 * to avoid union returns (see above).
 
@@ -830,7 +823,7 @@ context manager is meant to be subclassed, pick ``bool | None``.
 See https://github.com/python/mypy/issues/7214 for more details.
 
 ``__enter__`` methods and other methods that return ``self`` or ``cls(...)``
-should be annotated with the `typing.Self`
+should be annotated with ``typing.Self``
 (`example <https://github.com/python/typeshed/blob/3581846/stdlib/contextlib.pyi#L151>`_).
 
 Naming

--- a/docs/guides/writing_stubs.rst
+++ b/docs/guides/writing_stubs.rst
@@ -503,7 +503,7 @@ more concise files.
 Syntax Example
 --------------
 
-The below is an excerpt from the types for the `datetime` module.
+The below is an excerpt from the types for the ``datetime`` module.
 
   MAXYEAR: int
   MINYEAR: int
@@ -680,13 +680,12 @@ No::
         ...
     def to_int3(x: str) -> int: pass
 
-Avoid invariant collection types (`list`, `dict`) for function parameters,
-in favor of covariant types like `Mapping` or `Sequence`.
+Avoid invariant collection types (``list``, ``dict``) for function parameters,
+in favor of covariant types like ``Mapping`` or ``Sequence``.
 
 Avoid union return types. See https://github.com/python/mypy/issues/1693
 
-Use `float` instead of `int | float` for parameter annotations.
-See [PEP 484](https://peps.python.org/pep-0484/#the-numeric-tower).
+Use ``float`` instead of ``int | float`` for parameter annotations. See :pep:`484` for more details.
 
 Language Features
 -----------------
@@ -723,7 +722,7 @@ older versions of Python.
 Platform-dependent APIs
 -----------------------
 
-Use platform checks like `if sys.platform == 'win32'` to denote platform-dependent APIs.
+Use :ref:`version-and-platform-checks<platform checks>` like ``if sys.platform == 'win32'`` to denote platform-dependent APIs.
 
 NamedTuple and TypedDict
 ------------------------
@@ -752,7 +751,7 @@ No::
 Built-in Generics
 -----------------
 
-:pep:`585` built-in generics (such as `list`, `dict`, `tuple`, `set`) are supported and should be used instead
+:pep:`585` built-in generics (such as ``list``, ``dict``, ``tuple``, ``set``) are supported and should be used instead
 of the corresponding types from ``typing``::
 
     from collections import defaultdict
@@ -770,7 +769,7 @@ generally possible and recommended::
 Unions
 ------
 
-Declaring unions with the shorthand `|` syntax is recommended and supported by
+Declaring unions with the shorthand ``|`` syntax is recommended and supported by
 all type checkers::
 
   def foo(x: int | str) -> int | None: ...  # recommended
@@ -778,22 +777,22 @@ all type checkers::
 
 .. _using-any:
 
-Using `Any` and `object`
-------------------------
+Using ``Any`` and ``object``
+----------------------------
 
-When adding type hints, avoid using the `Any` type when possible. Reserve
-the use of `Any` for when:
+When adding type hints, avoid using the ``Any`` type when possible. Reserve
+the use of ``Any`` for when:
 * the correct type cannot be expressed in the current type system; and
 * to avoid union returns (see above).
 
-Note that `Any` is not the correct type to use if you want to indicate
+Note that ``Any`` is not the correct type to use if you want to indicate
 that some function can accept literally anything: in those cases use
-`object` instead.
+``object`` instead.
 
-When using `Any`, document the reason for using it in a comment. Ideally,
+When using ``Any``, document the reason for using it in a comment. Ideally,
 document what types could be used.
 
-The `Any` Trick
+The ``Any`` Trick
 -----------------
 
 In cases where a function or method can return ``None``, but where forcing the
@@ -822,17 +821,17 @@ Context Managers
 ----------------
 
 When adding type annotations for context manager classes, annotate
-the return type of `__exit__` as bool only if the context manager
-sometimes suppresses exceptions -- if it sometimes returns `True`
+the return type of ``__exit__`` as bool only if the context manager
+sometimes suppresses exceptions -- if it sometimes returns ``True``
 at runtime. If the context manager never suppresses exceptions,
-have the return type be either `None` or `bool | None`. If you
+have the return type be either ``None`` or ``bool | None``. If you
 are not sure whether exceptions are suppressed or not or if the
-context manager is meant to be subclassed, pick `bool | None`.
+context manager is meant to be subclassed, pick ``bool | None``.
 See https://github.com/python/mypy/issues/7214 for more details.
 
-`__enter__` methods and other methods that return instances of the
-current class should be annotated with `typing_extensions.Self`
-([example](https://github.com/python/typeshed/blob/3581846/stdlib/contextlib.pyi#L151)).
+``__enter__`` methods and other methods that return ``self`` or ``cls(...)``
+should be annotated with the `typing.Self`
+(`example <https://github.com/python/typeshed/blob/3581846/stdlib/contextlib.pyi#L151>`_).
 
 Naming
 ------
@@ -845,29 +844,39 @@ A few guidelines for protocol names below. In cases that don't fall
 into any of those categories, use your best judgement.
 
 * Use plain names for protocols that represent a clear concept
-  (e.g. `Iterator`, `Container`).
-* Use `SupportsX` for protocols that provide callable methods (e.g.
-  `SupportsInt`, `SupportsRead`, `SupportsReadSeek`).
-* Use `HasX` for protocols that have readable and/or writable attributes
-  or getter/setter methods (e.g. `HasItems`, `HasFileno`).
+  (e.g. ``Iterator``, ``Container``).
+* Use ``SupportsX`` for protocols that provide callable methods (e.g.
+  ``SupportsInt``, ``SupportsRead``, ``SupportsReadSeek``).
+* Use ``HasX`` for protocols that have readable and/or writable attributes
+  or getter/setter methods (e.g. ``HasItems``, ``HasFileno``).
 
 .. _type-checker-error-suppression:
 
 Type Checker Error Suppression Formats
 --------------------------------------
 
-* Use mypy error codes for mypy-specific `# type: ignore` annotations, e.g. `# type: ignore[override]` for Liskov Substitution Principle violations.
-* Use pyright error codes for pyright-specific suppressions, e.g. `# pyright: ignore[reportGeneralTypeIssues]`.
-* If you need both on the same line, mypy's annotation needs to go first, e.g. `# type: ignore[override]  # pyright: ignore[reportGeneralTypeIssues]`.
+* Use mypy error codes for mypy-specific ``# type: ignore`` annotations, e.g. ``# type: ignore[override]`` for Liskov Substitution Principle violations.
+* Use pyright error codes for pyright-specific suppressions, e.g. ``# pyright: ignore[reportGeneralTypeIssues]``.
+* If you need both on the same line, mypy's annotation needs to go first, e.g. ``# type: ignore[override]  # pyright: ignore[reportGeneralTypeIssues]``.
 
 
-`@deprecated`
--------------
+``@deprecated``
+---------------
 
-The `@typing_extensions.deprecated` decorator (`@warnings.deprecated`
+The ``@typing_extensions.deprecated`` decorator (``@warnings.deprecated``
 since Python 3.13) can be used to mark deprecated functionality; see
-[PEP 702](https://peps.python.org/pep-0702/).
+:pep:`702`.
 
 Keep the deprecation message concise, but try to mention the projected
 version when the functionality is to be removed, and a suggested
 replacement.
+
+Docstrings
+----------
+
+There are several tradeoffs around including docstrings in type stubs. Consider the intended purpose
+of your stubs when deciding whether to include docstrings in your project's stubs.
+
+* They do not affect type checking results and will be ignored by type checkers.
+* Docstrings can improve certain IDE functionality, such as hover info.
+* Duplicating docstrings between source code and stubs requires extra work to keep them in sync.

--- a/docs/guides/writing_stubs.rst
+++ b/docs/guides/writing_stubs.rst
@@ -270,7 +270,7 @@ annotated function ``bar()``::
 ``Any`` vs. ``Incomplete``
 --------------------------
 
-While ``Incomplete`` is a type alias of ``Any``, they serve difference purposes:
+While ``Incomplete`` is a type alias of ``Any``, they serve different purposes:
 ``Incomplete`` is a placeholder where a proper type might be substituted.
 It's a "to do" item and should be replaced if possible.
 

--- a/docs/guides/writing_stubs.rst
+++ b/docs/guides/writing_stubs.rst
@@ -94,13 +94,9 @@ It may be instructive to examine `typeshed <https://github.com/python/typeshed/>
 `setup for testing stubs <https://github.com/python/typeshed/blob/main/tests/README.md>`__.
 
 To suppress type errors on stubs:
-* use mypy error codes for mypy-specific `# type: ignore` annotations,
-  e.g. `# type: ignore[override]` for Liskov Substitution Principle violations.
-* use pyright error codes for pyright-specific suppressions,
-  e.g. `# pyright: ignore[reportGeneralTypeIssues]`.
-  - pyright is configured to discard `# type: ignore` annotations.
-  If you need both on the same line, mypy's annotation needs to go first,
-  e.g. `# type: ignore[override]  # pyright: ignore[reportGeneralTypeIssues]`.
+* use mypy error codes for mypy-specific `# type: ignore` annotations, e.g. `# type: ignore[override]` for Liskov Substitution Principle violations.
+* use pyright error codes for pyright-specific suppressions, e.g. `# pyright: ignore[reportGeneralTypeIssues]`. Pyright is configured to discard `# type: ignore` annotations.
+* If you need both on the same line, mypy's annotation needs to go first, e.g. `# type: ignore[override]  # pyright: ignore[reportGeneralTypeIssues]`.
 
 ..
    TODO: consider adding examples and configurations for specific type checkers
@@ -146,6 +142,8 @@ The following should not be included in stubs:
 2. Modules that are not supposed to be imported, such as ``__main__.py``
 3. Protected modules that start with a single ``_`` char. However, when needed protected modules can still be added (see :ref:`undocumented-objects` section below)
 4. Tests
+
+.. _undocumented-objects:
 
 Undocumented Objects
 --------------------
@@ -532,7 +530,7 @@ Yes::
 
     class Color(Enum):
         # An assignment with no type annotation is a convention used to indicate
-	# an enum member.
+        # an enum member.
         RED = 1
 
 No::
@@ -770,10 +768,8 @@ Imports
 
 Imports in stubs are considered private (not part of the exported API)
 unless:
-* they use the form ``from library import name as name`` (sic, using
-  explicit ``as`` even if the name stays the same); or
-* they use the form ``from library import *`` which means all names
-  from that library are exported.
+* they use the form ``from library import name as name`` (sic, using explicit ``as`` even if the name stays the same); or
+* they use the form ``from library import *`` which means all names from that library are exported.
 
 Forward References
 ------------------

--- a/docs/guides/writing_stubs.rst
+++ b/docs/guides/writing_stubs.rst
@@ -93,10 +93,8 @@ Liskov substitutability or detecting problematic overloads.
 It may be instructive to examine `typeshed <https://github.com/python/typeshed/>`__'s
 `setup for testing stubs <https://github.com/python/typeshed/blob/main/tests/README.md>`__.
 
-To suppress type errors on stubs:
-* use mypy error codes for mypy-specific `# type: ignore` annotations, e.g. `# type: ignore[override]` for Liskov Substitution Principle violations.
-* use pyright error codes for pyright-specific suppressions, e.g. `# pyright: ignore[reportGeneralTypeIssues]`. Pyright is configured to discard `# type: ignore` annotations.
-* If you need both on the same line, mypy's annotation needs to go first, e.g. `# type: ignore[override]  # pyright: ignore[reportGeneralTypeIssues]`.
+To suppress type errors on stubs, use a `# type: ignore` comment. Refer to the style guide for
+error suppression formats specific to individual typecheckers.
 
 ..
    TODO: consider adding examples and configurations for specific type checkers
@@ -538,7 +536,7 @@ No::
 
     class Foo:  # leave only one empty line above
         x: int
-    class MyError(Exception): ...
+    class MyError(Exception): ...  # leave an empty line between the classes
 
 Module Level Attributes
 -----------------------
@@ -802,6 +800,14 @@ into any of those categories, use your best judgement.
 * Use `HasX` for protocols that have readable and/or writable attributes
   or getter/setter methods (e.g. `HasItems`, `HasFileno`).
 
+Type Checker Error Suppression formats
+--------------------------------------
+
+* Use mypy error codes for mypy-specific `# type: ignore` annotations, e.g. `# type: ignore[override]` for Liskov Substitution Principle violations.
+* Use pyright error codes for pyright-specific suppressions, e.g. `# pyright: ignore[reportGeneralTypeIssues]`. Pyright is configured to discard `# type: ignore` annotations.
+* If you need both on the same line, mypy's annotation needs to go first, e.g. `# type: ignore[override]  # pyright: ignore[reportGeneralTypeIssues]`.
+
+
 `@deprecated`
 -------------
 
@@ -809,30 +815,6 @@ The `@typing_extensions.deprecated` decorator (`@warnings.deprecated`
 since Python 3.13) can be used to mark deprecated functionality; see
 [PEP 702](https://peps.python.org/pep-0702/).
 
-A few guidelines for how to use it:
-
-* In the standard library, apply the decorator only in Python versions
-  where an appropriate replacement for the deprecated functionality
-  exists. If in doubt, apply the decorator only on versions where the
-  functionality has been explicitly deprecated, either through runtime
-  warnings or in the documentation. Use `if sys.version_info` checks to
-  apply the decorator only to some versions.
-* Keep the deprecation message concise, but try to mention the projected
-  version when the functionality is to be removed, and a suggested
-  replacement.
-
-Imports
--------
-
-Imports in stubs are considered private (not part of the exported API)
-unless:
-* they use the form ``from library import name as name`` (sic, using explicit ``as`` even if the name stays the same); or
-* they use the form ``from library import *`` which means all names from that library are exported.
-
-Forward References
-------------------
-
-Stub files support forward references natively. In other words, the
-order of class declarations and type aliases does not matter in
-a stub file. Unlike regular Python files, you can use the name of the class within its own
-body without writing it as a comment.
+Keep the deprecation message concise, but try to mention the projected
+version when the functionality is to be removed, and a suggested
+replacement.

--- a/docs/guides/writing_stubs.rst
+++ b/docs/guides/writing_stubs.rst
@@ -847,7 +847,7 @@ into any of those categories, use your best judgement.
 * Use `HasX` for protocols that have readable and/or writable attributes
   or getter/setter methods (e.g. `HasItems`, `HasFileno`).
 
-:: _type-checker-error-suppression:
+.. _type-checker-error-suppression:
 
 Type Checker Error Suppression Formats
 --------------------------------------

--- a/docs/guides/writing_stubs.rst
+++ b/docs/guides/writing_stubs.rst
@@ -215,7 +215,7 @@ Incomplete Stubs
 
 When writing new stubs, it is not necessary to fully annotate all arguments,
 return types, and fields. Some items may be left unannotated or
-annotated with `_typeshed.Incomplete` (`documentation <https://github.com/python/typeshed/blob/main/stdlib/_typeshed/README.md>`_).::
+annotated with ``_typeshed.Incomplete`` (`documentation <https://github.com/python/typeshed/blob/main/stdlib/_typeshed/README.md>`_)::
 
     from _typeshed import Incomplete
 
@@ -223,7 +223,7 @@ annotated with `_typeshed.Incomplete` (`documentation <https://github.com/python
 
     def foo(x): ...  # unannotated argument and return type
 
-`Incomplete` can also be used for partially known types::
+``_typeshed.Incomplete`` can also be used for partially known types::
 
     def foo(x: Incomplete | None = None) -> list[Incomplete]: ...
 
@@ -267,39 +267,16 @@ annotated function ``bar()``::
 
     def bar(x: str, y, *, z=...): ...
 
-`Any` vs. `Incomplete`
-----------------------
+``Any`` vs. ``Incomplete``
+--------------------------
 
-While `Incomplete` is a type alias of `Any`, they serve difference purposes:
-`Incomplete` is a placeholder where a proper type might be substituted.
-It's a "to do" item and should be replaced if possible. `Any` is used when
-it's not possible to accurately type an item using the current type system.
-It should be used sparingly.
+While ``Incomplete`` is a type alias of ``Any``, they serve difference purposes:
+``Incomplete`` is a placeholder where a proper type might be substituted.
+It's a "to do" item and should be replaced if possible.
 
-The `Any` trick
----------------
-
-In cases where a function or method can return `None`, but where forcing the
-user to explicitly check for `None` can be detrimental, use
-`_typeshed.MaybeNone` (an alias to `Any`), instead of `None`.
-
-Consider the following (simplified) signature of `re.Match[str].group`::
-
-    class Match:
-        def group(self, group: str | int, /) -> str | MaybeNone: ...
-
-This avoid forcing the user to check for `None`::
-
-    match = re.fullmatch(r"\d+_(.*)", some_string)
-    assert match is not None
-    name_group = match.group(1)  # The user knows that this will never be None
-    return name_group.uper()  # This typo will be flagged by the type checker
-
-In this case, the user of `match.group()` must be prepared to handle a `str`,
-but type checkers are happy with `if name_group is None` checks, because we're
-saying it can also be something else than an `str`.
-
-This is sometimes called "the Any trick".
+``Any`` is used when it's not possible to accurately type an item using the current
+type system. It should be used sparingly, as described in the :ref:`using-any`
+section of the style guide.
 
 Attribute Access
 ----------------
@@ -799,6 +776,8 @@ all type checkers::
   def foo(x: int | str) -> int | None: ...  # recommended
   def foo(x: Union[int, str]) -> Optional[int]: ...  # ok
 
+.. _using-any:
+
 Using `Any` and `object`
 ------------------------
 
@@ -813,6 +792,31 @@ that some function can accept literally anything: in those cases use
 
 When using `Any`, document the reason for using it in a comment. Ideally,
 document what types could be used.
+
+The `Any` Trick
+-----------------
+
+In cases where a function or method can return ``None``, but where forcing the
+user to explicitly check for ``None`` can be detrimental, use
+``_typeshed.MaybeNone`` (an alias to ``Any``), instead of ``None``.
+
+Consider the following (simplified) signature of ``re.Match[str].group``::
+
+    class Match:
+        def group(self, group: str | int, /) -> str | MaybeNone: ...
+
+This avoid forcing the user to check for ``None``::
+
+    match = re.fullmatch(r"\d+_(.*)", some_string)
+    assert match is not None
+    name_group = match.group(1)  # The user knows that this will never be None
+    return name_group.uper()  # This typo will be flagged by the type checker
+
+In this case, the user of ``match.group()`` must be prepared to handle a ``str``,
+but type checkers are happy with ``if name_group is None`` checks, because we're
+saying it can also be something else than an ``str``.
+
+This is sometimes called "the Any trick".
 
 Context Managers
 ----------------

--- a/docs/guides/writing_stubs.rst
+++ b/docs/guides/writing_stubs.rst
@@ -722,7 +722,7 @@ older versions of Python.
 Platform-dependent APIs
 -----------------------
 
-Use :ref:`version-and-platform-checks<platform checks>` like ``if sys.platform == 'win32'`` to denote platform-dependent APIs.
+Use :ref:`platform checks<version-and-platform-checks>` like ``if sys.platform == 'win32'`` to denote platform-dependent APIs.
 
 NamedTuple and TypedDict
 ------------------------

--- a/docs/guides/writing_stubs.rst
+++ b/docs/guides/writing_stubs.rst
@@ -804,7 +804,7 @@ Type Checker Error Suppression formats
 --------------------------------------
 
 * Use mypy error codes for mypy-specific `# type: ignore` annotations, e.g. `# type: ignore[override]` for Liskov Substitution Principle violations.
-* Use pyright error codes for pyright-specific suppressions, e.g. `# pyright: ignore[reportGeneralTypeIssues]`. Pyright is configured to discard `# type: ignore` annotations.
+* Use pyright error codes for pyright-specific suppressions, e.g. `# pyright: ignore[reportGeneralTypeIssues]`.
 * If you need both on the same line, mypy's annotation needs to go first, e.g. `# type: ignore[override]  # pyright: ignore[reportGeneralTypeIssues]`.
 
 


### PR DESCRIPTION
This PR merges non-typeshed-specific content on writing stubs into main typing guide.

https://github.com/python/typeshed/blob/main/CONTRIBUTING.md

This would let us reference this guide from typeshed's CONTRIBUTING.md and delete the duplicate sections.

https://github.com/python/typing/issues/1880