### PR TITLE
Updated the typing spec to use modern (PEP 695) generics syntax

### DIFF
--- a/docs/spec/aliases.rst
+++ b/docs/spec/aliases.rst
@@ -34,29 +34,24 @@ Type aliases may be as complex as type hints in annotations --
 anything that is acceptable as a type hint is acceptable in a type
 alias::
 
-    from typing import TypeVar
     from collections.abc import Iterable
 
-    T = TypeVar('T', bound=float)
-    Vector = Iterable[tuple[T, T]]
+    type Vector[T: float] = Iterable[tuple[T, T]]
 
-    def inproduct(v: Vector[T]) -> T:
+    def inproduct[T: float](v: Vector[T]) -> T:
         return sum(x*y for x, y in v)
-    def dilate(v: Vector[T], scale: T) -> Vector[T]:
+    def dilate[T: float](v: Vector[T], scale: T) -> Vector[T]:
         return ((x * scale, y * scale) for x, y in v)
     vec: Vector[float] = []
 
 
 This is equivalent to::
 
-    from typing import TypeVar
     from collections.abc import Iterable
 
-    T = TypeVar('T', bound=float)
-
-    def inproduct(v: Iterable[tuple[T, T]]) -> T:
+    def inproduct[T: float](v: Iterable[tuple[T, T]]) -> T:
         return sum(x*y for x, y in v)
-    def dilate(v: Iterable[tuple[T, T]], scale: T) -> Iterable[tuple[T, T]]:
+    def dilate[T: float](v: Iterable[tuple[T, T]], scale: T) -> Iterable[tuple[T, T]]:
         return ((x * scale, y * scale) for x, y in v)
     vec: Iterable[tuple[float, float]] = []
 

--- a/docs/spec/annotations.rst
+++ b/docs/spec/annotations.rst
@@ -367,7 +367,7 @@ with a type variable. In this case the return type may use the same
 type variable, thus making that method a generic function. For example::
 
   class Copyable:
-      def copy[T: 'Copyable'](self: T) -> T:
+      def copy[T: Copyable](self: T) -> T:
           # return a copy of self
 
   class C(Copyable): ...

--- a/docs/spec/annotations.rst
+++ b/docs/spec/annotations.rst
@@ -379,7 +379,7 @@ of the first argument::
 
   class C:
       @classmethod
-      def factory[T: 'C'](cls: type[T]) -> T:
+      def factory[T: C](cls: type[T]) -> T:
           # make a new instance of cls
 
   class D(C): ...

--- a/docs/spec/annotations.rst
+++ b/docs/spec/annotations.rst
@@ -366,9 +366,8 @@ In addition, the first argument in an instance method can be annotated
 with a type variable. In this case the return type may use the same
 type variable, thus making that method a generic function. For example::
 
-  T = TypeVar('T', bound='Copyable')
   class Copyable:
-      def copy(self: T) -> T:
+      def copy[T: 'Copyable'](self: T) -> T:
           # return a copy of self
 
   class C(Copyable): ...
@@ -378,10 +377,9 @@ type variable, thus making that method a generic function. For example::
 The same applies to class methods using ``type[]`` in an annotation
 of the first argument::
 
-  T = TypeVar('T', bound='C')
   class C:
       @classmethod
-      def factory(cls: type[T]) -> T:
+      def factory[T: 'C'](cls: type[T]) -> T:
           # make a new instance of cls
 
   class D(C): ...

--- a/docs/spec/class-compat.rst
+++ b/docs/spec/class-compat.rst
@@ -101,11 +101,8 @@ For example, annotating the discussed class::
 As a matter of convenience (and convention), instance variables can be
 annotated in ``__init__`` or other methods, rather than in the class::
 
-  from typing import Generic, TypeVar
-  T = TypeVar('T')
-
-  class Box(Generic[T]):
-      def __init__(self, content):
+  class Box[T]:
+      def __init__(self, content: T):
           self.content: T = content
 
 ``ClassVar`` cannot be used as a qualifier for a :ref:`TypedDict <typeddict>`

--- a/docs/spec/constructors.rst
+++ b/docs/spec/constructors.rst
@@ -318,16 +318,14 @@ these method evaluations, they should take on their default values.
 
   ::
 
-    T1 = TypeVar("T1")
-    T2 = TypeVar("T2")
-    T3 = TypeVar("T3", default=str)
+    from typing import Any, Self, assert_type
 
-    class MyClass1(Generic[T1, T2]):
+    class MyClass1[T1, T2]:
         def __new__(cls, x: T1) -> Self: ...
 
     assert_type(MyClass1(1), MyClass1[int, Any])
 
-    class MyClass2(Generic[T1, T3]):
+    class MyClass2[T1, T3 = str]:
         def __new__(cls, x: T1) -> Self: ...
 
     assert_type(MyClass2(1), MyClass2[int, str])

--- a/docs/spec/dataclasses.rst
+++ b/docs/spec/dataclasses.rst
@@ -146,7 +146,11 @@ customization of default behaviors:
 
 .. code-block:: python
 
-  def dataclass_transform[T](
+  class _IdentityCallable(Protocol):
+      def __call__[T](self, arg: T, /) -> T:
+          ...
+
+  def dataclass_transform(
       *,
       eq_default: bool = True,
       order_default: bool = False,
@@ -154,7 +158,7 @@ customization of default behaviors:
       frozen_default: bool = False,
       field_specifiers: tuple[type | Callable[..., Any], ...] = (),
       **kwargs: Any,
-  ) -> Callable[[T], T]: ...
+  ) -> _IdentityCallable: ...
 
 * ``eq_default`` indicates whether the ``eq`` parameter is assumed to
   be True or False if it is omitted by the caller. If not specified,

--- a/docs/spec/dataclasses.rst
+++ b/docs/spec/dataclasses.rst
@@ -72,12 +72,10 @@ Decorator function example
 
 .. code-block:: python
 
-  _T = TypeVar("_T")
-
   # The ``create_model`` decorator is defined by a library.
   # This could be in a type stub or inline.
   @typing.dataclass_transform()
-  def create_model(cls: Type[_T]) -> Type[_T]:
+  def create_model[T](cls: type[T]) -> type[T]:
       cls.__init__ = ...
       cls.__eq__ = ...
       cls.__ne__ = ...
@@ -148,9 +146,7 @@ customization of default behaviors:
 
 .. code-block:: python
 
-  _T = TypeVar("_T")
-
-  def dataclass_transform(
+  def dataclass_transform[T](
       *,
       eq_default: bool = True,
       order_default: bool = False,
@@ -158,7 +154,7 @@ customization of default behaviors:
       frozen_default: bool = False,
       field_specifiers: tuple[type | Callable[..., Any], ...] = (),
       **kwargs: Any,
-  ) -> Callable[[_T], _T]: ...
+  ) -> Callable[[T], T]: ...
 
 * ``eq_default`` indicates whether the ``eq`` parameter is assumed to
   be True or False if it is omitted by the caller. If not specified,

--- a/docs/spec/generics.rst
+++ b/docs/spec/generics.rst
@@ -659,7 +659,7 @@ Declaration
 """"""""""""
 
 In Python 3.12 and newer, a parameter specification variable can be introduced
-inline by prefixing its name with ``**`` inside a generic parameter list
+inline by prefixing its name with ``**`` inside a type parameter list
 (for a function, class, or type alias).
 
 .. code-block::
@@ -730,7 +730,7 @@ specification.
 .. code-block::
 
    from collections.abc import Callable
-   from typing import Concatenate, ParamSpec
+   from typing import Concatenate
 
    class X[T, **P]:
        f: Callable[P, int]
@@ -1886,9 +1886,9 @@ literal "``...``" or another in-scope ``ParamSpec`` (see `Scoping Rules`_).
 
    class Foo[**P = [str, int]]: ...
 
-   reveal_type(Foo)                  # type is type[Foo[P = [str, int]]]
-   reveal_type(Foo())                # type is Foo[[str, int]]
-   reveal_type(Foo[[bool, bool]]())  # type is Foo[[bool, bool]]
+   reveal_type(Foo)                  # type is type[Foo[str, int]]
+   reveal_type(Foo())                # type is Foo[str, int]
+   reveal_type(Foo[[bool, bool]]())  # type is Foo[bool, bool]
 
 ``TypeVarTuple`` Defaults
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1901,7 +1901,7 @@ types or an unpacked, in-scope ``TypeVarTuple`` (see `Scoping Rules`_).
 
    class Foo[*Ts = *tuple[str, int]]: ...
 
-   reveal_type(Foo)               # type is type[Foo[Ts = *tuple[str, int]]]
+   reveal_type(Foo)               # type is type[Foo[str, int]]
    reveal_type(Foo())             # type is Foo[str, int]
    reveal_type(Foo[int, bool]())  # type is Foo[int, bool]
 

--- a/docs/spec/generics.rst
+++ b/docs/spec/generics.rst
@@ -338,7 +338,7 @@ Instantiating generic classes and type erasure
 ----------------------------------------------
 
 User-defined generic classes can be instantiated. Suppose we write
-a ``Node`` class using the new generic class syntax::
+a ``Node`` class::
 
   class Node[T]:
       ...

--- a/docs/spec/generics.rst
+++ b/docs/spec/generics.rst
@@ -210,15 +210,22 @@ defined class is generic if you subclass one or more other generic classes and
 specify type variables for their parameters. See :ref:`generic-base-classes`
 for details.
 
-You can use multiple inheritance with generic classes::
+You can use multiple inheritance with ``Generic``::
 
-  from collections.abc import Container, Iterable, Sized
+  from typing import TypeVar, Generic
+  from collections.abc import Sized, Iterable, Container
 
-  class LinkedList[T](Sized):
+  T = TypeVar('T')
+
+  class LinkedList(Sized, Generic[T]):
       ...
 
-  class MyMapping[K, V](Iterable[tuple[K, V]],
-                        Container[tuple[K, V]]):
+  K = TypeVar('K')
+  V = TypeVar('V')
+
+  class MyMapping(Iterable[tuple[K, V]],
+                  Container[tuple[K, V]],
+                  Generic[K, V]):
       ...
 
 Subclassing a generic class without specifying type parameters assumes
@@ -240,7 +247,7 @@ Scoping rules for type variables
 
 When using the generic class syntax introduced in Python 3.12, the location of
 its declaration defines its scope. When using the older syntax, the scoping
-rules are more subtle and complex.
+rules are more subtle and complex:
 
 * A type variable used in a generic function could be inferred to represent
   different types in the same code block. Example::
@@ -662,7 +669,7 @@ inline by prefixing its name with ``**`` inside a generic parameter list
    class CallbackWrapper[T, **P]:
        callback: Callable[P, T]
 
-Prior to 3.12, the ``ParamSpec`` constructor can be used::
+Prior to 3.12, the ``ParamSpec`` constructor can be used.
 
 .. code-block::
 
@@ -699,8 +706,8 @@ parameter specification variable (``Callable[Concatenate[int, P], int]``\ ).
                    "]"
 
 where ``parameter_specification_variable`` is introduced either inline (using
-``**``) or via ``typing.ParamSpec`` as shown above, and ``concatenate`` is
-``typing.Concatenate``.
+``**`` in a type parameter list) or via ``typing.ParamSpec`` as shown above,
+and ``concatenate`` is ``typing.Concatenate``.
 
 As before, ``parameters_expression``\ s by themselves are not acceptable in
 places where a type is expected
@@ -1086,7 +1093,7 @@ type such as ``int``, a type variable *tuple* is a stand-in for a *tuple* type s
 ``tuple[int, str]``.
 
 In Python 3.12 and newer, type variable tuples can be introduced inline by prefixing
-their name with ``*`` inside a generic parameter list.
+their name with ``*`` inside a type parameter list.
 
 ::
 

--- a/docs/spec/narrowing.rst
+++ b/docs/spec/narrowing.rst
@@ -34,9 +34,7 @@ User-defined type guards can be generic functions, as shown in this example:
 
 ::
 
-    _T = TypeVar("_T")
-
-    def is_two_element_tuple(val: Tuple[_T, ...]) -> TypeGuard[tuple[_T, _T]]:
+    def is_two_element_tuple[T](val: tuple[T, ...]) -> TypeGuard[tuple[T, T]]:
         return len(val) == 2
 
     def func(names: tuple[str, ...]):
@@ -65,9 +63,7 @@ than one argument:
             return allow_empty
         return all(isinstance(x, str) for x in val)
 
-    _T = TypeVar("_T")
-
-    def is_set_of(val: set[Any], type: type[_T]) -> TypeGuard[Set[_T]]:
+    def is_set_of[T](val: set[Any], type: type[T]) -> TypeGuard[set[T]]:
         return all(isinstance(x, type) for x in val)
 
 

--- a/docs/spec/overload.rst
+++ b/docs/spec/overload.rst
@@ -40,28 +40,28 @@ Another example where ``@overload`` comes in handy is the type of the
 builtin ``map()`` function, which takes a different number of
 arguments depending on the type of the callable::
 
-  from typing import TypeVar, overload
+  from typing import overload
   from collections.abc import Callable, Iterable, Iterator
 
-  T1 = TypeVar('T1')
-  T2 = TypeVar('T2')
-  S = TypeVar('S')
-
   @overload
-  def map(func: Callable[[T1], S], iter1: Iterable[T1]) -> Iterator[S]: ...
+  def map[T1, S](func: Callable[[T1], S], iter1: Iterable[T1]) -> Iterator[S]: ...
   @overload
-  def map(func: Callable[[T1, T2], S],
-          iter1: Iterable[T1], iter2: Iterable[T2]) -> Iterator[S]: ...
+  def map[T1, T2, S](
+      func: Callable[[T1, T2], S],
+      iter1: Iterable[T1], iter2: Iterable[T2],
+  ) -> Iterator[S]: ...
   # ... and we could add more items to support more than two iterables
 
 Note that we could also easily add items to support ``map(None, ...)``::
 
   @overload
-  def map(func: None, iter1: Iterable[T1]) -> Iterable[T1]: ...
+  def map[T1](func: None, iter1: Iterable[T1]) -> Iterable[T1]: ...
   @overload
-  def map(func: None,
-          iter1: Iterable[T1],
-          iter2: Iterable[T2]) -> Iterable[tuple[T1, T2]]: ...
+  def map[T1, T2](
+      func: None,
+      iter1: Iterable[T1],
+      iter2: Iterable[T2],
+  ) -> Iterable[tuple[T1, T2]]: ...
 
 Uses of the ``@overload`` decorator as shown above are suitable for
 stub files. In regular modules, a series of ``@overload``-decorated
@@ -91,11 +91,7 @@ A constrained ``TypeVar`` type can sometimes be used instead of
 using the ``@overload`` decorator. For example, the definitions
 of ``concat1`` and ``concat2`` in this stub file are equivalent::
 
-  from typing import TypeVar
-
-  AnyStr = TypeVar('AnyStr', str, bytes)
-
-  def concat1(x: AnyStr, y: AnyStr) -> AnyStr: ...
+  def concat1[AnyStr: (str, bytes)](x: AnyStr, y: AnyStr) -> AnyStr: ...
 
   @overload
   def concat2(x: str, y: str) -> str: ...
@@ -113,7 +109,7 @@ constraints for generic class type parameters. For example, the type
 parameter of the generic class ``typing.IO`` is constrained (only
 ``IO[str]``, ``IO[bytes]`` and ``IO[Any]`` are valid)::
 
-  class IO(Generic[AnyStr]): ...
+  class IO[AnyStr: (str, bytes)]: ...
 
 
 Invalid overload definitions

--- a/docs/spec/overload.rst
+++ b/docs/spec/overload.rst
@@ -48,7 +48,8 @@ arguments depending on the type of the callable::
   @overload
   def map[T1, T2, S](
       func: Callable[[T1, T2], S],
-      iter1: Iterable[T1], iter2: Iterable[T2],
+      iter1: Iterable[T1],
+      iter2: Iterable[T2],
   ) -> Iterator[S]: ...
   # ... and we could add more items to support more than two iterables
 
@@ -91,7 +92,7 @@ A constrained ``TypeVar`` type can sometimes be used instead of
 using the ``@overload`` decorator. For example, the definitions
 of ``concat1`` and ``concat2`` in this stub file are equivalent::
 
-  def concat1[AnyStr: (str, bytes)](x: AnyStr, y: AnyStr) -> AnyStr: ...
+  def concat1[S: (str, bytes)](x: S, y: S) -> S: ...
 
   @overload
   def concat2(x: str, y: str) -> str: ...
@@ -103,13 +104,13 @@ be represented precisely using type variables. We
 recommend that ``@overload`` is only used in cases where a type
 variable is not sufficient.
 
-Another important difference between type variables such as ``AnyStr``
-and using ``@overload`` is that the prior can also be used to define
-constraints for generic class type parameters. For example, the type
-parameter of the generic class ``typing.IO`` is constrained (only
-``IO[str]``, ``IO[bytes]`` and ``IO[Any]`` are valid)::
+Another important difference between type variables and an ``@overload``
+is that the former can also be used to define constraints for generic
+class type parameters. For example, the type parameter of the generic
+class ``typing.IO`` is constrained (only ``IO[str]``, ``IO[bytes]``
+and ``IO[Any]`` are valid)::
 
-  class IO[AnyStr: (str, bytes)]: ...
+  class IO[S: (str, bytes)]: ...
 
 
 Invalid overload definitions

--- a/docs/spec/protocol.rst
+++ b/docs/spec/protocol.rst
@@ -266,25 +266,25 @@ Generic protocols are important. For example, ``SupportsAbs``, ``Iterable``
 and ``Iterator`` are generic protocols. They are defined similar to normal
 non-protocol generic types::
 
-  class Iterable(Protocol[T]):
+  class Iterable[T](Protocol):
       @abstractmethod
       def __iter__(self) -> Iterator[T]:
           ...
 
-``Protocol[T, S, ...]`` is allowed as a shorthand for
-``Protocol, Generic[T, S, ...]``. It is an error to combine
-``Protocol[T, S, ...]`` with ``Generic[T, S, ...]``, or with the new syntax for
-generic classes in Python 3.12 and above::
+The older syntax ``Protocol[T, S, ...]`` remains available as a shorthand for
+``Protocol, Generic[T, S, ...]``. It is an error to combine the shorthand with
+``Generic[T, S, ...]`` or to mix it with the new ``class Iterable[T]`` form::
 
-  class Iterable(Protocol[T], Generic[T]):   # INVALID
+  class Iterable[T](Protocol, Generic[T]):   # INVALID
       ...
 
   class Iterable[T](Protocol[T]):   # INVALID
       ...
 
-User-defined generic protocols support explicitly declared variance.
-Type checkers will warn if the inferred variance is different from
-the declared variance. Examples::
+When using the generics syntax introduced in Python 3.12, the variance of
+type variables is inferred. When using the pre-3.12 generics syntax, variance
+must be specified. Type checkers will warn if the declared variance does not
+match the protocol definition. Examples::
 
   T = TypeVar('T')
   T_co = TypeVar('T_co', covariant=True)
@@ -362,17 +362,15 @@ Self-types in protocols
 The self-types in protocols follow the
 :ref:`rules for other methods <annotating-methods>`. For example::
 
-  C = TypeVar('C', bound='Copyable')
   class Copyable(Protocol):
-      def copy(self: C) -> C:
+      def copy[C: Copyable](self: C) -> C:
 
   class One:
       def copy(self) -> 'One':
           ...
 
-  T = TypeVar('T', bound='Other')
   class Other:
-      def copy(self: T) -> T:
+      def copy[T: Other](self: T) -> T:
           ...
 
   c: Copyable
@@ -407,8 +405,7 @@ corresponding protocols are *not imported*::
   # file lib.py
   from collections.abc import Sized
 
-  T = TypeVar('T', contravariant=True)
-  class ListLike(Sized, Protocol[T]):
+  class ListLike[T](Sized, Protocol):
       def append(self, x: T) -> None:
           pass
 
@@ -535,13 +532,12 @@ illusion that a distinct type is provided::
 In contrast, type aliases are fully supported, including generic type
 aliases::
 
-  from typing import TypeVar
   from collections.abc import Reversible, Iterable, Sized
 
-  T = TypeVar('T')
-  class SizedIterable(Iterable[T], Sized, Protocol):
+  class SizedIterable[T](Iterable[T], Sized, Protocol):
       pass
-  CompatReversible = Reversible[T] | SizedIterable[T]
+
+  type CompatReversible[T] = Reversible[T] | SizedIterable[T]
 
 
 Modules as implementations of protocols

--- a/docs/spec/protocol.rst
+++ b/docs/spec/protocol.rst
@@ -271,11 +271,12 @@ non-protocol generic types::
       def __iter__(self) -> Iterator[T]:
           ...
 
-The older syntax ``Protocol[T, S, ...]`` remains available as a shorthand for
-``Protocol, Generic[T, S, ...]``. It is an error to combine the shorthand with
-``Generic[T, S, ...]`` or to mix it with the new ``class Iterable[T]`` form::
+The older (pre-3.12) syntax ``Protocol[T, S, ...]`` remains available as a
+shorthand for ``Protocol, Generic[T, S, ...]``. It is an error to combine the
+shorthand with ``Generic[T, S, ...]`` or to mix it with the new
+``class Iterable[T]`` form::
 
-  class Iterable[T](Protocol, Generic[T]):   # INVALID
+  class Iterable(Protocol[T], Generic[T]):   # INVALID
       ...
 
   class Iterable[T](Protocol[T]):   # INVALID

--- a/docs/spec/protocol.rst
+++ b/docs/spec/protocol.rst
@@ -284,8 +284,8 @@ shorthand with ``Generic[T, S, ...]`` or to mix it with the new
 
 When using the generics syntax introduced in Python 3.12, the variance of
 type variables is inferred. When using the pre-3.12 generics syntax, variance
-must be specified. Type checkers will warn if the declared variance does not
-match the protocol definition. Examples::
+must be specified (unless ``infer_variance=True`` is used). Type checkers will
+warn if the declared variance does not match the protocol definition. Examples::
 
   T = TypeVar('T')
   T_co = TypeVar('T_co', covariant=True)

--- a/docs/spec/qualifiers.rst
+++ b/docs/spec/qualifiers.rst
@@ -292,11 +292,8 @@ Here are the specific details of the syntax:
 * ``Annotated`` can be used in definition of nested and generic aliases,
   but only if it wraps a :term:`type expression`::
 
-    T = TypeVar("T")
-    Vec = Annotated[list[tuple[T, T]], MaxLen(10)]
-    V = Vec[int]
-
-    V == Annotated[list[tuple[int, int]], MaxLen(10)]
+    type Vec[T] = Annotated[list[tuple[T, T]], MaxLen(10)]
+    type V = Vec[int] # Annotated[list[tuple[int, int]], MaxLen(10)]
 
 * As with most :term:`special forms <special form>`, ``Annotated`` is not assignable to
   ``type`` or ``type[T]``::

--- a/docs/spec/special-types.rst
+++ b/docs/spec/special-types.rst
@@ -152,8 +152,7 @@ would be::
 However using ``type[]`` and a type variable with an upper bound we
 can do much better::
 
-  U = TypeVar('U', bound=User)
-  def new_user(user_class: type[U]) -> U:
+  def new_user[U: User](user_class: type[U]) -> U:
       ...
 
 Now when we call ``new_user()`` with a specific subclass of ``User`` a


### PR DESCRIPTION
This PR attempts to update all places in the spec where the old-style `TypeVar`, `ParamSpec` and `TypeVarTuple` constructors are used in code samples, with the exception of samples that are intended to explain the older syntax. This should improve readability.

Since it doesn't make any substantive changes to the spec, I don't think this requires approval from the full typing council, but it would be good to have a thorough review.