### PR TITLE
Specs clarification: Forbid `ClassVar` and `Final` within `TypedDict` body

### DIFF
--- a/docs/spec/class-compat.rst
+++ b/docs/spec/class-compat.rst
@@ -89,6 +89,10 @@ annotated in ``__init__`` or other methods, rather than in the class::
       def __init__(self, content):
           self.content: T = content
 
+``ClassVar`` cannot be used as a qualifier for a :ref:`TypedDict <typeddict>`
+item or a :ref:`NamedTuple <namedtuple>`field. Such usages are also hard
+errors at runtime.
+
 .. _`override`:
 
 ``@override``

--- a/docs/spec/class-compat.rst
+++ b/docs/spec/class-compat.rst
@@ -90,7 +90,7 @@ annotated in ``__init__`` or other methods, rather than in the class::
           self.content: T = content
 
 ``ClassVar`` cannot be used as a qualifier for a :ref:`TypedDict <typeddict>`
-item or a :ref:`NamedTuple <namedtuple>`field. Such usages are also hard
+item or a :ref:`NamedTuple <namedtuple>` field. Such usages are also hard
 errors at runtime.
 
 .. _`override`:

--- a/docs/spec/class-compat.rst
+++ b/docs/spec/class-compat.rst
@@ -90,8 +90,8 @@ annotated in ``__init__`` or other methods, rather than in the class::
           self.content: T = content
 
 ``ClassVar`` cannot be used as a qualifier for a :ref:`TypedDict <typeddict>`
-item or a :ref:`NamedTuple <namedtuple>` field. Such usages are also hard
-errors at runtime.
+item or a :ref:`NamedTuple <namedtuple>` field. Such usage also generates
+an error at runtime.
 
 .. _`override`:
 

--- a/docs/spec/qualifiers.rst
+++ b/docs/spec/qualifiers.rst
@@ -203,6 +203,10 @@ following should be allowed::
    Y: Final = "y"
    N = NamedTuple("N", [(X, int), (Y, int)])
 
+``Final`` cannot be used as a qualifier for a :ref:`TypedDict <typeddict>`
+item or a :ref:`NamedTuple <namedtuple>`field. Such usages are also hard
+errors at runtime.
+
 .. _`annotated`:
 
 ``Annotated``

--- a/docs/spec/qualifiers.rst
+++ b/docs/spec/qualifiers.rst
@@ -204,8 +204,8 @@ following should be allowed::
    N = NamedTuple("N", [(X, int), (Y, int)])
 
 ``Final`` cannot be used as a qualifier for a :ref:`TypedDict <typeddict>`
-item or a :ref:`NamedTuple <namedtuple>` field. Such usages are also hard
-errors at runtime.
+item or a :ref:`NamedTuple <namedtuple>` field. Such usage also generates
+an error at runtime.
 
 .. _`annotated`:
 

--- a/docs/spec/qualifiers.rst
+++ b/docs/spec/qualifiers.rst
@@ -204,7 +204,7 @@ following should be allowed::
    N = NamedTuple("N", [(X, int), (Y, int)])
 
 ``Final`` cannot be used as a qualifier for a :ref:`TypedDict <typeddict>`
-item or a :ref:`NamedTuple <namedtuple>`field. Such usages are also hard
+item or a :ref:`NamedTuple <namedtuple>` field. Such usages are also hard
 errors at runtime.
 
 .. _`annotated`:

--- a/docs/spec/typeddict.rst
+++ b/docs/spec/typeddict.rst
@@ -508,13 +508,6 @@ make type declarations self-contained, and to simplify the
 implementation of type checkers.
 
 
-ClassVar and Final items
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-``ClassVar`` and ``Final`` are not allowed as qualifiers for an item
-of a ``TypedDict``. Such an item also causes a hard error at runtime.
-
-
 Backwards Compatibility
 ^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/spec/typeddict.rst
+++ b/docs/spec/typeddict.rst
@@ -508,6 +508,13 @@ make type declarations self-contained, and to simplify the
 implementation of type checkers.
 
 
+ClassVar and Final items
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+``ClassVar`` and ``Final`` are not allowed as qualifiers for an item
+of a ``TypedDict``. Such an item also causes a hard error at runtime.
+
+
 Backwards Compatibility
 ^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
* Discussion: <i>[What does it mean for a `TypedDict` to have a `ClassVar` field?](https://discuss.python.org/t/72880)</i>
* Typing council issue: [#39: <i>Typing spec update: `ClassVar` and `Final` within `TypedDict`</i>](https://github.com/python/typing-council/issues/39)

At runtime, both `ClassVar` and `Final` are not recognized as valid qualifiers for `TypedDict` items:

```pycon
>>> from typing import TypedDict, ClassVar, Final
>>> class D(TypedDict):
...     a: ClassVar[int]
...
[truncated]
TypeError: typing.ClassVar[int] is not valid as type argument
>>> class D(TypedDict):
...     a: Final[int]
...
[truncated]
TypeError: typing.Final[int] is not valid as type argument
```