### PR TITLE
Assign all TypeVars to variables

### DIFF
--- a/conformance/results/mypy/generics_defaults.toml
+++ b/conformance/results/mypy/generics_defaults.toml
@@ -12,6 +12,8 @@ generics_defaults.py:55: error: Expression is of type "type[AllTheDefaults[int, 
 generics_defaults.py:59: error: Expression is of type "type[AllTheDefaults[int, complex, str, int, DefaultBoolT]]", not "type[AllTheDefaults[int, complex, str, int, bool]]"  [assert-type]
 generics_defaults.py:79: error: Expression is of type "type[Class_ParamSpec[DefaultP]]", not "type[Class_ParamSpec[[str, int]]]"  [assert-type]
 generics_defaults.py:94: error: Expression is of type "type[Class_TypeVarTuple[*DefaultTs]]", not "type[Class_TypeVarTuple[str, int]]"  [assert-type]
+generics_defaults.py:104: error: TypeVar default must be a subtype of the bound type  [misc]
+generics_defaults.py:111: error: TypeVar default must be one of the constraint types  [misc]
 generics_defaults.py:151: error: Expression is of type "type[Foo6[*tuple[Any, ...], Any]]", not "type[Foo6[int, str, [float, bool]]]"  [assert-type]
 generics_defaults.py:151: error: Can only replace ParamSpec with a parameter types list or another ParamSpec, got "str"  [misc]
 generics_defaults.py:152: error: Expression is of type "type[Foo6[*tuple[Any, ...], Any]]", not "type[Foo6[int, str, [bytes]]]"  [assert-type]
@@ -22,8 +24,6 @@ generics_defaults.py:167: error: Access to generic instance variables via class 
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 104: Expected 1 errors
-Line 111: Expected 1 errors
 Line 138: Expected 1 errors
 Line 30: Unexpected errors ['generics_defaults.py:30: error: Expression is of type "type[NoNonDefaults[DefaultStrT, DefaultIntT]]", not "type[NoNonDefaults[str, int]]"  [assert-type]']
 Line 31: Unexpected errors ['generics_defaults.py:31: error: Expression is of type "type[NoNonDefaults[str, DefaultIntT]]", not "type[NoNonDefaults[str, int]]"  [assert-type]']

--- a/conformance/results/mypy/generics_defaults_referential.toml
+++ b/conformance/results/mypy/generics_defaults_referential.toml
@@ -3,6 +3,9 @@ output = """
 generics_defaults_referential.py:23: error: Expression is of type "type[slice[StartT, StopT, StepT]]", not "type[slice[int, int, int | None]]"  [assert-type]
 generics_defaults_referential.py:37: error: Argument 1 to "Foo" has incompatible type "str"; expected "int"  [arg-type]
 generics_defaults_referential.py:53: error: Type parameter "Start2T" has a default type that refers to one or more type variables that are out of scope  [misc]
+generics_defaults_referential.py:74: error: TypeVar default must be one of the constraint types  [misc]
+generics_defaults_referential.py:77: error: TypeVar default must be one of the constraint types  [misc]
+generics_defaults_referential.py:78: error: TypeVar default must be one of the constraint types  [misc]
 generics_defaults_referential.py:94: error: Expression is of type "type[Bar[Z1, ListDefaultT]]", not "type[Bar[Any, list[Any]]]"  [assert-type]
 generics_defaults_referential.py:95: error: Expression is of type "type[Bar[int, ListDefaultT]]", not "type[Bar[int, list[int]]]"  [assert-type]
 generics_defaults_referential.py:96: error: Expression is of type "Bar[int, list[Never]]", not "Bar[int, list[int]]"  [assert-type]
@@ -12,9 +15,8 @@ errors_diff = """
 Line 36: Expected 1 errors
 Line 60: Expected 1 errors
 Line 68: Expected 1 errors
-Line 74: Expected 1 errors
-Line 78: Expected 1 errors
 Line 23: Unexpected errors ['generics_defaults_referential.py:23: error: Expression is of type "type[slice[StartT, StopT, StepT]]", not "type[slice[int, int, int | None]]"  [assert-type]']
+Line 77: Unexpected errors ['generics_defaults_referential.py:77: error: TypeVar default must be one of the constraint types  [misc]']
 Line 94: Unexpected errors ['generics_defaults_referential.py:94: error: Expression is of type "type[Bar[Z1, ListDefaultT]]", not "type[Bar[Any, list[Any]]]"  [assert-type]']
 Line 95: Unexpected errors ['generics_defaults_referential.py:95: error: Expression is of type "type[Bar[int, ListDefaultT]]", not "type[Bar[int, list[int]]]"  [assert-type]']
 Line 96: Unexpected errors ['generics_defaults_referential.py:96: error: Expression is of type "Bar[int, list[Never]]", not "Bar[int, list[int]]"  [assert-type]']

--- a/conformance/results/mypy/version.toml
+++ b/conformance/results/mypy/version.toml
@@ -1,2 +1,2 @@
 version = "mypy 1.15.0"
-test_duration = 1.6
+test_duration = 1.2

--- a/conformance/results/pyre/version.toml
+++ b/conformance/results/pyre/version.toml
@@ -1,2 +1,2 @@
 version = "pyre 0.9.23"
-test_duration = 6.4
+test_duration = 6.9

--- a/conformance/results/pyright/generics_defaults.toml
+++ b/conformance/results/pyright/generics_defaults.toml
@@ -2,8 +2,8 @@ conformant = "Pass"
 output = """
 generics_defaults.py:24:7 - error: "T" cannot appear after "DefaultStrT" in type parameter list because it has no default type (reportGeneralTypeIssues)
 generics_defaults.py:50:16 - error: Too few type arguments provided for "AllTheDefaults"; expected 2 but received 1 (reportInvalidTypeArguments)
-generics_defaults.py:104:39 - error: TypeVar default type must be a subtype of the bound type (reportGeneralTypeIssues)
-generics_defaults.py:111:40 - error: TypeVar default type must be one of the constrained types (reportGeneralTypeIssues)
+generics_defaults.py:104:51 - error: TypeVar default type must be a subtype of the bound type (reportGeneralTypeIssues)
+generics_defaults.py:111:52 - error: TypeVar default type must be one of the constrained types (reportGeneralTypeIssues)
 generics_defaults.py:138:7 - error: TypeVar "T5" has a default value and cannot follow TypeVarTuple "Ts" (reportGeneralTypeIssues)
 generics_defaults.py:167:18 - error: Access to generic instance variable through class is ambiguous (reportGeneralTypeIssues)
 """

--- a/conformance/results/pyright/generics_defaults_referential.toml
+++ b/conformance/results/pyright/generics_defaults_referential.toml
@@ -8,9 +8,9 @@ generics_defaults_referential.py:53:7 - error: Type parameter "Start2T" has a de
   Type variable "StopT" is not in scope (reportGeneralTypeIssues)
 generics_defaults_referential.py:60:11 - error: Type parameter "S2" has a default type that refers to one or more type variables that are out of scope
   Type variable "S1" is not in scope (reportGeneralTypeIssues)
-generics_defaults_referential.py:68:29 - error: TypeVar default type must be a subtype of the bound type (reportGeneralTypeIssues)
-generics_defaults_referential.py:74:41 - error: TypeVar default type must be one of the constrained types (reportGeneralTypeIssues)
-generics_defaults_referential.py:78:48 - error: TypeVar default type must be one of the constrained types (reportGeneralTypeIssues)
+generics_defaults_referential.py:68:40 - error: TypeVar default type must be a subtype of the bound type (reportGeneralTypeIssues)
+generics_defaults_referential.py:74:52 - error: TypeVar default type must be one of the constrained types (reportGeneralTypeIssues)
+generics_defaults_referential.py:78:63 - error: TypeVar default type must be one of the constrained types (reportGeneralTypeIssues)
 """
 conformance_automated = "Pass"
 errors_diff = """

--- a/conformance/results/pyright/version.toml
+++ b/conformance/results/pyright/version.toml
@@ -1,2 +1,2 @@
 version = "pyright 1.1.398"
-test_duration = 1.3
+test_duration = 1.5

--- a/conformance/results/pytype/classes_override.toml
+++ b/conformance/results/pytype/classes_override.toml
@@ -20,8 +20,8 @@ classes_override.py:50:16: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in metho
 
 classes_override.py:53:5: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in ChildA: Attribute 'method3' not found on any parent class [override-error]
 
-    def method3(self) -> int:  # E: no matching signature in ancestor
-    \u001b[1m\u001b[31m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
+    def method3(self) -> int:  # E[method3]: no matching signature in ancestor
+    \u001b[1m\u001b[31m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
         return 1
 \u001b[1m\u001b[31m~~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
 
@@ -47,10 +47,10 @@ classes_override.py:101:5: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in Child
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 79: Expected 1 errors
-Line 84: Expected 1 errors
-Line 89: Expected 1 errors
-Lines 56, 65: Expected error (tag 'method4')
+Lines 56, 64, 65: Expected error (tag 'method4')
+Lines 78, 79: Expected error (tag 'static_method1')
+Lines 83, 84: Expected error (tag 'class_method1')
+Lines 88, 89: Expected error (tag 'property1')
 Line 7: Unexpected errors ['classes_override.py:7:1: \\x1b[1m\\x1b[31merror\\x1b[39m\\x1b[0m: in <module>: typing.override not supported yet [not-supported-yet]']
 Line 30: Unexpected errors ['classes_override.py:30:16: \\x1b[1m\\x1b[31merror\\x1b[39m\\x1b[0m: in method2: bad return type [bad-return-type]']
 Line 50: Unexpected errors ['classes_override.py:50:16: \\x1b[1m\\x1b[31merror\\x1b[39m\\x1b[0m: in method2: bad return type [bad-return-type]']

--- a/conformance/results/pytype/generics_defaults.toml
+++ b/conformance/results/pytype/generics_defaults.toml
@@ -185,25 +185,25 @@ generics_defaults.py:96:46: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in <mod
 assert_type(Class_TypeVarTuple[int, bool](), Class_TypeVarTuple[int, bool])
                                              \u001b[1m\u001b[31m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
 
-generics_defaults.py:103:1: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in <module>: wrong arguments [invalid-typevar]
+generics_defaults.py:103:7: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in <module>: wrong arguments [invalid-typevar]
 
-TypeVar("Ok", bound=float, default=int)  # OK
-\u001b[1m\u001b[31m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
+Ok1 = TypeVar("Ok1", bound=float, default=int)  # OK
+      \u001b[1m\u001b[31m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
 
-generics_defaults.py:104:1: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in <module>: wrong arguments [invalid-typevar]
+generics_defaults.py:104:12: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in <module>: wrong arguments [invalid-typevar]
 
-TypeVar("Invalid", bound=str, default=int)  # E: the bound and default are incompatible
-\u001b[1m\u001b[31m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
+Invalid1 = TypeVar("Invalid1", bound=str, default=int)  # E: the bound and default are incompatible
+           \u001b[1m\u001b[31m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
 
-generics_defaults.py:110:1: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in <module>: wrong arguments [invalid-typevar]
+generics_defaults.py:110:7: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in <module>: wrong arguments [invalid-typevar]
 
-TypeVar("Ok", float, str, default=float)  # OK
-\u001b[1m\u001b[31m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
+Ok2 = TypeVar("Ok2", float, str, default=float)  # OK
+      \u001b[1m\u001b[31m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
 
-generics_defaults.py:111:1: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in <module>: wrong arguments [invalid-typevar]
+generics_defaults.py:111:12: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in <module>: wrong arguments [invalid-typevar]
 
-TypeVar("Invalid", float, str, default=int)  # E: expected one of float or str got int
-\u001b[1m\u001b[31m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
+Invalid2 = TypeVar("Invalid2", float, str, default=int)  # E: expected one of float or str got int
+           \u001b[1m\u001b[31m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
 
 generics_defaults.py:121:6: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in <module>: wrong arguments [invalid-typevar]
 
@@ -314,8 +314,8 @@ Line 91: Unexpected errors ["generics_defaults.py:91:26: \\x1b[1m\\x1b[31merror\
 Line 94: Unexpected errors ['generics_defaults.py:94:38: \\x1b[1m\\x1b[31merror\\x1b[39m\\x1b[0m: in <module>: class Class_TypeVarTuple is not indexable [not-indexable]']
 Line 95: Unexpected errors ['generics_defaults.py:95:35: \\x1b[1m\\x1b[31merror\\x1b[39m\\x1b[0m: in <module>: class Class_TypeVarTuple is not indexable [not-indexable]']
 Line 96: Unexpected errors ['generics_defaults.py:96:13: \\x1b[1m\\x1b[31merror\\x1b[39m\\x1b[0m: in <module>: class Class_TypeVarTuple is not indexable [not-indexable]', 'generics_defaults.py:96:46: \\x1b[1m\\x1b[31merror\\x1b[39m\\x1b[0m: in <module>: class Class_TypeVarTuple is not indexable [not-indexable]']
-Line 103: Unexpected errors ['generics_defaults.py:103:1: \\x1b[1m\\x1b[31merror\\x1b[39m\\x1b[0m: in <module>: wrong arguments [invalid-typevar]']
-Line 110: Unexpected errors ['generics_defaults.py:110:1: \\x1b[1m\\x1b[31merror\\x1b[39m\\x1b[0m: in <module>: wrong arguments [invalid-typevar]']
+Line 103: Unexpected errors ['generics_defaults.py:103:7: \\x1b[1m\\x1b[31merror\\x1b[39m\\x1b[0m: in <module>: wrong arguments [invalid-typevar]']
+Line 110: Unexpected errors ['generics_defaults.py:110:7: \\x1b[1m\\x1b[31merror\\x1b[39m\\x1b[0m: in <module>: wrong arguments [invalid-typevar]']
 Line 121: Unexpected errors ['generics_defaults.py:121:6: \\x1b[1m\\x1b[31merror\\x1b[39m\\x1b[0m: in <module>: wrong arguments [invalid-typevar]']
 Line 127: Unexpected errors ['generics_defaults.py:127:1: \\x1b[1m\\x1b[31merror\\x1b[39m\\x1b[0m: in <module>: Any [assert-type]']
 Line 135: Unexpected errors ['generics_defaults.py:135:6: \\x1b[1m\\x1b[31merror\\x1b[39m\\x1b[0m: in <module>: wrong arguments [invalid-typevar]']

--- a/conformance/results/pytype/generics_defaults_referential.toml
+++ b/conformance/results/pytype/generics_defaults_referential.toml
@@ -110,35 +110,35 @@ generics_defaults_referential.py:60:16: \u001b[1m\u001b[31merror\u001b[39m\u001b
     class Bar2(Generic[S2]): ...  # E
                \u001b[1m\u001b[31m~~~~~~~~~~~\u001b[39m\u001b[0m
 
-generics_defaults_referential.py:66:1: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in <module>: wrong arguments [invalid-typevar]
+generics_defaults_referential.py:66:7: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in <module>: wrong arguments [invalid-typevar]
 
-TypeVar("Ok1", default=X1, bound=float)  # OK
-\u001b[1m\u001b[31m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
+Ok1 = TypeVar("Ok1", default=X1, bound=float)  # OK
+      \u001b[1m\u001b[31m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
 
-generics_defaults_referential.py:67:1: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in <module>: wrong arguments [invalid-typevar]
+generics_defaults_referential.py:67:11: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in <module>: wrong arguments [invalid-typevar]
 
-TypeVar("AlsoOk1", default=X1, bound=int)  # OK
-\u001b[1m\u001b[31m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
+AlsoOk1 = TypeVar("AlsoOk1", default=X1, bound=int)  # OK
+          \u001b[1m\u001b[31m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
 
-generics_defaults_referential.py:68:1: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in <module>: wrong arguments [invalid-typevar]
+generics_defaults_referential.py:68:12: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in <module>: wrong arguments [invalid-typevar]
 
-TypeVar("Invalid1", default=X1, bound=str)  # E: int is not a subtype of str
-\u001b[1m\u001b[31m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
+Invalid1 = TypeVar("Invalid1", default=X1, bound=str)  # E: int is not a subtype of str
+           \u001b[1m\u001b[31m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
 
-generics_defaults_referential.py:74:1: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in <module>: wrong arguments [invalid-typevar]
+generics_defaults_referential.py:74:12: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in <module>: wrong arguments [invalid-typevar]
 
-TypeVar("Invalid2", float, str, default=Y1)  # E: upper bound int is incompatible with constraints float or str
-\u001b[1m\u001b[31m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
+Invalid2 = TypeVar("Invalid2", float, str, default=Y1)  # E: upper bound int is incompatible with constraints float or str
+           \u001b[1m\u001b[31m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
 
-generics_defaults_referential.py:77:1: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in <module>: wrong arguments [invalid-typevar]
+generics_defaults_referential.py:77:11: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in <module>: wrong arguments [invalid-typevar]
 
-TypeVar("AlsoOk2", int, str, bool, default=Y2)  # OK
-\u001b[1m\u001b[31m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
+AlsoOk2 = TypeVar("AlsoOk2", int, str, bool, default=Y2)  # OK
+          \u001b[1m\u001b[31m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
 
-generics_defaults_referential.py:78:1: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in <module>: wrong arguments [invalid-typevar]
+generics_defaults_referential.py:78:16: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in <module>: wrong arguments [invalid-typevar]
 
-TypeVar("AlsoInvalid2", bool, complex, default=Y2)  # E: {bool, complex} is not a superset of {int, str}
-\u001b[1m\u001b[31m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
+AlsoInvalid2 = TypeVar("AlsoInvalid2", bool, complex, default=Y2)  # E: {bool, complex} is not a superset of {int, str}
+               \u001b[1m\u001b[31m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
 
 generics_defaults_referential.py:87:16: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in <module>: wrong arguments [invalid-typevar]
 
@@ -204,9 +204,9 @@ Line 43: Unexpected errors ['generics_defaults_referential.py:43:6: \\x1b[1m\\x1
 Line 46: Unexpected errors ["generics_defaults_referential.py:46:12: \\x1b[1m\\x1b[31merror\\x1b[39m\\x1b[0m: in <module>: Invalid type annotation 'Generic'  [invalid-annotation]"]
 Line 49: Unexpected errors ['generics_defaults_referential.py:49:11: \\x1b[1m\\x1b[31merror\\x1b[39m\\x1b[0m: in <module>: wrong arguments [invalid-typevar]']
 Line 50: Unexpected errors ['generics_defaults_referential.py:50:10: \\x1b[1m\\x1b[31merror\\x1b[39m\\x1b[0m: in <module>: wrong arguments [invalid-typevar]']
-Line 66: Unexpected errors ['generics_defaults_referential.py:66:1: \\x1b[1m\\x1b[31merror\\x1b[39m\\x1b[0m: in <module>: wrong arguments [invalid-typevar]']
-Line 67: Unexpected errors ['generics_defaults_referential.py:67:1: \\x1b[1m\\x1b[31merror\\x1b[39m\\x1b[0m: in <module>: wrong arguments [invalid-typevar]']
-Line 77: Unexpected errors ['generics_defaults_referential.py:77:1: \\x1b[1m\\x1b[31merror\\x1b[39m\\x1b[0m: in <module>: wrong arguments [invalid-typevar]']
+Line 66: Unexpected errors ['generics_defaults_referential.py:66:7: \\x1b[1m\\x1b[31merror\\x1b[39m\\x1b[0m: in <module>: wrong arguments [invalid-typevar]']
+Line 67: Unexpected errors ['generics_defaults_referential.py:67:11: \\x1b[1m\\x1b[31merror\\x1b[39m\\x1b[0m: in <module>: wrong arguments [invalid-typevar]']
+Line 77: Unexpected errors ['generics_defaults_referential.py:77:11: \\x1b[1m\\x1b[31merror\\x1b[39m\\x1b[0m: in <module>: wrong arguments [invalid-typevar]']
 Line 87: Unexpected errors ['generics_defaults_referential.py:87:16: \\x1b[1m\\x1b[31merror\\x1b[39m\\x1b[0m: in <module>: wrong arguments [invalid-typevar]']
 Line 90: Unexpected errors ["generics_defaults_referential.py:90:11: \\x1b[1m\\x1b[31merror\\x1b[39m\\x1b[0m: in <module>: Invalid type annotation 'Generic'  [invalid-annotation]"]
 Line 94: Unexpected errors ["generics_defaults_referential.py:94:23: \\x1b[1m\\x1b[31merror\\x1b[39m\\x1b[0m: in <module>: Invalid type annotation 'Bar[Any, list]'  [invalid-annotation]"]

--- a/conformance/results/pytype/version.toml
+++ b/conformance/results/pytype/version.toml
@@ -1,2 +1,2 @@
 version = "pytype 2024.10.11"
-test_duration = 32.7
+test_duration = 35.9

--- a/conformance/results/results.html
+++ b/conformance/results/results.html
@@ -159,16 +159,16 @@
         <div class="table_container"><table><tbody>
 <tr><th class="col1">&nbsp;</th>
 <th class='tc-header'><div class='tc-name'>mypy 1.15.0</div>
-<div class='tc-time'>1.6sec</div>
+<div class='tc-time'>1.2sec</div>
 </th>
 <th class='tc-header'><div class='tc-name'>pyright 1.1.398</div>
-<div class='tc-time'>1.3sec</div>
+<div class='tc-time'>1.5sec</div>
 </th>
 <th class='tc-header'><div class='tc-name'>pyre 0.9.23</div>
-<div class='tc-time'>6.4sec</div>
+<div class='tc-time'>6.9sec</div>
 </th>
 <th class='tc-header'><div class='tc-name'>pytype 2024.10.11</div>
-<div class='tc-time'>32.7sec</div>
+<div class='tc-time'>35.9sec</div>
 </th>
 </tr>
 <tr><th class="column" colspan="5">

--- a/conformance/tests/generics_defaults.py
+++ b/conformance/tests/generics_defaults.py
@@ -100,15 +100,15 @@ assert_type(Class_TypeVarTuple[int, bool](), Class_TypeVarTuple[int, bool])
 # > subtype of ``bound``. If not, the type checker should generate an
 # > error.
 
-TypeVar("Ok", bound=float, default=int)  # OK
-TypeVar("Invalid", bound=str, default=int)  # E: the bound and default are incompatible
+Ok1 = TypeVar("Ok1", bound=float, default=int)  # OK
+Invalid1 = TypeVar("Invalid1", bound=str, default=int)  # E: the bound and default are incompatible
 
 # > For constrained ``TypeVar``\ s, the default needs to be one of the
 # > constraints. A type checker should generate an error even if it is a
 # > subtype of one of the constraints.
 
-TypeVar("Ok", float, str, default=float)  # OK
-TypeVar("Invalid", float, str, default=int)  # E: expected one of float or str got int
+Ok2 = TypeVar("Ok2", float, str, default=float)  # OK
+Invalid2 = TypeVar("Invalid2", float, str, default=int)  # E: expected one of float or str got int
 
 
 # > In generic functions, type checkers may use a type parameter's default when the

--- a/conformance/tests/generics_defaults_referential.py
+++ b/conformance/tests/generics_defaults_referential.py
@@ -63,19 +63,19 @@ class Foo3(Generic[S1]):
 # > ``T1``'s bound must be a subtype of ``T2``'s bound.
 
 X1 = TypeVar("X1", bound=int)
-TypeVar("Ok1", default=X1, bound=float)  # OK
-TypeVar("AlsoOk1", default=X1, bound=int)  # OK
-TypeVar("Invalid1", default=X1, bound=str)  # E: int is not a subtype of str
+Ok1 = TypeVar("Ok1", default=X1, bound=float)  # OK
+AlsoOk1 = TypeVar("AlsoOk1", default=X1, bound=int)  # OK
+Invalid1 = TypeVar("Invalid1", default=X1, bound=str)  # E: int is not a subtype of str
 
 
 # > The constraints of ``T2`` must be a superset of the constraints of ``T1``.
 
 Y1 = TypeVar("Y1", bound=int)
-TypeVar("Invalid2", float, str, default=Y1)  # E: upper bound int is incompatible with constraints float or str
+Invalid2 = TypeVar("Invalid2", float, str, default=Y1)  # E: upper bound int is incompatible with constraints float or str
 
 Y2 = TypeVar("Y2", int, str)
-TypeVar("AlsoOk2", int, str, bool, default=Y2)  # OK
-TypeVar("AlsoInvalid2", bool, complex, default=Y2)  # E: {bool, complex} is not a superset of {int, str}
+AlsoOk2 = TypeVar("AlsoOk2", int, str, bool, default=Y2)  # OK
+AlsoInvalid2 = TypeVar("AlsoInvalid2", bool, complex, default=Y2)  # E: {bool, complex} is not a superset of {int, str}
 
 
 # > Type parameters are valid as parameters to generics inside of a


### PR DESCRIPTION
There were a few places in the conformance tests that had calls to `TypeVar` without assigning them to variables. This PR changes them to be assigned to variables, for consistency.

Based on the results, it appears that some existing typecheckers do not check TypeVars that are not assigned to variables, so the typechecker logic did not get exercised previously.