### PR TITLE
Conformance - fix issue running on Windows

### DIFF
--- a/conformance/README.md
+++ b/conformance/README.md
@@ -60,7 +60,7 @@ To run the conformance test suite:
 * Switch to the `conformance` subdirectory and install all dependencies (`pip install -r requirements.txt`).
 * Switch to the `src` subdirectory and run `python main.py`.
 
-Note that some type checkers may not run on some platforms. For example, pytype cannot be installed on Windows. If a type checker fails to install, tests will be skipped for that type checker.
+Note that some type checkers may not run on some platforms. If a type checker fails to install, tests will be skipped for that type checker.
 
 ## Reporting Conformance Results
 

--- a/conformance/requirements.txt
+++ b/conformance/requirements.txt
@@ -5,4 +5,4 @@ pyright
 mypy
 pip
 pyre-check
-pytype; platform_system != "Windows"
+pytype

--- a/conformance/src/main.py
+++ b/conformance/src/main.py
@@ -67,7 +67,7 @@ def get_expected_errors(test_case: Path) -> tuple[
             {"final": [3, 4]}
         )
     """
-    with open(test_case, "r") as f:
+    with open(test_case, "r", encoding="utf-8") as f:
         lines = f.readlines()
     output: dict[int, tuple[int, int]] = {}
     groups: dict[str, list[int]] = {}

--- a/conformance/src/type_checker.py
+++ b/conformance/src/type_checker.py
@@ -325,7 +325,7 @@ class PytypeTypeChecker(TypeChecker):
             if not fi.endswith(".py"):
                 continue
             options.tweak(input=fi)
-            with open(fi, "r") as test_file:
+            with open(fi, "r", encoding="utf-8") as test_file:
                 src = test_file.read()
             try:
                 analysis: pytype_analyze.Analysis = pytype_io.check_py(

--- a/conformance/src/type_checker.py
+++ b/conformance/src/type_checker.py
@@ -3,7 +3,6 @@ Classes that abstract differences between type checkers.
 """
 
 from abc import ABC, abstractmethod
-from curses.ascii import isspace
 import json
 from pathlib import Path
 import os

--- a/conformance/src/type_checker.py
+++ b/conformance/src/type_checker.py
@@ -114,7 +114,7 @@ class MypyTypeChecker(TypeChecker):
             "--enable-error-code",
             "deprecated",
         ]
-        proc = run(command, stdout=PIPE, text=True)
+        proc = run(command, stdout=PIPE, text=True, encoding="utf-8")
         lines = proc.stdout.split("\n")
 
         # Add results to a dictionary keyed by the file name.
@@ -174,7 +174,7 @@ class PyrightTypeChecker(TypeChecker):
 
     def run_tests(self, test_files: Sequence[str]) -> dict[str, str]:
         command = [sys.executable, "-m", "pyright", ".", "--outputjson"]
-        proc = run(command, stdout=PIPE, text=True)
+        proc = run(command, stdout=PIPE, text=True, encoding="utf-8")
         output_json = json.loads(proc.stdout)
         diagnostics = output_json["generalDiagnostics"]
 
@@ -253,7 +253,7 @@ class PyreTypeChecker(TypeChecker):
         return version
 
     def run_tests(self, test_files: Sequence[str]) -> dict[str, str]:
-        proc = run(["pyre", "check"], stdout=PIPE, text=True)
+        proc = run(["pyre", "check"], stdout=PIPE, text=True, encoding="utf-8")
         lines = proc.stdout.split("\n")
 
         # Add results to a dictionary keyed by the file name.


### PR DESCRIPTION
Changes:

1. Remove `curses` dependency - it was introduced in bd85af0 but apparently was never used. It was preventing running conformance on Windows as `curses` is not available.

2. Provide "utf-8" encoding explicitly to `open` and `subprocess.run` to fix errors on Windows.

3. Add pytype to requirements.txt on Windows too. Previously pytype was excluded from requirements but still used in conformance code leading to errors on Windows. But now pytype is available on Windows with `pip install pytype`, though it's not precompiled and may be added to conformance too.
To confirm it's working, below is a diff between results of 'unexpected_fails.py' based on the current repo state vs running conformance now on Windows - and there are no changes for pytype. (No idea where are those pyre errors coming through, but it's unrelated to this PR)




[current_repo_unexpected_fails.txt](https://github.com/user-attachments/files/19718324/current_repo_unexpected_fails.txt)
[current_unexpected_fails_windows_pytyped_included.txt](https://github.com/user-attachments/files/19718325/current_unexpected_fails_windows_pytyped_included.txt)

```diff
diff --git "a/L:\\oblivion\\current_repo_unexpected_fails.txt" "b/L:\\oblivion\\current_unexpected_fails_windows_pytyped_included.txt"
index 7803806..824cc08 100644
--- "a/L:\\oblivion\\current_repo_unexpected_fails.txt"
+++ "b/L:\\oblivion\\current_unexpected_fails_windows_pytyped_included.txt"
@@ -1,6 +1,47 @@
 mypy\protocols_explicit.toml: Pass vs. Fail
-pyre\namedtuples_define_class.toml: Partial vs. Pass
-pyre\namedtuples_usage.toml: Partial vs. Pass
+pyre\aliases_variance.toml: Pass vs. Fail
+pyre\annotations_typeexpr.toml: Pass vs. Fail
+pyre\callables_kwargs.toml: Pass vs. Fail
+pyre\classes_override.toml: Pass vs. Fail
+pyre\constructors_call_type.toml: Pass vs. Fail
+pyre\dataclasses_descriptors.toml: Partial vs. Pass
+pyre\dataclasses_final.toml: Pass vs. Fail
+pyre\dataclasses_frozen.toml: Pass vs. Fail
+pyre\dataclasses_order.toml: Pass vs. Fail
+pyre\directives_assert_type.toml: Pass vs. Fail
+pyre\directives_cast.toml: Pass vs. Fail
+pyre\directives_no_type_check.toml: Pass vs. Fail
+pyre\directives_reveal_type.toml: Pass vs. Fail
+pyre\directives_type_ignore_file2.toml: Pass vs. Fail
+pyre\enums_behaviors.toml: Pass vs. Fail
+pyre\enums_expansion.toml: Pass vs. Fail
+pyre\enums_member_values.toml: Pass vs. Fail
+pyre\exceptions_context_managers.toml: Partial vs. Pass
+pyre\generics_paramspec_semantics.toml: Pass vs. Fail
+pyre\generics_self_advanced.toml: Partial vs. Pass
+pyre\generics_typevartuple_concat.toml: Partial vs. Pass
+pyre\generics_typevartuple_overloads.toml: Unsupported vs. Pass
+pyre\generics_typevartuple_unpack.toml: Pass vs. Fail
+pyre\historical_positional.toml: Pass vs. Fail
+pyre\literals_semantics.toml: Pass vs. Fail
+pyre\namedtuples_define_functional.toml: Pass vs. Fail
+pyre\namedtuples_type_compat.toml: Pass vs. Fail
+pyre\narrowing_typeguard.toml: Pass vs. Fail
+pyre\narrowing_typeis.toml: Pass vs. Fail
+pyre\overloads_basic.toml: Pass vs. Fail
+pyre\protocols_merging.toml: Pass vs. Fail
+pyre\protocols_subtyping.toml: Pass vs. Fail
+pyre\specialtypes_none.toml: Pass vs. Fail
+pyre\tuples_type_form.toml: Pass vs. Fail
+pyre\tuples_unpacked.toml: Pass vs. Fail
+pyre\typeddicts_final.toml: Partial vs. Pass
+pyre\typeddicts_inheritance.toml: Pass vs. Fail
+pyre\typeddicts_operations.toml: Pass vs. Fail
+pyre\typeddicts_readonly.toml: Pass vs. Fail
+pyre\typeddicts_readonly_consistency.toml: Pass vs. Fail
+pyre\typeddicts_readonly_kwargs.toml: Pass vs. Fail
+pyre\typeddicts_readonly_update.toml: Pass vs. Fail
+pyre\typeddicts_usage.toml: Pass vs. Fail
 pyright\enums_members.toml: Pass vs. Fail
 pyright\protocols_explicit.toml: Pass vs. Fail
 pyright\typeddicts_required.toml: Pass vs. Fail
```