### PR TITLE
Small improvements to the conformance tests

### DIFF
--- a/conformance/results/mypy/aliases_recursive.toml
+++ b/conformance/results/mypy/aliases_recursive.toml
@@ -6,7 +6,7 @@ aliases_recursive.py:38: error: Incompatible types in assignment (expression has
 aliases_recursive.py:39: error: Name "t6" already defined on line 38  [no-redef]
 aliases_recursive.py:50: error: Dict entry 0 has incompatible type "str": "list[int]"; expected "str": "str | int | Mapping[str, RecursiveMapping]"  [dict-item]
 aliases_recursive.py:51: error: Dict entry 2 has incompatible type "str": "list[int]"; expected "str": "str | int | Mapping[str, RecursiveMapping]"  [dict-item]
-aliases_recursive.py:52: error: Dict entry 2 has incompatible type "str": "dict[str, str | int | list[int]]"; expected "str": "str | int | Mapping[str, RecursiveMapping]"  [dict-item]
+aliases_recursive.py:52: error: Dict entry 2 has incompatible type "str": "list[int]"; expected "str": "str | int | Mapping[str, RecursiveMapping]"  [dict-item]
 aliases_recursive.py:63: error: List item 0 has incompatible type "float"; expected "GenericTypeAlias1[str] | str"  [list-item]
 aliases_recursive.py:69: error: List item 0 has incompatible type "float"; expected "GenericTypeAlias2[str, int] | str | int"  [list-item]
 aliases_recursive.py:72: error: Invalid recursive alias: a union item of itself  [misc]

--- a/conformance/results/mypy/annotations_generators.toml
+++ b/conformance/results/mypy/annotations_generators.toml
@@ -16,7 +16,5 @@ annotations_generators.py:119: error: Incompatible types in "yield from" (actual
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 87: Expected 1 errors
-Line 92: Expected 1 errors
 Line 135: Expected 1 errors
 """

--- a/conformance/results/mypy/dataclasses_transform_func.toml
+++ b/conformance/results/mypy/dataclasses_transform_func.toml
@@ -4,15 +4,15 @@ Does not handle `kw_only=False` override when `kw_only_default=True`.
 Does not report error when `order=False` and comparison operators are used.
 """
 output = """
-dataclasses_transform_func.py:53: error: Too many positional arguments for "Customer1"  [misc]
-dataclasses_transform_func.py:57: error: Incompatible types in assignment (expression has type "int", variable has type "str")  [assignment]
-dataclasses_transform_func.py:65: error: Unexpected keyword argument "salary" for "Customer1"  [call-arg]
-dataclasses_transform_func.py:71: error: Too many positional arguments for "Customer2"  [misc]
-dataclasses_transform_func.py:90: error: Non-frozen dataclass cannot inherit from a frozen dataclass  [misc]
-dataclasses_transform_func.py:97: error: Property "id" defined in "Customer3" is read-only  [misc]
+dataclasses_transform_func.py:52: error: Too many positional arguments for "Customer1"  [misc]
+dataclasses_transform_func.py:56: error: Incompatible types in assignment (expression has type "int", variable has type "str")  [assignment]
+dataclasses_transform_func.py:64: error: Unexpected keyword argument "salary" for "Customer1"  [call-arg]
+dataclasses_transform_func.py:70: error: Too many positional arguments for "Customer2"  [misc]
+dataclasses_transform_func.py:89: error: Non-frozen dataclass cannot inherit from a frozen dataclass  [misc]
+dataclasses_transform_func.py:96: error: Property "id" defined in "Customer3" is read-only  [misc]
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 61: Expected 1 errors
-Line 53: Unexpected errors ['dataclasses_transform_func.py:53: error: Too many positional arguments for "Customer1"  [misc]']
+Line 60: Expected 1 errors
+Line 52: Unexpected errors ['dataclasses_transform_func.py:52: error: Too many positional arguments for "Customer1"  [misc]']
 """

--- a/conformance/results/mypy/version.toml
+++ b/conformance/results/mypy/version.toml
@@ -1,2 +1,2 @@
-version = "mypy 1.17.0"
-test_duration = 1.9
+version = "mypy 1.17.1"
+test_duration = 2.8

--- a/conformance/results/pyre/dataclasses_transform_func.toml
+++ b/conformance/results/pyre/dataclasses_transform_func.toml
@@ -5,37 +5,37 @@ Does not detect non-frozen class inheriting from frozen class.
 Emits "attribute not initialized" error for dataclass field.
 """
 output = """
-dataclasses_transform_func.py:25:5 Invalid type variable [34]: The type variable `Variable[T]` isn't present in the function's parameters.
-dataclasses_transform_func.py:29:0 Incompatible overload [43]: This definition does not have the same decorators as the preceding overload(s).
-dataclasses_transform_func.py:35:4 Uninitialized attribute [13]: Attribute `id` is declared in class `Customer1` to have type `int` but is never initialized.
-dataclasses_transform_func.py:36:4 Uninitialized attribute [13]: Attribute `name` is declared in class `Customer1` to have type `str` but is never initialized.
-dataclasses_transform_func.py:41:4 Uninitialized attribute [13]: Attribute `id` is declared in class `Customer2` to have type `int` but is never initialized.
-dataclasses_transform_func.py:42:4 Uninitialized attribute [13]: Attribute `name` is declared in class `Customer2` to have type `str` but is never initialized.
-dataclasses_transform_func.py:47:4 Uninitialized attribute [13]: Attribute `salary` is declared in class `Customer2Subclass` to have type `float` but is never initialized.
-dataclasses_transform_func.py:50:7 Unexpected keyword [28]: Unexpected keyword argument `id` to call `object.__init__`.
-dataclasses_transform_func.py:53:7 Too many arguments [19]: Call `object.__init__` expects 0 positional arguments, 2 were provided.
-dataclasses_transform_func.py:57:0 Incompatible attribute type [8]: Attribute `name` declared in class `Customer1` has type `str` but is used as type `int`.
-dataclasses_transform_func.py:61:5 Unsupported operand [58]: `<` is not supported for operand types `Customer1` and `Customer1`.
-dataclasses_transform_func.py:65:7 Unexpected keyword [28]: Unexpected keyword argument `id` to call `object.__init__`.
-dataclasses_transform_func.py:67:7 Unexpected keyword [28]: Unexpected keyword argument `id` to call `object.__init__`.
-dataclasses_transform_func.py:71:7 Too many arguments [19]: Call `object.__init__` expects 0 positional arguments, 2 were provided.
-dataclasses_transform_func.py:73:5 Unsupported operand [58]: `<` is not supported for operand types `Customer2` and `Customer2`.
-dataclasses_transform_func.py:91:4 Uninitialized attribute [13]: Attribute `age` is declared in class `Customer3Subclass` to have type `int` but is never initialized.
-dataclasses_transform_func.py:97:0 Invalid assignment [41]: Cannot reassign final attribute `c3_1.id`.
+dataclasses_transform_func.py:19:0 Incompatible overload [43]: This definition does not have the same decorators as the preceding overload(s).
+dataclasses_transform_func.py:24:5 Invalid type variable [34]: The type variable `Variable[T]` isn't present in the function's parameters.
+dataclasses_transform_func.py:34:4 Uninitialized attribute [13]: Attribute `id` is declared in class `Customer1` to have type `int` but is never initialized.
+dataclasses_transform_func.py:35:4 Uninitialized attribute [13]: Attribute `name` is declared in class `Customer1` to have type `str` but is never initialized.
+dataclasses_transform_func.py:40:4 Uninitialized attribute [13]: Attribute `id` is declared in class `Customer2` to have type `int` but is never initialized.
+dataclasses_transform_func.py:41:4 Uninitialized attribute [13]: Attribute `name` is declared in class `Customer2` to have type `str` but is never initialized.
+dataclasses_transform_func.py:46:4 Uninitialized attribute [13]: Attribute `salary` is declared in class `Customer2Subclass` to have type `float` but is never initialized.
+dataclasses_transform_func.py:49:7 Unexpected keyword [28]: Unexpected keyword argument `id` to call `object.__init__`.
+dataclasses_transform_func.py:52:7 Too many arguments [19]: Call `object.__init__` expects 0 positional arguments, 2 were provided.
+dataclasses_transform_func.py:56:0 Incompatible attribute type [8]: Attribute `name` declared in class `Customer1` has type `str` but is used as type `int`.
+dataclasses_transform_func.py:60:5 Unsupported operand [58]: `<` is not supported for operand types `Customer1` and `Customer1`.
+dataclasses_transform_func.py:64:7 Unexpected keyword [28]: Unexpected keyword argument `id` to call `object.__init__`.
+dataclasses_transform_func.py:66:7 Unexpected keyword [28]: Unexpected keyword argument `id` to call `object.__init__`.
+dataclasses_transform_func.py:70:7 Too many arguments [19]: Call `object.__init__` expects 0 positional arguments, 2 were provided.
+dataclasses_transform_func.py:72:5 Unsupported operand [58]: `<` is not supported for operand types `Customer2` and `Customer2`.
+dataclasses_transform_func.py:90:4 Uninitialized attribute [13]: Attribute `age` is declared in class `Customer3Subclass` to have type `int` but is never initialized.
+dataclasses_transform_func.py:96:0 Invalid assignment [41]: Cannot reassign final attribute `c3_1.id`.
 """
 conformance_automated = "Fail"
 errors_diff = """
-Lines 89, 90: Expected error (tag 'Customer3Subclass')
-Line 25: Unexpected errors ["dataclasses_transform_func.py:25:5 Invalid type variable [34]: The type variable `Variable[T]` isn't present in the function's parameters."]
-Line 29: Unexpected errors ['dataclasses_transform_func.py:29:0 Incompatible overload [43]: This definition does not have the same decorators as the preceding overload(s).']
-Line 35: Unexpected errors ['dataclasses_transform_func.py:35:4 Uninitialized attribute [13]: Attribute `id` is declared in class `Customer1` to have type `int` but is never initialized.']
-Line 36: Unexpected errors ['dataclasses_transform_func.py:36:4 Uninitialized attribute [13]: Attribute `name` is declared in class `Customer1` to have type `str` but is never initialized.']
-Line 41: Unexpected errors ['dataclasses_transform_func.py:41:4 Uninitialized attribute [13]: Attribute `id` is declared in class `Customer2` to have type `int` but is never initialized.']
-Line 42: Unexpected errors ['dataclasses_transform_func.py:42:4 Uninitialized attribute [13]: Attribute `name` is declared in class `Customer2` to have type `str` but is never initialized.']
-Line 47: Unexpected errors ['dataclasses_transform_func.py:47:4 Uninitialized attribute [13]: Attribute `salary` is declared in class `Customer2Subclass` to have type `float` but is never initialized.']
-Line 50: Unexpected errors ['dataclasses_transform_func.py:50:7 Unexpected keyword [28]: Unexpected keyword argument `id` to call `object.__init__`.']
-Line 53: Unexpected errors ['dataclasses_transform_func.py:53:7 Too many arguments [19]: Call `object.__init__` expects 0 positional arguments, 2 were provided.']
-Line 67: Unexpected errors ['dataclasses_transform_func.py:67:7 Unexpected keyword [28]: Unexpected keyword argument `id` to call `object.__init__`.']
-Line 73: Unexpected errors ['dataclasses_transform_func.py:73:5 Unsupported operand [58]: `<` is not supported for operand types `Customer2` and `Customer2`.']
-Line 91: Unexpected errors ['dataclasses_transform_func.py:91:4 Uninitialized attribute [13]: Attribute `age` is declared in class `Customer3Subclass` to have type `int` but is never initialized.']
+Lines 88, 89: Expected error (tag 'Customer3Subclass')
+Line 19: Unexpected errors ['dataclasses_transform_func.py:19:0 Incompatible overload [43]: This definition does not have the same decorators as the preceding overload(s).']
+Line 24: Unexpected errors ["dataclasses_transform_func.py:24:5 Invalid type variable [34]: The type variable `Variable[T]` isn't present in the function's parameters."]
+Line 34: Unexpected errors ['dataclasses_transform_func.py:34:4 Uninitialized attribute [13]: Attribute `id` is declared in class `Customer1` to have type `int` but is never initialized.']
+Line 35: Unexpected errors ['dataclasses_transform_func.py:35:4 Uninitialized attribute [13]: Attribute `name` is declared in class `Customer1` to have type `str` but is never initialized.']
+Line 40: Unexpected errors ['dataclasses_transform_func.py:40:4 Uninitialized attribute [13]: Attribute `id` is declared in class `Customer2` to have type `int` but is never initialized.']
+Line 41: Unexpected errors ['dataclasses_transform_func.py:41:4 Uninitialized attribute [13]: Attribute `name` is declared in class `Customer2` to have type `str` but is never initialized.']
+Line 46: Unexpected errors ['dataclasses_transform_func.py:46:4 Uninitialized attribute [13]: Attribute `salary` is declared in class `Customer2Subclass` to have type `float` but is never initialized.']
+Line 49: Unexpected errors ['dataclasses_transform_func.py:49:7 Unexpected keyword [28]: Unexpected keyword argument `id` to call `object.__init__`.']
+Line 52: Unexpected errors ['dataclasses_transform_func.py:52:7 Too many arguments [19]: Call `object.__init__` expects 0 positional arguments, 2 were provided.']
+Line 66: Unexpected errors ['dataclasses_transform_func.py:66:7 Unexpected keyword [28]: Unexpected keyword argument `id` to call `object.__init__`.']
+Line 72: Unexpected errors ['dataclasses_transform_func.py:72:5 Unsupported operand [58]: `<` is not supported for operand types `Customer2` and `Customer2`.']
+Line 90: Unexpected errors ['dataclasses_transform_func.py:90:4 Uninitialized attribute [13]: Attribute `age` is declared in class `Customer3Subclass` to have type `int` but is never initialized.']
 """

--- a/conformance/results/pyre/version.toml
+++ b/conformance/results/pyre/version.toml
@@ -1,2 +1,2 @@
 version = "pyre 0.9.25"
-test_duration = 7.4
+test_duration = 5.4

--- a/conformance/results/pyright/dataclasses_transform_func.toml
+++ b/conformance/results/pyright/dataclasses_transform_func.toml
@@ -1,12 +1,12 @@
 conformant = "Pass"
 output = """
-dataclasses_transform_func.py:57:13 - error: Cannot assign to attribute "name" for class "Customer1"
+dataclasses_transform_func.py:56:13 - error: Cannot assign to attribute "name" for class "Customer1"
   "Literal[3]" is not assignable to "str" (reportAttributeAccessIssue)
-dataclasses_transform_func.py:61:6 - error: Operator "<" not supported for types "Customer1" and "Customer1" (reportOperatorIssue)
-dataclasses_transform_func.py:65:36 - error: No parameter named "salary" (reportCallIssue)
-dataclasses_transform_func.py:71:18 - error: Expected 0 positional arguments (reportCallIssue)
-dataclasses_transform_func.py:89:1 - error: A non-frozen class cannot inherit from a class that is frozen (reportGeneralTypeIssues)
-dataclasses_transform_func.py:97:6 - error: Cannot assign to attribute "id" for class "Customer3"
+dataclasses_transform_func.py:60:6 - error: Operator "<" not supported for types "Customer1" and "Customer1" (reportOperatorIssue)
+dataclasses_transform_func.py:64:36 - error: No parameter named "salary" (reportCallIssue)
+dataclasses_transform_func.py:70:18 - error: Expected 0 positional arguments (reportCallIssue)
+dataclasses_transform_func.py:88:1 - error: A non-frozen class cannot inherit from a class that is frozen (reportGeneralTypeIssues)
+dataclasses_transform_func.py:96:6 - error: Cannot assign to attribute "id" for class "Customer3"
   Attribute "id" is read-only (reportAttributeAccessIssue)
 """
 conformance_automated = "Pass"

--- a/conformance/results/pyright/version.toml
+++ b/conformance/results/pyright/version.toml
@@ -1,2 +1,2 @@
 version = "pyright 1.1.403"
-test_duration = 1.4
+test_duration = 4.3

--- a/conformance/results/results.html
+++ b/conformance/results/results.html
@@ -158,14 +158,14 @@
         </header>
         <div class="table_container"><table><tbody>
 <tr><th class="col1">&nbsp;</th>
-<th class='tc-header'><div class='tc-name'>mypy 1.17.0</div>
-<div class='tc-time'>1.9sec</div>
+<th class='tc-header'><div class='tc-name'>mypy 1.17.1</div>
+<div class='tc-time'>2.8sec</div>
 </th>
 <th class='tc-header'><div class='tc-name'>pyright 1.1.403</div>
-<div class='tc-time'>1.4sec</div>
+<div class='tc-time'>4.3sec</div>
 </th>
 <th class='tc-header'><div class='tc-name'>pyre 0.9.25</div>
-<div class='tc-time'>7.4sec</div>
+<div class='tc-time'>5.4sec</div>
 </th>
 </tr>
 <tr><th class="column" colspan="4">

--- a/conformance/tests/annotations_generators.py
+++ b/conformance/tests/annotations_generators.py
@@ -84,12 +84,12 @@ def generator7() -> Iterator[dict[str, int]]:
 
 
 def generator8() -> int:  # E: incompatible return type
-    yield None  # E
+    yield None  # E?
     return 0
 
 
 async def generator9() -> int:  # E: incompatible return type
-    yield None  # E
+    yield None  # E?
 
 
 class IntIterator(Protocol):

--- a/conformance/tests/classes_override.py
+++ b/conformance/tests/classes_override.py
@@ -54,7 +54,7 @@ class ChildA(ParentA):
         return 1
 
     @overload  # E[method4]
-    def method4(self, x: int) -> int:
+    def method4(self, x: int) -> int:  # E[method4]
         ...
 
     @overload

--- a/conformance/tests/dataclasses_transform_func.py
+++ b/conformance/tests/dataclasses_transform_func.py
@@ -16,7 +16,6 @@ def create_model(cls: T) -> T:
 
 
 @overload
-@dataclass_transform(kw_only_default=True, order_default=True)
 def create_model(
     *,
     frozen: bool = False,


### PR DESCRIPTION
A few tweaks to the conformance tests that I'm hoping are uncontroversial. Happy to split up this PR if any of these seem like they need more discussion.

* When a generator is annotated incorrectly, pyright reports errors on both the return type and the `yield`, while mypy reports an error on just the return type. IMO both of these are reasonable choices, so I suggest we mark the error on the `yield` as optional.
* Most of the errors in class_override.py are tagged as allowed to occur on either the `@override` line or the `def` line. One error was missing a tag on the `def` line, which I've added.
* The `dataclass_transform` decorator should not be applied to more than one of an overloaded function's overloads and implementation (https://typing.python.org/en/latest/spec/dataclasses.html#specification). dataclasses_transform_func.py applied `dataclass_transform` to two overloads of the same function, so I removed the decorator from the second overload.