### PR TITLE
Table of Content improvements

### DIFF
--- a/docs/guides/index.rst
+++ b/docs/guides/index.rst
@@ -1,9 +1,14 @@
+:orphan:
+
 ******************
 Type System Guides
 ******************
 
+..
+   Keep in sync with docs/index.rst.
+
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :caption: Contents:
 
    libraries

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,18 +5,33 @@ Static Typing with Python
 Guides
 ======
 
-.. toctree::
-   :maxdepth: 2
+..
+   Keep in sync with docs/guides/index.rst.
 
-   guides/index
+.. toctree::
+   :maxdepth: 1
+
+   guides/libraries
+   guides/writing_stubs
+   guides/modernizing
+   guides/unreachable
+   guides/type_narrowing
+   guides/typing_anti_pitch
 
 Reference
 =========
 
-.. toctree::
-   :maxdepth: 2
+..
+   Keep in sync with docs/reference/index.rst.
 
-   reference/index
+.. toctree::
+   :maxdepth: 1
+
+   reference/generics
+   reference/protocols
+   reference/best_practices
+   reference/quality
+   typing Module Documentation <https://docs.python.org/3/library/typing.html>
 
 .. seealso::
 
@@ -27,7 +42,7 @@ Specification
 =============
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
 
    spec/index
 

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -1,6 +1,11 @@
+:orphan:
+
 *********************
 Type System Reference
 *********************
+
+..
+   Keep in sync with docs/index.rst.
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
* Remove extra top levels from main ToC.
* Don't include sub-chapters of the specification in the main ToC.
* Reduce the ToC level by one on the guides index.