### PR TITLE
Update URLs to typing.python.org

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation-issue.md
+++ b/.github/ISSUE_TEMPLATE/documentation-issue.md
@@ -1,6 +1,6 @@
 ---
 name: Documentation issue
-about: Report a problem or suggest changes for the documentation at https://typing.readthedocs.io/
+about: Report a problem or suggest changes for the documentation at https://typing.python.org/
 title: ''
 labels: 'topic: documentation'
 assignees: ''

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Documentation and Support
 
 The documentation for Python's static typing can be found at
-[typing.readthedocs.io](https://typing.readthedocs.io/). You can get
+[typing.python.org](https://typing.python.org/). You can get
 help in our [support forum](https://github.com/python/typing/discussions).
 
 Improvements to the type system should be discussed on
@@ -20,10 +20,10 @@ For conversations that are more suitable to a chat platform, you can use one of 
 
 This GitHub repository is used for several things:
 
-- The documentation at [typing.readthedocs.io](https://typing.readthedocs.io/)
+- The documentation at [typing.python.org](https://typing.python.org/)
   is maintained in the [docs directory](./docs). This includes the
-  [specification](https://typing.readthedocs.io/en/latest/spec/index.html) for the
-  type system. See especially [the update procedure](https://typing.readthedocs.io/en/latest/spec/meta.html)
+  [specification](https://typing.python.org/en/latest/spec/index.html) for the
+  type system. See especially [the update procedure](https://typing.python.org/en/latest/spec/meta.html)
   for the spec.
 
 - A [discussion forum](https://github.com/python/typing/discussions) for typing-related user

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -2,7 +2,7 @@
 
 ## Motivation
 
-[PEP 729](https://peps.python.org/pep-0729/) provides a structured and documented way to specify and evolve the Python type system. In support of this effort, an official [Python typing spec](https://github.com/python/typing/tree/main/docs/spec) has been drafted. This spec consolidates details from various historical typing-related PEPs. The spec will be modified over time to clarify unspecified and under-specified parts of the type system. It will also be extended to cover new features of the type system.
+[PEP 729](https://peps.python.org/pep-0729/) provides a structured and documented way to specify and evolve the Python type system. In support of this effort, an official [Python typing spec](https://typing.python.org/en/latest/spec/) has been drafted. This spec consolidates details from various historical typing-related PEPs. The spec will be modified over time to clarify unspecified and under-specified parts of the type system. It will also be extended to cover new features of the type system.
 
 Accompanying the typing specification is this conformance test suite which validates the behavior of static type checkers against the specification.
 
@@ -10,26 +10,26 @@ Accompanying the typing specification is this conformance test suite which valid
 
 This project contains test cases for behaviors defined in the Python typing spec. Tests are structured and grouped in accordance with the specification's chapter headings.
 
-* [concepts](https://typing.readthedocs.io/en/latest/spec/concepts.html)
-* [annotations](https://typing.readthedocs.io/en/latest/spec/annotations.html)
-* [specialtypes](https://typing.readthedocs.io/en/latest/spec/special-types.html)
-* [generics](https://typing.readthedocs.io/en/latest/spec/generics.html)
-* [qualifiers](https://typing.readthedocs.io/en/latest/spec/qualifiers.html)
-* [classes](https://typing.readthedocs.io/en/latest/spec/class-compat.html)
-* [aliases](https://typing.readthedocs.io/en/latest/spec/aliases.html)
-* [literals](https://typing.readthedocs.io/en/latest/spec/literal.html)
-* [protocols](https://typing.readthedocs.io/en/latest/spec/protocol.html)
-* [callables](https://typing.readthedocs.io/en/latest/spec/callables.html)
-* [constructors](https://typing.readthedocs.io/en/latest/spec/constructors.html)
-* [overloads](https://typing.readthedocs.io/en/latest/spec/overload.html)
-* [dataclasses](https://typing.readthedocs.io/en/latest/spec/dataclasses.html)
-* [typeddicts](https://typing.readthedocs.io/en/latest/spec/typeddict.html)
-* [tuples](https://typing.readthedocs.io/en/latest/spec/tuples.html)
-* [namedtuples](https://typing.readthedocs.io/en/latest/spec/namedtuples.html)
-* [narrowing](https://typing.readthedocs.io/en/latest/spec/narrowing.html)
-* [directives](https://typing.readthedocs.io/en/latest/spec/directives.html)
-* [distribution](https://typing.readthedocs.io/en/latest/spec/distributing.html)
-* [historical](https://typing.readthedocs.io/en/latest/spec/historical.html)
+* [concepts](https://typing.python.org/en/latest/spec/concepts.html)
+* [annotations](https://typing.python.org/en/latest/spec/annotations.html)
+* [specialtypes](https://typing.python.org/en/latest/spec/special-types.html)
+* [generics](https://typing.python.org/en/latest/spec/generics.html)
+* [qualifiers](https://typing.python.org/en/latest/spec/qualifiers.html)
+* [classes](https://typing.python.org/en/latest/spec/class-compat.html)
+* [aliases](https://typing.python.org/en/latest/spec/aliases.html)
+* [literals](https://typing.python.org/en/latest/spec/literal.html)
+* [protocols](https://typing.python.org/en/latest/spec/protocol.html)
+* [callables](https://typing.python.org/en/latest/spec/callables.html)
+* [constructors](https://typing.python.org/en/latest/spec/constructors.html)
+* [overloads](https://typing.python.org/en/latest/spec/overload.html)
+* [dataclasses](https://typing.python.org/en/latest/spec/dataclasses.html)
+* [typeddicts](https://typing.python.org/en/latest/spec/typeddict.html)
+* [tuples](https://typing.python.org/en/latest/spec/tuples.html)
+* [namedtuples](https://typing.python.org/en/latest/spec/namedtuples.html)
+* [narrowing](https://typing.python.org/en/latest/spec/narrowing.html)
+* [directives](https://typing.python.org/en/latest/spec/directives.html)
+* [distribution](https://typing.python.org/en/latest/spec/distributing.html)
+* [historical](https://typing.python.org/en/latest/spec/historical.html)
 
 A test file is a ".py" file. The file name should start with one of the above names followed by a description of the test (with words separated by underscores). For example, `generics_paramspec_basic_usage.py` would contain the basic usage tests for `ParamSpec`. Each test file can contain multiple individual unit tests, but these tests should be related to each other. If the number of unit tests in a single test file exceeds ten, it may be desirable to split it into separate test files. This will help maintain a consistent level of granularity across tests.
 

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -5,7 +5,7 @@ Reading the docs
 =================
 
 The live documentation for Python's static typing can be found at
-`typing.readthedocs.io <https://typing.readthedocs.io/>`_.
+`typing.python.org <https://typing.python.org/>`_.
 
 Building the docs
 =================


### PR DESCRIPTION
@EricTraut The conformance tests also reference typing.readthedocs.io (a lot). I've left those alone for now, since I'm not whether just replacing the links there would work.