### PR TITLE
Fixed manual scoring results for conformance report

### DIFF
--- a/conformance/results/pyright/callables_kwargs.toml
+++ b/conformance/results/pyright/callables_kwargs.toml
@@ -1,4 +1,4 @@
-conformant = "Partial"
+conformant = "Pass"
 output = """
 callables_kwargs.py:28:5 - error: Could not access item in TypedDict
   "v2" is not a required key in "TD2", so access may result in runtime exception (reportTypedDictNotRequiredAccess)

--- a/conformance/results/results.html
+++ b/conformance/results/results.html
@@ -608,7 +608,7 @@
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;callables_kwargs</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Allows callable without kwargs to be assigned to callable with unpacked kwargs</p></span></div></th>
-<th class="column col2 partially-conformant">Partial</th>
+<th class="column col2 conformant">Pass</th>
 <th class="column col2 conformant">Pass</th>
 <th class="column col2 not-conformant"><div class="hover-text">Unsupported<span class="tooltip-text" id="bottom"><p>Does not understand Unpack in the context of **kwargs annotation.</p></span></div></th>
 </tr>


### PR DESCRIPTION
I forgot to make this change in the previous commit.