### PR TITLE
chore: Remove unused library tqdm

### DIFF
--- a/conformance/requirements.txt
+++ b/conformance/requirements.txt
@@ -1,6 +1,5 @@
 tomli
 tomlkit
-tqdm
 pyright
 mypy
 pip

--- a/conformance/src/type_checker.py
+++ b/conformance/src/type_checker.py
@@ -10,7 +10,6 @@ import re
 import shutil
 from subprocess import PIPE, CalledProcessError, run
 import sys
-from tqdm import tqdm
 from typing import Sequence
 
 


### PR DESCRIPTION
## Why?

Appears like tqdm is unused, probably since removal of pytype?

## What?

Remove from `requirements.txt` and `type_checker.py`

## Testing

https://github.com/search?q=repo%3Apython%2Ftyping%20tqdm&type=code

No usage of tqdm beyond the import and package in requirements.txt

Running `python main.py` runs sucessfully