### PR TITLE
Remove free return in snippet

### DIFF
--- a/docs/guides/writing_stubs.rst
+++ b/docs/guides/writing_stubs.rst
@@ -811,7 +811,7 @@ This avoid forcing the user to check for ``None``::
     match = re.fullmatch(r"\d+_(.*)", some_string)
     assert match is not None
     name_group = match.group(1)  # The user knows that this will never be None
-    return name_group.uper()  # This typo will be flagged by the type checker
+    name_group.uper()  # This typo will be flagged by the type checker
 
 In this case, the user of ``match.group()`` must be prepared to handle a ``str``,
 but type checkers are happy with ``if name_group is None`` checks, because we're


### PR DESCRIPTION
Currently there is a return statement in the snippet that can be removed. This makes the snippet also have valid syntax.