### PR TITLE
Print URL after building docs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -29,6 +29,8 @@ build:
 html: BUILDER = html
 html: build
 	@echo "Build finished. The HTML pages are in build/html."
+	@echo "file://$(shell pwd)/build/html"
+	@echo
 
 text: BUILDER = text
 text: build


### PR DESCRIPTION
This makes it easier to open the generated HTML docs. In some terminal emulators, it allows the user to click the link instead of having to navigate to the build directory in the web browser.