### PR TITLE
typeddicts - update conformance tests according to the spec

### DIFF
--- a/conformance/results/mypy/typeddicts_operations.toml
+++ b/conformance/results/mypy/typeddicts_operations.toml
@@ -8,9 +8,26 @@ typeddicts_operations.py:28: error: Missing key "year" for TypedDict "Movie"  [t
 typeddicts_operations.py:29: error: Incompatible types (expression has type "float", TypedDict item "year" has type "int")  [typeddict-item]
 typeddicts_operations.py:32: error: Extra key "other" for TypedDict "Movie"  [typeddict-unknown-key]
 typeddicts_operations.py:37: error: Expected TypedDict key to be string literal  [misc]
-typeddicts_operations.py:47: error: "Movie" has no attribute "clear"  [attr-defined]
-typeddicts_operations.py:49: error: Key "name" of TypedDict "Movie" cannot be deleted  [misc]
-typeddicts_operations.py:62: error: "MovieOptional" has no attribute "clear"  [attr-defined]
+typeddicts_operations.py:40: error: TypedDict key must be a string literal; expected one of ("name", "year")  [literal-required]
+typeddicts_operations.py:41: error: Expected TypedDict key to be string literal  [misc]
+typeddicts_operations.py:44: note: Revealed type is "Any"
+typeddicts_operations.py:44: error: TypedDict key must be a string literal; expected one of ("name", "year")  [literal-required]
+typeddicts_operations.py:47: note: Revealed type is "builtins.bool"
+typeddicts_operations.py:58: note: Revealed type is "builtins.bool"
+typeddicts_operations.py:60: error: "Movie" has no attribute "clear"  [attr-defined]
+typeddicts_operations.py:61: error: "Movie" has no attribute "popitem"  [attr-defined]
+typeddicts_operations.py:63: error: Key "name" of TypedDict "Movie" cannot be deleted  [misc]
+typeddicts_operations.py:80: note: Revealed type is "builtins.object"
+typeddicts_operations.py:83: note: Revealed type is "builtins.bool"
+typeddicts_operations.py:86: note: Revealed type is "builtins.bool"
+typeddicts_operations.py:88: error: "MovieOptional" has no attribute "clear"  [attr-defined]
+typeddicts_operations.py:89: error: "MovieOptional" has no attribute "popitem"  [attr-defined]
+typeddicts_operations.py:96: error: Expected TypedDict key to be string literal  [misc]
+typeddicts_operations.py:99: error: TypedDict key must be a string literal; expected one of ("name", "year")  [literal-required]
+typeddicts_operations.py:100: error: Expected TypedDict key to be string literal  [misc]
+typeddicts_operations.py:103: note: Revealed type is "Any"
+typeddicts_operations.py:103: error: TypedDict key must be a string literal; expected one of ("name", "year")  [literal-required]
+typeddicts_operations.py:106: note: Revealed type is "builtins.bool"
 """
 conformance_automated = "Pass"
 errors_diff = """

--- a/conformance/results/mypy/version.toml
+++ b/conformance/results/mypy/version.toml
@@ -1,2 +1,2 @@
 version = "mypy 1.15.0"
-test_duration = 2.1
+test_duration = 1.9

--- a/conformance/results/pyre/typeddicts_operations.toml
+++ b/conformance/results/pyre/typeddicts_operations.toml
@@ -10,9 +10,26 @@ typeddicts_operations.py:28:8 TypedDict initialization error [55]: Missing requi
 typeddicts_operations.py:29:8 TypedDict initialization error [55]: Expected type `int` for `Movie` field `year` but got `float`.
 typeddicts_operations.py:32:8 TypedDict initialization error [55]: TypedDict `Movie` has no field `other`.
 typeddicts_operations.py:37:4 Incompatible variable type [9]: movie is declared to have type `Movie` but is used as type `Dict[str, Union[int, str]]`.
-typeddicts_operations.py:47:0 Undefined attribute [16]: `Movie` has no attribute `clear`.
-typeddicts_operations.py:49:0 Invalid TypedDict operation [54]: Cannot delete required field `name` from TypedDict `Movie`.
-typeddicts_operations.py:62:0 Undefined attribute [16]: `MovieOptional` has no attribute `clear`.
+typeddicts_operations.py:40:19 TypedDict accessed with a non-literal [26]: TypedDict key must be a string literal. Expected one of ('name', 'year').
+typeddicts_operations.py:41:23 TypedDict accessed with a non-literal [26]: TypedDict key must be a string literal. Expected one of ('name', 'year').
+typeddicts_operations.py:44:4 Revealed type [-1]: Revealed type for `existing_movie[variable_key]` is `str`.
+typeddicts_operations.py:44:31 TypedDict accessed with a non-literal [26]: TypedDict key must be a string literal. Expected one of ('name', 'year').
+typeddicts_operations.py:47:4 Revealed type [-1]: Revealed type for `variable_key in existing_movie` is `bool`.
+typeddicts_operations.py:58:0 Revealed type [-1]: Revealed type for `"other" in movie` is `bool`.
+typeddicts_operations.py:60:0 Undefined attribute [16]: `Movie` has no attribute `clear`.
+typeddicts_operations.py:61:0 Undefined attribute [16]: `Movie` has no attribute `popitem`.
+typeddicts_operations.py:63:0 Invalid TypedDict operation [54]: Cannot delete required field `name` from TypedDict `Movie`.
+typeddicts_operations.py:80:0 Revealed type [-1]: Revealed type for `movie_optional.get("other")` is `typing.Optional[object]`.
+typeddicts_operations.py:83:0 Revealed type [-1]: Revealed type for `"name" in movie_optional` is `bool`.
+typeddicts_operations.py:86:0 Revealed type [-1]: Revealed type for `"other" in movie_optional` is `bool`.
+typeddicts_operations.py:88:0 Undefined attribute [16]: `MovieOptional` has no attribute `clear`.
+typeddicts_operations.py:89:0 Undefined attribute [16]: `MovieOptional` has no attribute `popitem`.
+typeddicts_operations.py:96:4 Incompatible variable type [9]: movie_optional is declared to have type `MovieOptional` but is used as type `Dict[str, Union[int, str]]`.
+typeddicts_operations.py:99:28 TypedDict accessed with a non-literal [26]: TypedDict key must be a string literal. Expected one of ('name', 'year').
+typeddicts_operations.py:100:32 TypedDict accessed with a non-literal [26]: TypedDict key must be a string literal. Expected one of ('name', 'year').
+typeddicts_operations.py:103:4 Revealed type [-1]: Revealed type for `existing_optional_movie[variable_key]` is `str`.
+typeddicts_operations.py:103:40 TypedDict accessed with a non-literal [26]: TypedDict key must be a string literal. Expected one of ('name', 'year').
+typeddicts_operations.py:106:4 Revealed type [-1]: Revealed type for `variable_key in existing_optional_movie` is `bool`.
 """
 conformance_automated = "Pass"
 errors_diff = """

--- a/conformance/results/pyre/version.toml
+++ b/conformance/results/pyre/version.toml
@@ -1,2 +1,2 @@
 version = "pyre 0.9.23"
-test_duration = 3.9
+test_duration = 1.6

--- a/conformance/results/pyright/typeddicts_operations.toml
+++ b/conformance/results/pyright/typeddicts_operations.toml
@@ -1,4 +1,4 @@
-conformant = "Pass"
+conformant = "Fail"
 output = """
 typeddicts_operations.py:22:1 - error: Could not assign item in TypedDict
   "Literal[1982]" is not assignable to "str" (reportGeneralTypeIssues)
@@ -15,13 +15,38 @@ typeddicts_operations.py:29:42 - error: Type "dict[str, str | float]" is not ass
 typeddicts_operations.py:32:36 - error: Type "dict[str, str | int]" is not assignable to declared type "Movie"
   "other" is an undefined item in type "Movie" (reportAssignmentType)
 typeddicts_operations.py:37:20 - error: Type "dict[str, str | int]" is not assignable to declared type "Movie" (reportAssignmentType)
-typeddicts_operations.py:47:7 - error: Cannot access attribute "clear" for class "Movie"
+typeddicts_operations.py:44:17 - information: Type of "existing_movie[variable_key]" is "Unknown"
+typeddicts_operations.py:47:17 - information: Type of "variable_key in existing_movie" is "bool"
+typeddicts_operations.py:48:17 - error: "assert_type" mismatch: expected "object | None" but received "Any | None" (reportAssertTypeFailure)
+typeddicts_operations.py:58:13 - information: Type of ""other" in movie" is "bool"
+typeddicts_operations.py:60:7 - error: Cannot access attribute "clear" for class "Movie"
   Attribute "clear" is unknown (reportAttributeAccessIssue)
-typeddicts_operations.py:49:5 - error: Could not delete item in TypedDict
+typeddicts_operations.py:61:7 - error: Cannot access attribute "popitem" for class "Movie"
+  Attribute "popitem" is unknown (reportAttributeAccessIssue)
+typeddicts_operations.py:63:5 - error: Could not delete item in TypedDict
   "name" is a required key and cannot be deleted (reportGeneralTypeIssues)
-typeddicts_operations.py:62:16 - error: Cannot access attribute "clear" for class "MovieOptional"
+typeddicts_operations.py:76:1 - error: Could not access item in TypedDict
+  "name" is not a required key in "MovieOptional", so access may result in runtime exception (reportTypedDictNotRequiredAccess)
+typeddicts_operations.py:80:13 - information: Type of "movie_optional.get("other")" is "Any | None"
+typeddicts_operations.py:83:13 - information: Type of ""name" in movie_optional" is "bool"
+typeddicts_operations.py:86:13 - information: Type of ""other" in movie_optional" is "bool"
+typeddicts_operations.py:88:16 - error: Cannot access attribute "clear" for class "MovieOptional"
   Attribute "clear" is unknown (reportAttributeAccessIssue)
+typeddicts_operations.py:89:16 - error: Cannot access attribute "popitem" for class "MovieOptional"
+  Attribute "popitem" is unknown (reportAttributeAccessIssue)
+typeddicts_operations.py:96:37 - error: Type "dict[str, str | int]" is not assignable to declared type "MovieOptional" (reportAssignmentType)
+typeddicts_operations.py:103:17 - information: Type of "existing_optional_movie[variable_key]" is "Unknown"
+typeddicts_operations.py:106:17 - information: Type of "variable_key in existing_optional_movie" is "bool"
+typeddicts_operations.py:107:17 - error: "assert_type" mismatch: expected "object | None" but received "Any | None" (reportAssertTypeFailure)
 """
-conformance_automated = "Pass"
+conformance_automated = "Fail"
 errors_diff = """
+Line 40: Expected 1 errors
+Line 41: Expected 1 errors
+Line 44: Expected 1 errors
+Line 99: Expected 1 errors
+Line 100: Expected 1 errors
+Line 103: Expected 1 errors
+Line 48: Unexpected errors ['typeddicts_operations.py:48:17 - error: "assert_type" mismatch: expected "object | None" but received "Any | None" (reportAssertTypeFailure)']
+Line 107: Unexpected errors ['typeddicts_operations.py:107:17 - error: "assert_type" mismatch: expected "object | None" but received "Any | None" (reportAssertTypeFailure)']
 """

--- a/conformance/results/pyright/version.toml
+++ b/conformance/results/pyright/version.toml
@@ -1,2 +1,2 @@
 version = "pyright 1.1.399"
-test_duration = 2.5
+test_duration = 2.4

--- a/conformance/results/pyright/version.toml
+++ b/conformance/results/pyright/version.toml
@@ -1,2 +1,2 @@
-version = "pyright 1.1.398"
-test_duration = 2.3
+version = "pyright 1.1.399"
+test_duration = 2.5

--- a/conformance/results/pytype/protocols_merging.toml
+++ b/conformance/results/pytype/protocols_merging.toml
@@ -6,12 +6,12 @@ Does not report attempt to instantiate abstract class downgraded from protocol c
 output = """
 protocols_merging.py:52:1: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in <module>: Type annotation for s6 does not match type of assignment [annotation-type-mismatch]
 
-s6: SizedAndClosable1 = SCConcrete2()  # E: doesn't implement close
+s6: SizedAndClosable1 = SCConcrete2()  # E: doesn't implement `__len__`
 \u001b[1m\u001b[31m~~\u001b[39m\u001b[0m
 
 protocols_merging.py:53:1: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in <module>: Type annotation for s7 does not match type of assignment [annotation-type-mismatch]
 
-s7: SizedAndClosable2 = SCConcrete2()  # E: doesn't implement close
+s7: SizedAndClosable2 = SCConcrete2()  # E: doesn't implement `__len__`
 \u001b[1m\u001b[31m~~\u001b[39m\u001b[0m
 
 protocols_merging.py:54:1: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in <module>: Type annotation for s8 does not match type of assignment [annotation-type-mismatch]

--- a/conformance/results/pytype/typeddicts_operations.toml
+++ b/conformance/results/pytype/typeddicts_operations.toml
@@ -26,10 +26,90 @@ typeddicts_operations.py:37:5: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in f
     movie: Movie = {variable_key: "", "year": 1900}  # E: variable key
     \u001b[1m\u001b[31m~~~~~\u001b[39m\u001b[0m
 
-typeddicts_operations.py:60:1: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in <module>: str [assert-type]
+typeddicts_operations.py:40:5: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in func1: TypedDict Movie requires all keys to be constant strings [typed-dict-error]
+
+    existing_movie[variable_key] = 1982  # E: variable key
+    \u001b[1m\u001b[31m~~~~~~~~~~~~~~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
+
+typeddicts_operations.py:41:9: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in func1: TypedDict Movie requires all keys to be constant strings [typed-dict-error]
+
+    del existing_movie[variable_key]  # E
+        \u001b[1m\u001b[31m~~~~~~~~~~~~~~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
+
+typeddicts_operations.py:44:17: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in func1: TypedDict Movie requires all keys to be constant strings [typed-dict-error]
+
+    reveal_type(existing_movie[variable_key])  # E
+                \u001b[1m\u001b[31m~~~~~~~~~~~~~~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
+
+typeddicts_operations.py:44:5: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in func1: Any [reveal-type]
+
+    reveal_type(existing_movie[variable_key])  # E
+    \u001b[1m\u001b[31m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
+
+typeddicts_operations.py:47:5: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in func1: bool [reveal-type]
+
+    reveal_type(variable_key in existing_movie)  # `bool`
+    \u001b[1m\u001b[31m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
+
+typeddicts_operations.py:48:5: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in func1: None [assert-type]
+
+    assert_type(existing_movie.get(variable_key), object | None)
+    \u001b[1m\u001b[31m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
+
+typeddicts_operations.py:58:1: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in <module>: bool [reveal-type]
+
+reveal_type("other" in movie)  # E?
+\u001b[1m\u001b[31m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
+
+typeddicts_operations.py:77:1: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in <module>: str [assert-type]
 
 assert_type(movie_optional.get("name"), str | None)
 \u001b[1m\u001b[31m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
+
+typeddicts_operations.py:80:1: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in <module>: None [reveal-type]
+
+reveal_type(movie_optional.get("other"))  # E?
+\u001b[1m\u001b[31m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
+
+typeddicts_operations.py:83:1: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in <module>: bool [reveal-type]
+
+reveal_type("name" in movie_optional)  # E?
+\u001b[1m\u001b[31m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
+
+typeddicts_operations.py:86:1: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in <module>: bool [reveal-type]
+
+reveal_type("other" in movie_optional)  # E?
+\u001b[1m\u001b[31m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
+
+typeddicts_operations.py:99:5: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in func2: TypedDict MovieOptional requires all keys to be constant strings [typed-dict-error]
+
+    existing_optional_movie[variable_key] = 1982  # E: variable key
+    \u001b[1m\u001b[31m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
+
+typeddicts_operations.py:100:9: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in func2: TypedDict MovieOptional requires all keys to be constant strings [typed-dict-error]
+
+    del existing_optional_movie[variable_key]  # E: variable key
+        \u001b[1m\u001b[31m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
+
+typeddicts_operations.py:103:17: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in func2: TypedDict MovieOptional requires all keys to be constant strings [typed-dict-error]
+
+    reveal_type(existing_optional_movie[variable_key])  # E
+                \u001b[1m\u001b[31m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
+
+typeddicts_operations.py:103:5: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in func2: Any [reveal-type]
+
+    reveal_type(existing_optional_movie[variable_key])  # E
+    \u001b[1m\u001b[31m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
+
+typeddicts_operations.py:106:5: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in func2: bool [reveal-type]
+
+    reveal_type(variable_key in existing_optional_movie)  # `bool`
+    \u001b[1m\u001b[31m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
+
+typeddicts_operations.py:107:5: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in func2: None [assert-type]
+
+    assert_type(existing_optional_movie.get(variable_key), object | None)
+    \u001b[1m\u001b[31m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\u001b[39m\u001b[0m
 
 """
 conformance_automated = "Fail"
@@ -38,8 +118,15 @@ Line 22: Expected 1 errors
 Line 23: Expected 1 errors
 Line 24: Expected 1 errors
 Line 26: Expected 1 errors
-Line 47: Expected 1 errors
-Line 49: Expected 1 errors
-Line 62: Expected 1 errors
-Line 60: Unexpected errors ['typeddicts_operations.py:60:1: \\x1b[1m\\x1b[31merror\\x1b[39m\\x1b[0m: in <module>: str [assert-type]']
+Line 60: Expected 1 errors
+Line 61: Expected 1 errors
+Line 63: Expected 1 errors
+Line 88: Expected 1 errors
+Line 89: Expected 1 errors
+Line 96: Expected 1 errors
+Line 47: Unexpected errors ['typeddicts_operations.py:47:5: \\x1b[1m\\x1b[31merror\\x1b[39m\\x1b[0m: in func1: bool [reveal-type]']
+Line 48: Unexpected errors ['typeddicts_operations.py:48:5: \\x1b[1m\\x1b[31merror\\x1b[39m\\x1b[0m: in func1: None [assert-type]']
+Line 77: Unexpected errors ['typeddicts_operations.py:77:1: \\x1b[1m\\x1b[31merror\\x1b[39m\\x1b[0m: in <module>: str [assert-type]']
+Line 106: Unexpected errors ['typeddicts_operations.py:106:5: \\x1b[1m\\x1b[31merror\\x1b[39m\\x1b[0m: in func2: bool [reveal-type]']
+Line 107: Unexpected errors ['typeddicts_operations.py:107:5: \\x1b[1m\\x1b[31merror\\x1b[39m\\x1b[0m: in func2: None [assert-type]']
 """

--- a/conformance/results/pytype/version.toml
+++ b/conformance/results/pytype/version.toml
@@ -1,2 +1,2 @@
 version = "pytype 2024.10.11"
-test_duration = 43.3
+test_duration = 42.2

--- a/conformance/results/pytype/version.toml
+++ b/conformance/results/pytype/version.toml
@@ -1,2 +1,2 @@
 version = "pytype 2024.10.11"
-test_duration = 42.2
+test_duration = 37.8

--- a/conformance/results/results.html
+++ b/conformance/results/results.html
@@ -161,14 +161,14 @@
 <th class='tc-header'><div class='tc-name'>mypy 1.15.0</div>
 <div class='tc-time'>2.1sec</div>
 </th>
-<th class='tc-header'><div class='tc-name'>pyright 1.1.398</div>
-<div class='tc-time'>2.3sec</div>
+<th class='tc-header'><div class='tc-name'>pyright 1.1.399</div>
+<div class='tc-time'>2.5sec</div>
 </th>
 <th class='tc-header'><div class='tc-name'>pyre 0.9.23</div>
 <div class='tc-time'>3.9sec</div>
 </th>
 <th class='tc-header'><div class='tc-name'>pytype 2024.10.11</div>
-<div class='tc-time'>43.3sec</div>
+<div class='tc-time'>42.2sec</div>
 </th>
 </tr>
 <tr><th class="column" colspan="5">
@@ -445,10 +445,10 @@
 <a class="test_group" href="https://typing.readthedocs.io/en/latest/spec/class-compat.html">Class type compatibility</a>
 </th></tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;classes_classvar</th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Internal error if TypeVarTuple is used in ClassVar.</p><p>Does not reject use of ParamSpec in ClassVar.</p><p>Rejects ClassVar nested in Annotated.</p><p>Does not reject use of ClassVar in TypeAlias definition.</p><p>Does not infer type of ClassVar from assignment if no type is provided.</p></span></div></th>
+<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Internal error if TypeVarTuple is used in ClassVar.</p><p>Does not reject use of ParamSpec in ClassVar.</p><p>Rejects ClassVar nested in Annotated.</p><p>Does not reject use of ClassVar in TypeAlias definition.</p></span></div></th>
 <th class="column col2 conformant">Pass</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not reject use of TypeVar in ClassVar.</p><p>Does not reject use of ParamSpec in ClassVar.</p><p>Does not reject use of ClassVar as a generic type argument.</p><p>Does not reject use of ClassVar in parameter type annotation.</p><p>Does not reject use of ClassVar in local variable annotation.</p><p>Does not reject use of ClassVar in instance variable annotation.</p><p>Does not reject use of ClassVar in return type annotation.</p><p>Does not reject use of ClassVar in type alias definition.</p><p>Does not infer type from initialization for bare ClassVar.</p></span></div></th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not reject use of TypeVar in ClassVar.</p><p>Does not reject use of ParamSpec in ClassVar.</p><p>Does not reject use of ClassVar as a generic type argument.</p><p>Rejects initialization of ClassVar if no type argument is provided.</p><p>Does not reject use of ClassVar in parameter type annotation.</p><p>Does not reject use of ClassVar in local variable annotation.</p><p>Does not reject use of ClassVar in instance variable annotation.</p><p>Does not reject use of ClassVar in return type annotation.</p><p>Does not reject use of ClassVar in type alias definition.</p><p>Does not reject assignment of ClassVar through instance of class.</p></span></div></th>
+<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not reject use of TypeVar in ClassVar.</p><p>Does not reject use of ParamSpec in ClassVar.</p><p>Does not reject use of ClassVar as a generic type argument.</p><p>Rejects initialization of ClassVar if no type argument is provided.</p><p>Does not infer ClassVar with no type argument and no assigned value as Any.</p><p>Does not reject use of ClassVar in parameter type annotation.</p><p>Does not reject use of ClassVar in local variable annotation.</p><p>Does not reject use of ClassVar in instance variable annotation.</p><p>Does not reject use of ClassVar in return type annotation.</p><p>Does not reject use of ClassVar in type alias definition.</p><p>Does not reject assignment of ClassVar through instance of class.</p></span></div></th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;classes_override</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not handle case where parent class derives from Any.</p></span></div></th>

--- a/conformance/results/results.html
+++ b/conformance/results/results.html
@@ -159,16 +159,16 @@
         <div class="table_container"><table><tbody>
 <tr><th class="col1">&nbsp;</th>
 <th class='tc-header'><div class='tc-name'>mypy 1.15.0</div>
-<div class='tc-time'>2.1sec</div>
+<div class='tc-time'>1.9sec</div>
 </th>
 <th class='tc-header'><div class='tc-name'>pyright 1.1.399</div>
-<div class='tc-time'>2.5sec</div>
+<div class='tc-time'>2.4sec</div>
 </th>
 <th class='tc-header'><div class='tc-name'>pyre 0.9.23</div>
-<div class='tc-time'>3.9sec</div>
+<div class='tc-time'>1.6sec</div>
 </th>
 <th class='tc-header'><div class='tc-name'>pytype 2024.10.11</div>
-<div class='tc-time'>42.2sec</div>
+<div class='tc-time'>37.8sec</div>
 </th>
 </tr>
 <tr><th class="column" colspan="5">

--- a/conformance/tests/typeddicts_operations.py
+++ b/conformance/tests/typeddicts_operations.py
@@ -54,6 +54,8 @@ movie.get("name")
 # It's not clear from the spec what type this should be.
 movie.get("other")  # E?
 
+# It's not clear from the spec whether it's allowed.
+reveal_type("other" in movie)  # E?
 
 movie.clear()  # E: clear not allowed
 movie.popitem()  # E: popitem not allowed
@@ -73,6 +75,12 @@ movie_optional: MovieOptional = {}
 # even if the key 'x' is not required.
 movie_optional["name"]  # E?
 assert_type(movie_optional.get("name"), str | None)
+
+# It's not clear from the spec what type this should be.
+reveal_type(movie_optional.get("other"))  # E?
+
+# It's not clear from the spec whether it's allowed.
+reveal_type("other" in movie_optional)  # E?
 
 movie_optional.clear()  # E: clear not allowed
 movie_optional.popitem()  # E: popitem not allowed

--- a/conformance/tests/typeddicts_operations.py
+++ b/conformance/tests/typeddicts_operations.py
@@ -69,6 +69,9 @@ class MovieOptional(TypedDict, total=False):
 
 movie_optional: MovieOptional = {}
 
+# > Type checkers may allow reading an item using d['x']
+# even if the key 'x' is not required.
+movie_optional["name"]  # E?
 assert_type(movie_optional.get("name"), str | None)
 
 movie_optional.clear()  # E: clear not allowed

--- a/conformance/tests/typeddicts_operations.py
+++ b/conformance/tests/typeddicts_operations.py
@@ -45,6 +45,7 @@ movie.get("other")  # E?
 
 
 movie.clear()  # E: clear not allowed
+movie.popitem()  # E: popitem not allowed
 
 del movie["name"]  # E: del not allowed for required key
 
@@ -60,5 +61,6 @@ movie_optional: MovieOptional = {}
 assert_type(movie_optional.get("name"), str | None)
 
 movie_optional.clear()  # E: clear not allowed
+movie_optional.popitem()  # E: popitem not allowed
 
 del movie_optional["name"]

--- a/conformance/tests/typeddicts_operations.py
+++ b/conformance/tests/typeddicts_operations.py
@@ -32,9 +32,20 @@ movie = {"name": "Blade Runner", "year": 1982.1}  # E: year is wrong type
 movie = {"name": "", "year": 1900, "other": 2}  # E: extra key
 
 
-def func1(variable_key: str):
+def func1(variable_key: str, existing_movie: Movie):
     # > A key that is not a literal should generally be rejected.
     movie: Movie = {variable_key: "", "year": 1900}  # E: variable key
+
+    # Destructive operations.
+    existing_movie[variable_key] = 1982  # E: variable key
+    del existing_movie[variable_key]  # E
+
+    # Read-only operations.
+    reveal_type(existing_movie[variable_key])  # E
+
+    # Exceptions.
+    reveal_type(variable_key in existing_movie)  # `bool`
+    assert_type(existing_movie.get(variable_key), object | None)
 
 
 # It's not clear from the spec what type this should be.
@@ -64,3 +75,19 @@ movie_optional.clear()  # E: clear not allowed
 movie_optional.popitem()  # E: popitem not allowed
 
 del movie_optional["name"]
+
+
+def func2(variable_key: str, existing_optional_movie: MovieOptional):
+    # > A key that is not a literal should generally be rejected.
+    movie_optional: MovieOptional = {variable_key: "", "year": 1900}  # E: variable key
+
+    # Destructive operations.
+    existing_optional_movie[variable_key] = 1982  # E: variable key
+    del existing_optional_movie[variable_key]  # E: variable key
+
+    # Read-only operations.
+    reveal_type(existing_optional_movie[variable_key])  # E
+
+    # Exceptions.
+    reveal_type(variable_key in existing_optional_movie)  # `bool`
+    assert_type(existing_optional_movie.get(variable_key), object | None)


### PR DESCRIPTION
Added missing tests to typeddicts_operations.py based on the current state of https://typing.python.org/en/latest/spec/typeddict.html#supported-and-unsupported-operations

Stumbled upon type checkers having a different behaviour for `typed_dict[str]`, investigated the spec and the spec is clear about type checkers generally rejecting operations with arbitrary strings - so wanted to reflect the spec in conformance tests.

Added tests for:
1. Disallowed `popitem`.
2. Not requires keys - spec allows both behaviours.
3. Extra keys in `get` and with `in` - spec is not certain about this, so I guess it allows both behaviours.
4. Operations with variable keys - disallowed descructive and non-destructive operations except `.get` and `in`.

Added baseline output commit just for a reference - to confirm that there no other typecheckers version changes at play in the updated output. I can remove it before merge to avoid additional diffs.