### PR TITLE
Conformance - fix issues on Windows (unicode, Pyre)

### DIFF
--- a/conformance/README.md
+++ b/conformance/README.md
@@ -60,7 +60,8 @@ To run the conformance test suite:
 * Switch to the `conformance` subdirectory and install all dependencies (`pip install -r requirements.txt`).
 * Switch to the `src` subdirectory and run `python main.py`.
 
-Note that some type checkers may not run on some platforms. If a type checker fails to install, tests will be skipped for that type checker.
+Note that some type checkers may not run on some platforms. If a type checker fails to install, tests will be skipped for that type checker.  
+Currently, the only unsupported type checker is Pyre on Windows.
 
 ## Reporting Conformance Results
 

--- a/conformance/requirements.txt
+++ b/conformance/requirements.txt
@@ -4,5 +4,5 @@ tqdm
 pyright
 mypy
 pip
-pyre-check
+pyre-check; platform_system != "Windows"
 pytype

--- a/conformance/src/main.py
+++ b/conformance/src/main.py
@@ -197,7 +197,7 @@ def update_output_for_test(
                 notes = "\n" + notes
             existing_results["notes"] = tomlkit.string(notes, multiline=True)
         results_file.parent.mkdir(parents=True, exist_ok=True)
-        with open(results_file, "w") as f:
+        with open(results_file, "w", encoding="utf-8") as f:
             tomlkit.dump(existing_results, f)
 
 

--- a/conformance/src/type_checker.py
+++ b/conformance/src/type_checker.py
@@ -387,6 +387,6 @@ class PytypeTypeChecker(TypeChecker):
 TYPE_CHECKERS: Sequence[TypeChecker] = (
     MypyTypeChecker(),
     PyrightTypeChecker(),
-    PyreTypeChecker(),
+    *([] if os.name == "nt" else [PyreTypeChecker()]),
     PytypeTypeChecker(),
 )


### PR DESCRIPTION
1. Noticed that pyright is giving unicode output that on Windows is leading to issues generating reports later. Saving this output explicitly as unicode resolves the issue.
2. Made Pyre optional as it does not support Windows currently (https://github.com/facebook/pyre-check/issues/554)
 
Unicode error traceback:
```python
Generating summary report
Traceback (most recent call last):
  File "\typing\conformance\src\main.py", line 260, in <module>
    main()
  File "\typing\conformance\src\main.py", line 256, in main
    generate_summary(root_dir)
  File "\typing\conformance\src\reporting.py", line 19, in generate_summary
    summary = template.replace("{{summary}}", generate_summary_html(root_dir))
                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "\typing\conformance\src\reporting.py", line 87, in generate_summary_html
    results = tomli.load(f)
              ^^^^^^^^^^^^^
  File "src\tomli\_parser.py", line 134, in load
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xa0 in position 110: invalid start byte
```