### PR TITLE
Fix a type error in generics

### DIFF
--- a/docs/spec/generics.rst
+++ b/docs/spec/generics.rst
@@ -1071,7 +1071,7 @@ outer ``Callable``.  This has the following semantics:
 .. code-block::
 
    def a_int_b_str(a: int, b: str) -> int:
-     pass
+     return a
 
    twice(a_int_b_str, 1, "A")       # Accepted
 


### PR DESCRIPTION
The function says it returns an `int`, but used `pass` so returned `None`. Fix by returning the `a` argument which is of type `int`.