### PR TITLE
Removed mandatory enforcement of a dataclass check

### DIFF
--- a/conformance/results/mypy/dataclasses_inheritance.toml
+++ b/conformance/results/mypy/dataclasses_inheritance.toml
@@ -1,12 +1,8 @@
-conformant = "Partial"
-notes = """
-Does not report when the default value of dataclass field is mutable (is of type list, dict, or set).
-"""
+conformant = "Pass"
 output = """
-dataclasses_inheritance.py:60: error: Cannot override instance variable (previously declared on base class "DC6") with class variable  [misc]
-dataclasses_inheritance.py:64: error: Cannot override class variable (previously declared on base class "DC6") with instance variable  [misc]
+dataclasses_inheritance.py:62: error: Cannot override instance variable (previously declared on base class "DC6") with class variable  [misc]
+dataclasses_inheritance.py:66: error: Cannot override class variable (previously declared on base class "DC6") with instance variable  [misc]
 """
-conformance_automated = "Fail"
+conformance_automated = "Pass"
 errors_diff = """
-Line 47: Expected 1 errors
 """

--- a/conformance/results/mypy/version.toml
+++ b/conformance/results/mypy/version.toml
@@ -1,2 +1,2 @@
 version = "mypy 1.16.0"
-test_duration = 2.0
+test_duration = 1.7

--- a/conformance/results/pyre/dataclasses_inheritance.toml
+++ b/conformance/results/pyre/dataclasses_inheritance.toml
@@ -1,6 +1,5 @@
 conformant = "Partial"
 notes = """
-Does not report when the default value of dataclass field is mutable (is of type list, dict, or set).
 Does not reject ClassVar that is overridden by instance variable.
 Does not reject instance variable that is overridden by ClassVar.
 """
@@ -8,7 +7,6 @@ output = """
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 47: Expected 1 errors
-Line 60: Expected 1 errors
-Line 64: Expected 1 errors
+Line 62: Expected 1 errors
+Line 66: Expected 1 errors
 """

--- a/conformance/results/pyre/version.toml
+++ b/conformance/results/pyre/version.toml
@@ -1,2 +1,2 @@
 version = "pyre 0.9.23"
-test_duration = 9.1
+test_duration = 6.6

--- a/conformance/results/pyright/aliases_typealiastype.toml
+++ b/conformance/results/pyright/aliases_typealiastype.toml
@@ -1,7 +1,4 @@
-conformant = "Partial"
-notes = """
-Incorrectly allows undefined self reference.
-"""
+conformant = "Pass"
 output = """
 aliases_typealiastype.py:32:18 - error: Cannot access attribute "other_attrib" for class "TypeAliasType"
   Attribute "other_attrib" is unknown (reportAttributeAccessIssue)

--- a/conformance/results/pyright/dataclasses_inheritance.toml
+++ b/conformance/results/pyright/dataclasses_inheritance.toml
@@ -1,12 +1,8 @@
-conformant = "Partial"
-notes = """
-Does not report when the default value of dataclass field is mutable (is of type list, dict, or set).
-"""
+conformant = "Pass"
 output = """
-dataclasses_inheritance.py:60:5 - error: Class variable "x" overrides instance variable of same name in class "DC6" (reportIncompatibleVariableOverride)
-dataclasses_inheritance.py:64:5 - error: Instance variable "y" overrides class variable of same name in class "DC6" (reportIncompatibleVariableOverride)
+dataclasses_inheritance.py:62:5 - error: Class variable "x" overrides instance variable of same name in class "DC6" (reportIncompatibleVariableOverride)
+dataclasses_inheritance.py:66:5 - error: Instance variable "y" overrides class variable of same name in class "DC6" (reportIncompatibleVariableOverride)
 """
-conformance_automated = "Fail"
+conformance_automated = "Pass"
 errors_diff = """
-Line 47: Expected 1 errors
 """

--- a/conformance/results/pyright/version.toml
+++ b/conformance/results/pyright/version.toml
@@ -1,2 +1,2 @@
 version = "pyright 1.1.401"
-test_duration = 1.4
+test_duration = 1.0

--- a/conformance/results/results.html
+++ b/conformance/results/results.html
@@ -159,13 +159,13 @@
         <div class="table_container"><table><tbody>
 <tr><th class="col1">&nbsp;</th>
 <th class='tc-header'><div class='tc-name'>mypy 1.16.0</div>
-<div class='tc-time'>2.0sec</div>
+<div class='tc-time'>1.7sec</div>
 </th>
 <th class='tc-header'><div class='tc-name'>pyright 1.1.401</div>
-<div class='tc-time'>1.4sec</div>
+<div class='tc-time'>1.0sec</div>
 </th>
 <th class='tc-header'><div class='tc-name'>pyre 0.9.23</div>
-<div class='tc-time'>9.1sec</div>
+<div class='tc-time'>6.6sec</div>
 </th>
 </tr>
 <tr><th class="column" colspan="4">
@@ -438,7 +438,7 @@
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;aliases_typealiastype</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Incorrectly rejects some recursive type aliases using TypeAliasType.</p><p>Incorrectly rejects the use of a class-scoped TypeVar in a TypeAliasType definition.</p></span></div></th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Incorrectly allows undefined self reference.</p></span></div></th>
+<th class="column col2 conformant">Pass</th>
 <th class="column col2 not-conformant"><div class="hover-text">Unsupported<span class="tooltip-text" id="bottom"><p>Support for TypeAliasType is not implemented.</p></span></div></th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;aliases_variance</th>
@@ -643,9 +643,9 @@
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not report when dataclass is not compatible with Hashable protocol.</p></span></div></th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dataclasses_inheritance</th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not report when the default value of dataclass field is mutable (is of type list, dict, or set).</p></span></div></th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not report when the default value of dataclass field is mutable (is of type list, dict, or set).</p></span></div></th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not report when the default value of dataclass field is mutable (is of type list, dict, or set).</p><p>Does not reject ClassVar that is overridden by instance variable.</p><p>Does not reject instance variable that is overridden by ClassVar.</p></span></div></th>
+<th class="column col2 conformant">Pass</th>
+<th class="column col2 conformant">Pass</th>
+<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not reject ClassVar that is overridden by instance variable.</p><p>Does not reject instance variable that is overridden by ClassVar.</p></span></div></th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dataclasses_kwonly</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Incorrectly rejects kw_only field with default before positional field.</p></span></div></th>

--- a/conformance/tests/dataclasses_inheritance.py
+++ b/conformance/tests/dataclasses_inheritance.py
@@ -42,9 +42,11 @@ dc4_1 = DC4(0.0, "", (1,))
 
 @dataclass
 class DC5:
-    # This should generate an error because a default value of
-    # type list, dict, or set generate a runtime error.
-    x: list[int] = []  # E
+    # While this generates an error at runtime for the stdlib dataclass,
+    # other libraries that use dataclass_transform don't have similar
+    # restrictions. It is therefore not required that a type checker
+    # report an error here.
+    x: list[int] = []  # E?
 
 
 @dataclass


### PR DESCRIPTION
Removed mandatory enforcement of "default value type of list, dict, or set" for dataclass fields in the `dataclasses_inheritance` test. This error is now optional for type checkers.

The typing spec doesn't mandate such a rule. This particular test in the conformance suite was based on a part of PEP 557 that was not officially incorporated into the typing spec, so it's questionable whether it belongs in the conformance suite in the first place. None of the major type checkers currently implement this check. I tried implementing it in pyright, and it creates a bunch of false positives for libraries like pydantic and attrs that use `dataclass_transform` and don't have this same limitation. See [this thread](https://github.com/microsoft/pyright/issues/10553) for more details.

Also fixed the conformance summary for pyright in the `aliases_typealiastype` test, which was out of date and didn't reflect the fact that pyright now passes this test.