### PR TITLE
Explain that `GenericAlias` instances are not considered to be a class

### DIFF
--- a/docs/spec/generics.rst
+++ b/docs/spec/generics.rst
@@ -397,8 +397,8 @@ the runtime class of the objects created by instantiating them doesn't
 record the distinction. This behavior is called "type erasure"; it is
 common practice in languages with generics (e.g. Java, TypeScript).
 
-Additionally, at the runtime, objects like ``Node[int]`` will not be considered as a class,
-even though they behave like them. This is because these objects are instances of ``GenericAlias``::
+Additionally, objects like ``Node[int]`` will not be considered as a class at the runtime,
+even though they behave like them (e.g they can be instantiated). This is because these objects are instances of ``GenericAlias``::
 
     import inspect
 

--- a/docs/spec/generics.rst
+++ b/docs/spec/generics.rst
@@ -397,6 +397,17 @@ the runtime class of the objects created by instantiating them doesn't
 record the distinction. This behavior is called "type erasure"; it is
 common practice in languages with generics (e.g. Java, TypeScript).
 
+Additionally, at the runtime, objects like ``Node[int]`` will not be considered as a class,
+even though they behave like them. This is because these objects are instances of ``GenericAlias``::
+
+    import inspect
+
+    inspect.isclass(Node)  # True
+    inspect.isclass(Node[int])  # False
+    inspect.isclass(Node[str])  # False
+
+    type(Node[int]) # <class 'typing._GenericAlias'>
+
 Using generic classes (parameterized or not) to access attributes will result
 in type check failure. Outside the class definition body, a class attribute
 cannot be assigned, and can only be looked up by accessing it through a


### PR DESCRIPTION
I added new explanations to the part of the document that relates to that issue (after explanation of "type erasure").

Related issue: python/cpython#132467