### PR TITLE
Adjust error locations for typeddicts_class_syntax conformance test

### DIFF
--- a/conformance/results/mypy/version.toml
+++ b/conformance/results/mypy/version.toml
@@ -1,2 +1,2 @@
 version = "mypy 1.15.0"
-test_duration = 2.1
+test_duration = 2.3

--- a/conformance/results/pyre/typeddicts_class_syntax.toml
+++ b/conformance/results/pyre/typeddicts_class_syntax.toml
@@ -11,7 +11,7 @@ typeddicts_class_syntax.py:49:0 Unexpected keyword [28]: Unexpected keyword argu
 conformance_automated = "Fail"
 errors_diff = """
 Line 29: Expected 1 errors
-Line 33: Expected 1 errors
-Line 38: Expected 1 errors
 Line 44: Expected 1 errors
+Lines 33, 34: Expected error (tag 'method2')
+Lines 38, 39: Expected error (tag 'method3')
 """

--- a/conformance/results/pyre/version.toml
+++ b/conformance/results/pyre/version.toml
@@ -1,2 +1,2 @@
 version = "pyre 0.9.23"
-test_duration = 3.9
+test_duration = 8.2

--- a/conformance/results/pyright/version.toml
+++ b/conformance/results/pyright/version.toml
@@ -1,2 +1,2 @@
-version = "pyright 1.1.398"
-test_duration = 2.3
+version = "pyright 1.1.399"
+test_duration = 1.4

--- a/conformance/results/pytype/protocols_merging.toml
+++ b/conformance/results/pytype/protocols_merging.toml
@@ -6,12 +6,12 @@ Does not report attempt to instantiate abstract class downgraded from protocol c
 output = """
 protocols_merging.py:52:1: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in <module>: Type annotation for s6 does not match type of assignment [annotation-type-mismatch]
 
-s6: SizedAndClosable1 = SCConcrete2()  # E: doesn't implement close
+s6: SizedAndClosable1 = SCConcrete2()  # E: doesn't implement `__len__`
 \u001b[1m\u001b[31m~~\u001b[39m\u001b[0m
 
 protocols_merging.py:53:1: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in <module>: Type annotation for s7 does not match type of assignment [annotation-type-mismatch]
 
-s7: SizedAndClosable2 = SCConcrete2()  # E: doesn't implement close
+s7: SizedAndClosable2 = SCConcrete2()  # E: doesn't implement `__len__`
 \u001b[1m\u001b[31m~~\u001b[39m\u001b[0m
 
 protocols_merging.py:54:1: \u001b[1m\u001b[31merror\u001b[39m\u001b[0m: in <module>: Type annotation for s8 does not match type of assignment [annotation-type-mismatch]

--- a/conformance/results/pytype/typeddicts_class_syntax.toml
+++ b/conformance/results/pytype/typeddicts_class_syntax.toml
@@ -18,9 +18,9 @@ class GenericTypedDict(TypedDict, Generic[T]):
 conformance_automated = "Fail"
 errors_diff = """
 Line 29: Expected 1 errors
-Line 33: Expected 1 errors
-Line 38: Expected 1 errors
 Line 44: Expected 1 errors
 Line 49: Expected 1 errors
+Lines 33, 34: Expected error (tag 'method2')
+Lines 38, 39: Expected error (tag 'method3')
 Line 57: Unexpected errors ['typeddicts_class_syntax.py:57:1: \\x1b[1m\\x1b[31merror\\x1b[39m\\x1b[0m: in <module>: Invalid base class: Generic[T] [base-class-error]']
 """

--- a/conformance/results/pytype/version.toml
+++ b/conformance/results/pytype/version.toml
@@ -1,2 +1,2 @@
 version = "pytype 2024.10.11"
-test_duration = 43.3
+test_duration = 35.2

--- a/conformance/results/results.html
+++ b/conformance/results/results.html
@@ -159,16 +159,16 @@
         <div class="table_container"><table><tbody>
 <tr><th class="col1">&nbsp;</th>
 <th class='tc-header'><div class='tc-name'>mypy 1.15.0</div>
-<div class='tc-time'>2.1sec</div>
-</th>
-<th class='tc-header'><div class='tc-name'>pyright 1.1.398</div>
 <div class='tc-time'>2.3sec</div>
 </th>
+<th class='tc-header'><div class='tc-name'>pyright 1.1.399</div>
+<div class='tc-time'>1.4sec</div>
+</th>
 <th class='tc-header'><div class='tc-name'>pyre 0.9.23</div>
-<div class='tc-time'>3.9sec</div>
+<div class='tc-time'>8.2sec</div>
 </th>
 <th class='tc-header'><div class='tc-name'>pytype 2024.10.11</div>
-<div class='tc-time'>43.3sec</div>
+<div class='tc-time'>35.2sec</div>
 </th>
 </tr>
 <tr><th class="column" colspan="5">
@@ -445,10 +445,10 @@
 <a class="test_group" href="https://typing.readthedocs.io/en/latest/spec/class-compat.html">Class type compatibility</a>
 </th></tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;classes_classvar</th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Internal error if TypeVarTuple is used in ClassVar.</p><p>Does not reject use of ParamSpec in ClassVar.</p><p>Rejects ClassVar nested in Annotated.</p><p>Does not reject use of ClassVar in TypeAlias definition.</p><p>Does not infer type of ClassVar from assignment if no type is provided.</p></span></div></th>
+<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Internal error if TypeVarTuple is used in ClassVar.</p><p>Does not reject use of ParamSpec in ClassVar.</p><p>Rejects ClassVar nested in Annotated.</p><p>Does not reject use of ClassVar in TypeAlias definition.</p></span></div></th>
 <th class="column col2 conformant">Pass</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not reject use of TypeVar in ClassVar.</p><p>Does not reject use of ParamSpec in ClassVar.</p><p>Does not reject use of ClassVar as a generic type argument.</p><p>Does not reject use of ClassVar in parameter type annotation.</p><p>Does not reject use of ClassVar in local variable annotation.</p><p>Does not reject use of ClassVar in instance variable annotation.</p><p>Does not reject use of ClassVar in return type annotation.</p><p>Does not reject use of ClassVar in type alias definition.</p><p>Does not infer type from initialization for bare ClassVar.</p></span></div></th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not reject use of TypeVar in ClassVar.</p><p>Does not reject use of ParamSpec in ClassVar.</p><p>Does not reject use of ClassVar as a generic type argument.</p><p>Rejects initialization of ClassVar if no type argument is provided.</p><p>Does not reject use of ClassVar in parameter type annotation.</p><p>Does not reject use of ClassVar in local variable annotation.</p><p>Does not reject use of ClassVar in instance variable annotation.</p><p>Does not reject use of ClassVar in return type annotation.</p><p>Does not reject use of ClassVar in type alias definition.</p><p>Does not reject assignment of ClassVar through instance of class.</p></span></div></th>
+<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not reject use of TypeVar in ClassVar.</p><p>Does not reject use of ParamSpec in ClassVar.</p><p>Does not reject use of ClassVar as a generic type argument.</p><p>Rejects initialization of ClassVar if no type argument is provided.</p><p>Does not infer ClassVar with no type argument and no assigned value as Any.</p><p>Does not reject use of ClassVar in parameter type annotation.</p><p>Does not reject use of ClassVar in local variable annotation.</p><p>Does not reject use of ClassVar in instance variable annotation.</p><p>Does not reject use of ClassVar in return type annotation.</p><p>Does not reject use of ClassVar in type alias definition.</p><p>Does not reject assignment of ClassVar through instance of class.</p></span></div></th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;classes_override</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not handle case where parent class derives from Any.</p></span></div></th>

--- a/conformance/tests/typeddicts_class_syntax.py
+++ b/conformance/tests/typeddicts_class_syntax.py
@@ -30,13 +30,13 @@ class BadTypedDict1(TypedDict):
         pass
 
     # Methods are not allowed, so this should generate an error.
-    @classmethod  # E
-    def method2(cls):
+    @classmethod  # E[method2]
+    def method2(cls):  # E[method2]
         pass
 
     # Methods are not allowed, so this should generate an error.
-    @staticmethod  # E
-    def method3():
+    @staticmethod  # E[method3]
+    def method3():  # E[method3]
         pass
 
 


### PR DESCRIPTION
Instead of requiring the error to be on the line with the decorator (if present), also allow it on the line with the `def`