### PR TITLE
Allowed bare `typing.Final` in an annotation expression

### DIFF
--- a/docs/spec/annotations.rst
+++ b/docs/spec/annotations.rst
@@ -110,7 +110,7 @@ The following grammar describes the allowed elements of type and annotation expr
                          : | <NotRequired> '[' `annotation_expression` ']'
                          : | <ReadOnly> '[' `annotation_expression`']'
                          : | <ClassVar> '[' `annotation_expression`']'
-                         : | <Final> '[' `annotation_expression`']'
+                         : | <Final> ('[' `annotation_expression`']')?
                          : | <InitVar> '[' `annotation_expression` ']'
                          : | <Annotated> '[' `annotation_expression` ','
                          :               expression (',' expression)* ']'


### PR DESCRIPTION
The current grammar only allows `typing.Final[...]`, but not `typing.Final`.