### PR TITLE
Replace typing_extensions -> typing in examples

### DIFF
--- a/docs/guides/unreachable.rst
+++ b/docs/guides/unreachable.rst
@@ -54,7 +54,7 @@ As an example, consider this simple calculator:
 .. code:: python
 
    import enum
-   from typing_extensions import Never
+   from typing import Never
 
    def assert_never(arg: Never) -> Never:
        raise AssertionError("Expected code to be unreachable")

--- a/docs/reference/generics.rst
+++ b/docs/reference/generics.rst
@@ -651,8 +651,7 @@ for a more faithful type annotation:
 
 .. code-block:: python
 
-   from typing import Callable, TypeVar
-   from typing_extensions import ParamSpec
+   from typing import Callable, ParamSpec, TypeVar
 
    P = ParamSpec('P')
    T = TypeVar('T')
@@ -668,8 +667,7 @@ alter the signature of the input function:
 
 .. code-block:: python
 
-   from typing import Callable, TypeVar
-   from typing_extensions import ParamSpec
+   from typing import Callable, ParamSpec, TypeVar
 
    P = ParamSpec('P')
    T = TypeVar('T')
@@ -692,8 +690,7 @@ Or insert an argument:
 
 .. code-block:: python
 
-    from typing import Callable, TypeVar
-    from typing_extensions import Concatenate, ParamSpec
+    from typing import Callable, Concatenate, ParamSpec, TypeVar
 
     P = ParamSpec('P')
     T = TypeVar('T')
@@ -774,8 +771,7 @@ Example:
 
 .. code-block:: python
 
-   from typing import TypeVar
-   from typing_extensions import Protocol
+   from typing import Protocol, TypeVar
 
    T = TypeVar('T')
 

--- a/docs/reference/protocols.rst
+++ b/docs/reference/protocols.rst
@@ -71,8 +71,7 @@ You can define your own protocol class by inheriting from the special
 
 .. code-block:: python
 
-   from typing import Iterable
-   from typing_extensions import Protocol
+   from typing import Iterable, Protocol
 
    class SupportsClose(Protocol):
        # Empty method body (explicit '...')
@@ -231,8 +230,7 @@ such as trees and linked lists:
 
 .. code-block:: python
 
-   from typing import TypeVar, Optional
-   from typing_extensions import Protocol
+   from typing import TypeVar, Optional, Protocol
 
    class TreeLike(Protocol):
        value: int
@@ -260,7 +258,7 @@ rudimentary support for runtime structural checks:
 
 .. code-block:: python
 
-   from typing_extensions import Protocol, runtime_checkable
+   from typing import Protocol, runtime_checkable
 
    @runtime_checkable
    class Portable(Protocol):
@@ -303,8 +301,7 @@ member:
 
 .. code-block:: python
 
-   from typing import Optional, Iterable
-   from typing_extensions import Protocol
+   from typing import Optional, Iterable, Protocol
 
    class Combiner(Protocol):
        def __call__(self, *vals: bytes, maxlen: Optional[int] = None) -> list[bytes]: ...
@@ -328,8 +325,7 @@ a double underscore prefix is used. For example:
 
 .. code-block:: python
 
-   from typing import Callable, TypeVar
-   from typing_extensions import Protocol
+   from typing import Callable, TypeVar, Protocol
 
    T = TypeVar('T')
 

--- a/docs/reference/quality.rst
+++ b/docs/reference/quality.rst
@@ -40,7 +40,7 @@ then the following file tests ``foo.py``:
 
 .. code-block:: python
 
-    from typing_extensions import assert_type
+    from typing import assert_type
 
     assert_type(bar(42), str)
 


### PR DESCRIPTION
Fixes #1986.