### PR TITLE
Glossary: Clarify which types don't participate in subtyping

### DIFF
--- a/docs/spec/glossary.rst
+++ b/docs/spec/glossary.rst
@@ -65,11 +65,7 @@ This section defines a few terms that may be used elsewhere in the specification
       primary gradual form is :ref:`Any`. The ellipsis (``...``) is a gradual
       form in some, but not all, contexts. It is a gradual form when used in a
       :ref:`Callable` type, and when used in ``tuple[Any, ...]`` (but not in
-      other :ref:`tuple <tuples>` types). Types that contain gradual forms do not participate
-      in the :term:`subtype` relation, but they do participate in
-      :term:`consistency <consistent>` and :term:`assignability <assignable>`.
-      They can be :term:`materialized <materialize>` to a more static, or fully static,
-      type. See :ref:`type-system-concepts`.
+      other :ref:`tuple <tuples>` types).
 
    gradual type
       All types in the Python type system are "gradual". A gradual type may be
@@ -77,7 +73,11 @@ This section defines a few terms that may be used elsewhere in the specification
       contains ``Any`` or another :term:`gradual form`. A gradual type does not
       necessarily represent a single set of possible runtime values; instead it
       can represent a set of possible static types (a set of possible sets of
-      possible runtime values).
+      possible runtime values). Gradual types which are not fully static do not
+      participate in the :term:`subtype` relation, but they do participate in
+      :term:`consistency <consistent>` and :term:`assignability <assignable>`.
+      They can be :term:`materialized <materialize>` to a more static, or fully static,
+      type. See :ref:`type-system-concepts`.
 
    inline
       Inline type annotations are annotations that are included in the

--- a/docs/spec/glossary.rst
+++ b/docs/spec/glossary.rst
@@ -65,7 +65,11 @@ This section defines a few terms that may be used elsewhere in the specification
       primary gradual form is :ref:`Any`. The ellipsis (``...``) is a gradual
       form in some, but not all, contexts. It is a gradual form when used in a
       :ref:`Callable` type, and when used in ``tuple[Any, ...]`` (but not in
-      other :ref:`tuple <tuples>` types).
+      other :ref:`tuple <tuples>` types). Types that contain gradual forms do not participate
+      in the :term:`subtype` relation, but they do participate in
+      :term:`consistency <consistent>` and :term:`assignability <assignable>`.
+      They can be :term:`materialized <materialize>` to a more static, or fully static,
+      type. See :ref:`type-system-concepts`.
 
    gradual type
       All types in the Python type system are "gradual". A gradual type may be
@@ -73,11 +77,7 @@ This section defines a few terms that may be used elsewhere in the specification
       contains ``Any`` or another :term:`gradual form`. A gradual type does not
       necessarily represent a single set of possible runtime values; instead it
       can represent a set of possible static types (a set of possible sets of
-      possible runtime values). Gradual types do not participate in the
-      :term:`subtype` relation, but they do participate in :term:`consistency
-      <consistent>` and :term:`assignability <assignable>`. They can be
-      :term:`materialized <materialize>` to a more static, or fully static,
-      type. See :ref:`type-system-concepts`.
+      possible runtime values).
 
    inline
       Inline type annotations are annotations that are included in the


### PR DESCRIPTION
The existing definition of gradual types implies that no type in the Python type system participates in the subtype relation.

I moved the fragment that introduced the contradiction to the definition of gradual forms, as that is likely a better place for it (facts about types that contain gradual forms aren't inherently about gradual types as a whole).