### PR TITLE
Conformance - document Python 3.11 requirement for pytype tests

### DIFF
--- a/conformance/README.md
+++ b/conformance/README.md
@@ -57,6 +57,7 @@ Test cases use the following conventions:
 To run the conformance test suite:
 * Clone the https://github.com/python/typing repo.
 * Create and activate a Python 3.12 virtual environment.
+* Ensure Python 3.11 is also installed (required for pytype tests to run).
 * Switch to the `conformance` subdirectory and install all dependencies (`pip install -r requirements.txt`).
 * Switch to the `src` subdirectory and run `python main.py`.
 


### PR DESCRIPTION
Not sure if it's still required-required by pytype - I haven't investigated, but wanted to document as it is the current conformance requirement.


Source:
https://github.com/python/typing/blob/0b9fed83ee2ac10aeac187d4182ae949f9fc25f0/conformance/src/type_checker.py#L313-L318