### PR TITLE
Update docs on equivalence between gradual types 

### DIFF
--- a/docs/spec/concepts.rst
+++ b/docs/spec/concepts.rst
@@ -298,11 +298,11 @@ visualize this analogy in the following table:
    * - ``B`` is :term:`equivalent` to ``A``
      - ``B`` is :term:`consistent` with ``A``
 
-We can also define equivalence on gradual types. Two gradual types ``A`` and
-``B`` are equivalent (that is, the same gradual type, not merely consistent
-with one another) if and only if all materializations of ``A`` are also
-materializations of ``B``, and all materializations of ``B`` are also
-materializations of ``A``.
+We can also define an **equivalence** relation on gradual types: the gradual 
+types ``A`` and ``B`` are equivalent (that is, the same gradual type, not 
+merely consistent with one another) if and only if all materializations of 
+``A`` are also materializations of ``B``, and all materializations of ``B``
+are also materializations of ``A``.
 
 Attributes and methods
 ----------------------


### PR DESCRIPTION
Update docs to include that the relation on "equivalent" gradual types is an equivalence relation.

Or i guess more explicitly state that it is an equivalence relation.