### PR TITLE
Extend possible error location in overloads_definitions.py

### DIFF
--- a/conformance/tests/overloads_definitions.py
+++ b/conformance/tests/overloads_definitions.py
@@ -194,7 +194,7 @@ class Child(Base):  # E[override-final]
     @overload
     def bad_override(self, x: str) -> str: ...
 
-    @override
+    @override  # E[bad_override]
     def bad_override(self, x: int | str) -> int | str:  # E[bad_override]
         ...
 


### PR DESCRIPTION
This extends possible error locations for an invalid override in overloads_definitions.py.
This is consistent with other test classes_override.py where it's allowed to place such error at the override decorator itself.