### PR TITLE
Updated conformance tests for pyright 1.1.394.

### DIFF
--- a/conformance/results/mypy/annotations_generators.toml
+++ b/conformance/results/mypy/annotations_generators.toml
@@ -11,12 +11,12 @@ annotations_generators.py:71: error: No return value expected  [return-value]
 annotations_generators.py:75: error: Incompatible types in "yield" (actual type "B", expected type "A")  [misc]
 annotations_generators.py:86: error: The return type of a generator function should be "Generator" or one of its supertypes  [misc]
 annotations_generators.py:91: error: The return type of an async generator function should be "AsyncGenerator" or one of its supertypes  [misc]
-annotations_generators.py:118: error: Incompatible types in "yield from" (actual type "A", expected type "B")  [misc]
-annotations_generators.py:119: error: Incompatible types in "yield from" (actual type "int", expected type "B")  [misc]
+annotations_generators.py:116: error: Incompatible types in "yield from" (actual type "A", expected type "B")  [misc]
+annotations_generators.py:117: error: Incompatible types in "yield from" (actual type "int", expected type "B")  [misc]
 """
 conformance_automated = "Fail"
 errors_diff = """
 Line 87: Expected 1 errors
 Line 92: Expected 1 errors
-Line 135: Expected 1 errors
+Line 133: Expected 1 errors
 """

--- a/conformance/results/mypy/version.toml
+++ b/conformance/results/mypy/version.toml
@@ -1,2 +1,2 @@
 version = "mypy 1.15.0"
-test_duration = 1.2
+test_duration = 1.8

--- a/conformance/results/pyre/annotations_generators.toml
+++ b/conformance/results/pyre/annotations_generators.toml
@@ -12,15 +12,15 @@ annotations_generators.py:87:4 Incompatible return type [7]: Expected `int` but 
 annotations_generators.py:88:4 Incompatible return type [7]: Expected `int` but got `Generator[typing.Any, typing.Any, int]`.
 annotations_generators.py:91:0 Incompatible async generator return type [57]: Expected return annotation to be AsyncGenerator or a superclass but got `int`.
 annotations_generators.py:92:4 Incompatible return type [7]: Expected `int` but got `AsyncGenerator[None, typing.Any]`.
-annotations_generators.py:118:4 Incompatible return type [7]: Expected `Iterator[B]` but got `Generator[A, None, typing.Any]`.
-annotations_generators.py:119:4 Incompatible return type [7]: Expected `Iterator[B]` but got `Generator[int, None, typing.Any]`.
-annotations_generators.py:135:4 Incompatible return type [7]: Expected `Generator[None, str, None]` but got `Generator[None, int, typing.Any]`.
-annotations_generators.py:182:0 Assert type [70]: Expected `typing.Callable[[], Coroutine[typing.Any, typing.Any, AsyncIterator[int]]]` but got `typing.Callable(generator29)[[], AsyncIterator[int]]`.
+annotations_generators.py:116:4 Incompatible return type [7]: Expected `Iterator[B]` but got `Generator[A, None, typing.Any]`.
+annotations_generators.py:117:4 Incompatible return type [7]: Expected `Iterator[B]` but got `Generator[int, None, typing.Any]`.
+annotations_generators.py:133:4 Incompatible return type [7]: Expected `Generator[None, str, None]` but got `Generator[None, int, typing.Any]`.
+annotations_generators.py:183:0 Incompatible variable type [9]: v1 is declared to have type `typing.Callable[[], Coroutine[typing.Any, typing.Any, AsyncIterator[int]]]` but is used as type `typing.Callable(generator29)[[], AsyncIterator[int]]`.
 """
 conformance_automated = "Fail"
 errors_diff = """
 Line 51: Expected 1 errors
 Line 86: Expected 1 errors
 Line 88: Unexpected errors ['annotations_generators.py:88:4 Incompatible return type [7]: Expected `int` but got `Generator[typing.Any, typing.Any, int]`.']
-Line 182: Unexpected errors ['annotations_generators.py:182:0 Assert type [70]: Expected `typing.Callable[[], Coroutine[typing.Any, typing.Any, AsyncIterator[int]]]` but got `typing.Callable(generator29)[[], AsyncIterator[int]]`.']
+Line 183: Unexpected errors ['annotations_generators.py:183:0 Incompatible variable type [9]: v1 is declared to have type `typing.Callable[[], Coroutine[typing.Any, typing.Any, AsyncIterator[int]]]` but is used as type `typing.Callable(generator29)[[], AsyncIterator[int]]`.']
 """

--- a/conformance/results/pyre/version.toml
+++ b/conformance/results/pyre/version.toml
@@ -1,2 +1,2 @@
 version = "pyre 0.9.23"
-test_duration = 7.8
+test_duration = 6.5

--- a/conformance/results/pyright/annotations_generators.toml
+++ b/conformance/results/pyright/annotations_generators.toml
@@ -18,15 +18,15 @@ annotations_generators.py:91:27 - error: Return type of async generator function
   "AsyncGenerator[Any, Any, Any]" is not assignable to "int" (reportInvalidTypeForm)
 annotations_generators.py:92:11 - error: Return type of async generator function must be compatible with "AsyncGenerator[None, Any]"
   "AsyncGenerator[None, Unknown, Unknown]" is not assignable to "int" (reportReturnType)
-annotations_generators.py:118:16 - error: Return type of generator function must be compatible with "Generator[A, Any, Any]"
+annotations_generators.py:116:16 - error: Return type of generator function must be compatible with "Generator[A, Any, Any]"
   "Generator[A, Unknown, Unknown]" is not assignable to "Iterator[B]"
     Type parameter "_T_co@Iterator" is covariant, but "A" is not a subtype of "B"
       "A" is not assignable to "B" (reportReturnType)
-annotations_generators.py:119:16 - error: Return type of generator function must be compatible with "Generator[int, Any, Any]"
+annotations_generators.py:117:16 - error: Return type of generator function must be compatible with "Generator[int, Any, Any]"
   "Generator[int, Unknown, Unknown]" is not assignable to "Iterator[B]"
     Type parameter "_T_co@Iterator" is covariant, but "int" is not a subtype of "B"
       "int" is not assignable to "B" (reportReturnType)
-annotations_generators.py:135:16 - error: Return type of generator function must be compatible with "Generator[None, Any, Any]"
+annotations_generators.py:133:16 - error: Return type of generator function must be compatible with "Generator[None, Any, Any]"
   "Generator[None, int, Unknown]" is not assignable to "Generator[None, str, None]"
     Type parameter "_SendT_contra@Generator" is contravariant, but "int" is not a supertype of "str"
       "str" is not assignable to "int" (reportReturnType)

--- a/conformance/results/pyright/callables_kwargs.toml
+++ b/conformance/results/pyright/callables_kwargs.toml
@@ -1,7 +1,4 @@
 conformant = "Partial"
-notes = """
-Allows callable without kwargs to be assigned to callable with unpacked kwargs
-"""
 output = """
 callables_kwargs.py:28:5 - error: Could not access item in TypedDict
   "v2" is not a required key in "TD2", so access may result in runtime exception (reportTypedDictNotRequiredAccess)
@@ -30,8 +27,10 @@ callables_kwargs.py:103:19 - error: Type "(**kwargs: **TD2) -> None" is not assi
       Extra parameter "v3" (reportAssignmentType)
 callables_kwargs.py:111:30 - error: Typed dictionary overlaps with keyword parameter: v1 (reportGeneralTypeIssues)
 callables_kwargs.py:122:21 - error: Expected TypedDict type argument for Unpack (reportGeneralTypeIssues)
+callables_kwargs.py:134:19 - error: Type "(*, v1: int, v3: str, v2: str = "") -> None" is not assignable to declared type "TDProtocol6"
+  Type "(*, v1: int, v3: str, v2: str = "") -> None" is not assignable to type "(**kwargs: **TD2) -> None"
+    Parameter "**kwargs" has no corresponding parameter (reportAssignmentType)
 """
-conformance_automated = "Fail"
+conformance_automated = "Pass"
 errors_diff = """
-Line 134: Expected 1 errors
 """

--- a/conformance/results/pyright/version.toml
+++ b/conformance/results/pyright/version.toml
@@ -1,2 +1,2 @@
-version = "pyright 1.1.393"
-test_duration = 1.4
+version = "pyright 1.1.394"
+test_duration = 1.3

--- a/conformance/results/pytype/annotations_generators.toml
+++ b/conformance/results/pytype/annotations_generators.toml
@@ -46,26 +46,26 @@ async def generator9() -> int:  # E: incompatible return type
     yield None  # E
 \u001b[1m\u001b[31m~~~~~~~~~~~~~~\u001b[39m\u001b[0m
 
-annotations_generators.py:100:1: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in <module>: Bad return type 'IntIterator' for generator function generator15 [bad-yield-annotation]
+annotations_generators.py:99:1: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in <module>: Bad return type 'IntIterator' for generator function generator15 [bad-yield-annotation]
 
 def generator15() -> IntIterator:  # OK
 \u001b[1m\u001b[31m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
     yield 0
 \u001b[1m\u001b[31m~~~~~~~~~~~\u001b[39m\u001b[0m
 
-annotations_generators.py:109:1: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in <module>: Bad return type 'AsyncIntIterator' for async generator function generator16 [bad-yield-annotation]
+annotations_generators.py:107:1: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in <module>: Bad return type 'AsyncIntIterator' for async generator function generator16 [bad-yield-annotation]
 
 async def generator16() -> AsyncIntIterator:  # OK
 \u001b[1m\u001b[31m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
     yield 0
 \u001b[1m\u001b[31m~~~~~~~~~~~\u001b[39m\u001b[0m
 
-annotations_generators.py:118:5: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in generator18: bad return type [bad-return-type]
+annotations_generators.py:116:5: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in generator18: bad return type [bad-return-type]
 
     yield from generator17()  # E: incompatible generator type
     \u001b[1m\u001b[31m~~~~~~~~~~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
 
-annotations_generators.py:119:5: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in generator18: bad return type [bad-return-type]
+annotations_generators.py:117:5: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in generator18: bad return type [bad-return-type]
 
     yield from [1]  # E: incompatible generator type
     \u001b[1m\u001b[31m~~~~~~~~~~~~~~\u001b[39m\u001b[0m
@@ -76,7 +76,7 @@ errors_diff = """
 Line 51: Expected 1 errors
 Line 87: Expected 1 errors
 Line 92: Expected 1 errors
-Line 135: Expected 1 errors
-Line 100: Unexpected errors ["annotations_generators.py:100:1: \\x1b[1m\\x1b[31merror\\x1b[39m\\x1b[0m: in <module>: Bad return type 'IntIterator' for generator function generator15 [bad-yield-annotation]"]
-Line 109: Unexpected errors ["annotations_generators.py:109:1: \\x1b[1m\\x1b[31merror\\x1b[39m\\x1b[0m: in <module>: Bad return type 'AsyncIntIterator' for async generator function generator16 [bad-yield-annotation]"]
+Line 133: Expected 1 errors
+Line 99: Unexpected errors ["annotations_generators.py:99:1: \\x1b[1m\\x1b[31merror\\x1b[39m\\x1b[0m: in <module>: Bad return type 'IntIterator' for generator function generator15 [bad-yield-annotation]"]
+Line 107: Unexpected errors ["annotations_generators.py:107:1: \\x1b[1m\\x1b[31merror\\x1b[39m\\x1b[0m: in <module>: Bad return type 'AsyncIntIterator' for async generator function generator16 [bad-yield-annotation]"]
 """

--- a/conformance/results/pytype/version.toml
+++ b/conformance/results/pytype/version.toml
@@ -1,2 +1,2 @@
 version = "pytype 2024.10.11"
-test_duration = 36.6
+test_duration = 34.9

--- a/conformance/results/results.html
+++ b/conformance/results/results.html
@@ -159,16 +159,16 @@
         <div class="table_container"><table><tbody>
 <tr><th class="col1">&nbsp;</th>
 <th class='tc-header'><div class='tc-name'>mypy 1.15.0</div>
-<div class='tc-time'>1.2sec</div>
+<div class='tc-time'>1.8sec</div>
 </th>
-<th class='tc-header'><div class='tc-name'>pyright 1.1.393</div>
-<div class='tc-time'>1.4sec</div>
+<th class='tc-header'><div class='tc-name'>pyright 1.1.394</div>
+<div class='tc-time'>1.3sec</div>
 </th>
 <th class='tc-header'><div class='tc-name'>pyre 0.9.23</div>
-<div class='tc-time'>7.8sec</div>
+<div class='tc-time'>6.5sec</div>
 </th>
 <th class='tc-header'><div class='tc-name'>pytype 2024.10.11</div>
-<div class='tc-time'>36.6sec</div>
+<div class='tc-time'>34.9sec</div>
 </th>
 </tr>
 <tr><th class="column" colspan="5">
@@ -608,7 +608,7 @@
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;callables_kwargs</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Allows callable without kwargs to be assigned to callable with unpacked kwargs</p></span></div></th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Allows callable without kwargs to be assigned to callable with unpacked kwargs</p></span></div></th>
+<th class="column col2 partially-conformant">Partial</th>
 <th class="column col2 conformant">Pass</th>
 <th class="column col2 not-conformant"><div class="hover-text">Unsupported<span class="tooltip-text" id="bottom"><p>Does not understand Unpack in the context of **kwargs annotation.</p></span></div></th>
 </tr>

--- a/conformance/tests/annotations_coroutines.py
+++ b/conformance/tests/annotations_coroutines.py
@@ -16,7 +16,10 @@ async def func1(ignored: int, /) -> str:
     return "spam"
 
 
-assert_type(func1, Callable[[int], Coroutine[Any, Any, str]])
+# Don't use assert_type here because some type checkers infer
+# the narrower type types.CoroutineType rather than typing.Coroutine
+# in this case.
+v1: Callable[[int], Coroutine[Any, Any, str]] = func1
 
 
 async def func2() -> None:

--- a/conformance/tests/annotations_generators.py
+++ b/conformance/tests/annotations_generators.py
@@ -179,7 +179,10 @@ async def generator29() -> AsyncIterator[int]:
     raise NotImplementedError
 
 
-assert_type(generator29, Callable[[], Coroutine[Any, Any, AsyncIterator[int]]])
+# Don't use assert_type here because some type checkers infer
+# the narrower type types.CoroutineType rather than typing.Coroutine
+# in this case.
+v1: Callable[[], Coroutine[Any, Any, AsyncIterator[int]]] = generator29
 
 
 async def generator30() -> AsyncIterator[int]:


### PR DESCRIPTION
This version of pyright fixes a conformance issue detected by the `callables_kwargs` test. Also updated the `annotations_generatosr` and `annotations_coroutines` test cases to accommodate a more precise (narrower) type inferred for `async def` functions. Pyright now infers `types.CoroutineType` rather than `typing.Coroutine`. Both are correct and should be accepted by the test.