### PR TITLE
Remove tests with invalid syntax (Python 3.14)

### DIFF
--- a/conformance/results/mypy/qualifiers_annotated.toml
+++ b/conformance/results/mypy/qualifiers_annotated.toml
@@ -7,33 +7,33 @@ Does not reject type[T] compatibility for type alias defined with Annotated.
 Does not reject call of type alias defined with Annotated.
 """
 output = """
-qualifiers_annotated.py:43: error: Bracketed expression "[...]" is not valid as a type  [valid-type]
-qualifiers_annotated.py:44: error: Syntax error in type annotation  [syntax]
-qualifiers_annotated.py:44: note: Suggestion: Is there a spurious trailing comma?
-qualifiers_annotated.py:45: error: Invalid type comment or annotation  [valid-type]
-qualifiers_annotated.py:46: error: Inline TypedDict is experimental, must be enabled with --enable-incomplete-feature=InlineTypedDict  [misc]
-qualifiers_annotated.py:46: error: Name "b" is not defined  [name-defined]
-qualifiers_annotated.py:47: error: Invalid type comment or annotation  [valid-type]
+qualifiers_annotated.py:38: error: Bracketed expression "[...]" is not valid as a type  [valid-type]
+qualifiers_annotated.py:39: error: Syntax error in type annotation  [syntax]
+qualifiers_annotated.py:39: note: Suggestion: Is there a spurious trailing comma?
+qualifiers_annotated.py:40: error: Invalid type comment or annotation  [valid-type]
+qualifiers_annotated.py:41: error: Inline TypedDict is experimental, must be enabled with --enable-incomplete-feature=InlineTypedDict  [misc]
+qualifiers_annotated.py:41: error: Name "b" is not defined  [name-defined]
+qualifiers_annotated.py:42: error: Invalid type comment or annotation  [valid-type]
+qualifiers_annotated.py:43: error: Invalid type comment or annotation  [valid-type]
+qualifiers_annotated.py:44: error: Invalid type comment or annotation  [valid-type]
+qualifiers_annotated.py:45: error: Name "var1" is not defined  [name-defined]
+qualifiers_annotated.py:46: error: Invalid type: try using Literal[True] instead?  [valid-type]
+qualifiers_annotated.py:47: error: Invalid type: try using Literal[1] instead?  [valid-type]
 qualifiers_annotated.py:48: error: Invalid type comment or annotation  [valid-type]
 qualifiers_annotated.py:49: error: Invalid type comment or annotation  [valid-type]
-qualifiers_annotated.py:50: error: Name "var1" is not defined  [name-defined]
-qualifiers_annotated.py:51: error: Invalid type: try using Literal[True] instead?  [valid-type]
-qualifiers_annotated.py:52: error: Invalid type: try using Literal[1] instead?  [valid-type]
-qualifiers_annotated.py:53: error: Invalid type comment or annotation  [valid-type]
-qualifiers_annotated.py:54: error: Invalid type comment or annotation  [valid-type]
-qualifiers_annotated.py:64: error: Annotated[...] must have exactly one type argument and at least one annotation  [valid-type]
-qualifiers_annotated.py:76: error: Incompatible types in assignment (expression has type "<typing special form>", variable has type "type[Any]")  [assignment]
-qualifiers_annotated.py:84: error: Argument 1 to "func4" has incompatible type "<typing special form>"; expected "type[Never]"  [arg-type]
-qualifiers_annotated.py:91: error: "<typing special form>" not callable  [operator]
-qualifiers_annotated.py:92: error: "<typing special form>" not callable  [operator]
-qualifiers_annotated.py:98: error: Invalid type: ClassVar nested inside other type  [valid-type]
-qualifiers_annotated.py:100: error: Final can be only used as an outermost qualifier in a variable annotation  [valid-type]
+qualifiers_annotated.py:59: error: Annotated[...] must have exactly one type argument and at least one annotation  [valid-type]
+qualifiers_annotated.py:71: error: Incompatible types in assignment (expression has type "<typing special form>", variable has type "type[Any]")  [assignment]
+qualifiers_annotated.py:79: error: Argument 1 to "func4" has incompatible type "<typing special form>"; expected "type[Never]"  [arg-type]
+qualifiers_annotated.py:86: error: "<typing special form>" not callable  [operator]
+qualifiers_annotated.py:87: error: "<typing special form>" not callable  [operator]
+qualifiers_annotated.py:93: error: Invalid type: ClassVar nested inside other type  [valid-type]
+qualifiers_annotated.py:95: error: Final can be only used as an outermost qualifier in a variable annotation  [valid-type]
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 77: Expected 1 errors
-Line 85: Expected 1 errors
-Line 93: Expected 1 errors
-Line 98: Unexpected errors ['qualifiers_annotated.py:98: error: Invalid type: ClassVar nested inside other type  [valid-type]']
-Line 100: Unexpected errors ['qualifiers_annotated.py:100: error: Final can be only used as an outermost qualifier in a variable annotation  [valid-type]']
+Line 72: Expected 1 errors
+Line 80: Expected 1 errors
+Line 88: Expected 1 errors
+Line 93: Unexpected errors ['qualifiers_annotated.py:93: error: Invalid type: ClassVar nested inside other type  [valid-type]']
+Line 95: Unexpected errors ['qualifiers_annotated.py:95: error: Final can be only used as an outermost qualifier in a variable annotation  [valid-type]']
 """

--- a/conformance/results/pyre/qualifiers_annotated.toml
+++ b/conformance/results/pyre/qualifiers_annotated.toml
@@ -4,31 +4,31 @@ Does not reject Annotated with a single parameter.
 Does not reject call of Annotated with no type arguments.
 """
 output = """
-qualifiers_annotated.py:43:6 Undefined or invalid type [11]: Annotation `` is not defined as a type.
-qualifiers_annotated.py:44:6 Invalid type [31]: Expression `typing.Annotated[(((int, str)), "")]` is not a valid type.
-qualifiers_annotated.py:45:6 Invalid type [31]: Expression `typing.Annotated[(comprehension(int for generators(generator(i in range(1) if ))), "")]` is not a valid type.
-qualifiers_annotated.py:46:6 Invalid type [31]: Expression `typing.Annotated[({ "a":"b" }, "")]` is not a valid type.
-qualifiers_annotated.py:47:6 Invalid type [31]: Expression `typing.Annotated[(lambda () (int)(), "")]` is not a valid type.
-qualifiers_annotated.py:48:6 Invalid type [31]: Expression `typing.Annotated[([int][0], "")]` is not a valid type.
-qualifiers_annotated.py:49:6 Invalid type [31]: Expression `typing.Annotated[(int if 1 < 3 else str, "")]` is not a valid type.
-qualifiers_annotated.py:50:16 Unbound name [10]: Name `var1` is used but not defined in the current scope.
-qualifiers_annotated.py:51:6 Invalid type [31]: Expression `typing.Annotated[(True, "")]` is not a valid type.
-qualifiers_annotated.py:52:7 Invalid type [31]: Expression `typing.Annotated[(1, "")]` is not a valid type.
-qualifiers_annotated.py:53:7 Invalid type [31]: Expression `typing.Annotated[(list or set, "")]` is not a valid type.
-qualifiers_annotated.py:54:7 Invalid type [31]: Expression `typing.Annotated[(f"{"int"}", "")]` is not a valid type.
-qualifiers_annotated.py:64:7 Invalid type parameters [24]: Generic type `Annotated` expects at least 2 type parameters, received 1.
-qualifiers_annotated.py:77:0 Incompatible variable type [9]: not_type2 is declared to have type `Type[typing.Any]` but is used as type `TypeAlias`.
-qualifiers_annotated.py:85:6 Incompatible parameter type [6]: In call `func4`, for 1st positional argument, expected `Type[Variable[T]]` but got `TypeAlias`.
-qualifiers_annotated.py:91:0 Invalid class instantiation [45]: `Annotated` cannot be instantiated.
-qualifiers_annotated.py:93:0 Call error [29]: `TypeAlias` is not a function.
-qualifiers_annotated.py:105:4 Undefined attribute [16]: `typing.Type` has no attribute `a`.
-qualifiers_annotated.py:106:4 Undefined attribute [16]: `typing.Type` has no attribute `b`.
+qualifiers_annotated.py:38:6 Undefined or invalid type [11]: Annotation `` is not defined as a type.
+qualifiers_annotated.py:39:6 Invalid type [31]: Expression `typing.Annotated[(((int, str)), "")]` is not a valid type.
+qualifiers_annotated.py:40:6 Invalid type [31]: Expression `typing.Annotated[(comprehension(int for generators(generator(i in range(1) if ))), "")]` is not a valid type.
+qualifiers_annotated.py:41:6 Invalid type [31]: Expression `typing.Annotated[({ "a":"b" }, "")]` is not a valid type.
+qualifiers_annotated.py:42:6 Invalid type [31]: Expression `typing.Annotated[(lambda () (int)(), "")]` is not a valid type.
+qualifiers_annotated.py:43:6 Invalid type [31]: Expression `typing.Annotated[([int][0], "")]` is not a valid type.
+qualifiers_annotated.py:44:6 Invalid type [31]: Expression `typing.Annotated[(int if 1 < 3 else str, "")]` is not a valid type.
+qualifiers_annotated.py:45:16 Unbound name [10]: Name `var1` is used but not defined in the current scope.
+qualifiers_annotated.py:46:6 Invalid type [31]: Expression `typing.Annotated[(True, "")]` is not a valid type.
+qualifiers_annotated.py:47:7 Invalid type [31]: Expression `typing.Annotated[(1, "")]` is not a valid type.
+qualifiers_annotated.py:48:7 Invalid type [31]: Expression `typing.Annotated[(list or set, "")]` is not a valid type.
+qualifiers_annotated.py:49:7 Invalid type [31]: Expression `typing.Annotated[(f"{"int"}", "")]` is not a valid type.
+qualifiers_annotated.py:59:7 Invalid type parameters [24]: Generic type `Annotated` expects at least 2 type parameters, received 1.
+qualifiers_annotated.py:72:0 Incompatible variable type [9]: not_type2 is declared to have type `Type[typing.Any]` but is used as type `TypeAlias`.
+qualifiers_annotated.py:80:6 Incompatible parameter type [6]: In call `func4`, for 1st positional argument, expected `Type[Variable[T]]` but got `TypeAlias`.
+qualifiers_annotated.py:86:0 Invalid class instantiation [45]: `Annotated` cannot be instantiated.
+qualifiers_annotated.py:88:0 Call error [29]: `TypeAlias` is not a function.
+qualifiers_annotated.py:100:4 Undefined attribute [16]: `typing.Type` has no attribute `a`.
+qualifiers_annotated.py:101:4 Undefined attribute [16]: `typing.Type` has no attribute `b`.
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 76: Expected 1 errors
-Line 84: Expected 1 errors
-Line 92: Expected 1 errors
-Line 105: Unexpected errors ['qualifiers_annotated.py:105:4 Undefined attribute [16]: `typing.Type` has no attribute `a`.']
-Line 106: Unexpected errors ['qualifiers_annotated.py:106:4 Undefined attribute [16]: `typing.Type` has no attribute `b`.']
+Line 71: Expected 1 errors
+Line 79: Expected 1 errors
+Line 87: Expected 1 errors
+Line 100: Unexpected errors ['qualifiers_annotated.py:100:4 Undefined attribute [16]: `typing.Type` has no attribute `a`.']
+Line 101: Unexpected errors ['qualifiers_annotated.py:101:4 Undefined attribute [16]: `typing.Type` has no attribute `b`.']
 """

--- a/conformance/results/pyrefly/qualifiers_annotated.toml
+++ b/conformance/results/pyrefly/qualifiers_annotated.toml
@@ -4,28 +4,28 @@ Allows Annotated in some contexts where it should not be allowed
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 76: Expected 1 errors
-Line 77: Expected 1 errors
-Line 84: Expected 1 errors
-Line 85: Expected 1 errors
-Line 92: Expected 1 errors
-Line 93: Expected 1 errors
+Line 71: Expected 1 errors
+Line 72: Expected 1 errors
+Line 79: Expected 1 errors
+Line 80: Expected 1 errors
+Line 87: Expected 1 errors
+Line 88: Expected 1 errors
 """
 output = """
-ERROR qualifiers_annotated.py:43:17-27: list literal cannot be used in annotations [invalid-annotation]
-ERROR qualifiers_annotated.py:44:17-30: tuple literal cannot be used in annotations [invalid-annotation]
-ERROR qualifiers_annotated.py:45:17-40: list comprehension cannot be used in annotations [invalid-annotation]
-ERROR qualifiers_annotated.py:46:17-27: dict literal cannot be used in annotations [invalid-annotation]
-ERROR qualifiers_annotated.py:46:19-20: Could not find name `a` [unknown-name]
-ERROR qualifiers_annotated.py:46:24-25: Could not find name `b` [unknown-name]
-ERROR qualifiers_annotated.py:47:17-32: function call cannot be used in annotations [invalid-annotation]
-ERROR qualifiers_annotated.py:48:17-25: invalid subscript expression cannot be used in annotations [invalid-annotation]
-ERROR qualifiers_annotated.py:49:17-38: if expression cannot be used in annotations [invalid-annotation]
-ERROR qualifiers_annotated.py:50:17-21: Could not find name `var1` [unknown-name]
-ERROR qualifiers_annotated.py:51:17-21: bool literal cannot be used in annotations [invalid-annotation]
-ERROR qualifiers_annotated.py:52:18-19: number literal cannot be used in annotations [invalid-annotation]
-ERROR qualifiers_annotated.py:53:18-29: boolean operation cannot be used in annotations [invalid-annotation]
-ERROR qualifiers_annotated.py:54:18-28: f-string cannot be used in annotations [invalid-annotation]
-ERROR qualifiers_annotated.py:64:8-22: `Annotated` needs at least one piece of metadata in addition to the type [invalid-annotation]
-ERROR qualifiers_annotated.py:91:1-10: Expected a callable, got type[Annotated] [not-callable]
+ERROR qualifiers_annotated.py:38:17-27: list literal cannot be used in annotations [invalid-annotation]
+ERROR qualifiers_annotated.py:39:17-30: tuple literal cannot be used in annotations [invalid-annotation]
+ERROR qualifiers_annotated.py:40:17-40: list comprehension cannot be used in annotations [invalid-annotation]
+ERROR qualifiers_annotated.py:41:17-27: dict literal cannot be used in annotations [invalid-annotation]
+ERROR qualifiers_annotated.py:41:19-20: Could not find name `a` [unknown-name]
+ERROR qualifiers_annotated.py:41:24-25: Could not find name `b` [unknown-name]
+ERROR qualifiers_annotated.py:42:17-32: function call cannot be used in annotations [invalid-annotation]
+ERROR qualifiers_annotated.py:43:17-25: invalid subscript expression cannot be used in annotations [invalid-annotation]
+ERROR qualifiers_annotated.py:44:17-38: if expression cannot be used in annotations [invalid-annotation]
+ERROR qualifiers_annotated.py:45:17-21: Could not find name `var1` [unknown-name]
+ERROR qualifiers_annotated.py:46:17-21: bool literal cannot be used in annotations [invalid-annotation]
+ERROR qualifiers_annotated.py:47:18-19: number literal cannot be used in annotations [invalid-annotation]
+ERROR qualifiers_annotated.py:48:18-29: boolean operation cannot be used in annotations [invalid-annotation]
+ERROR qualifiers_annotated.py:49:18-28: f-string cannot be used in annotations [invalid-annotation]
+ERROR qualifiers_annotated.py:59:8-22: `Annotated` needs at least one piece of metadata in addition to the type [invalid-annotation]
+ERROR qualifiers_annotated.py:86:1-10: Expected a callable, got `type[Annotated]` [not-callable]
 """

--- a/conformance/results/pyright/qualifiers_annotated.toml
+++ b/conformance/results/pyright/qualifiers_annotated.toml
@@ -1,36 +1,36 @@
 conformant = "Pass"
 output = """
-qualifiers_annotated.py:43:17 - error: List expression not allowed for this type argument (reportInvalidTypeForm)
-qualifiers_annotated.py:44:17 - error: Expected class but received "tuple[tuple[type[int], type[str]]]" (reportGeneralTypeIssues)
-qualifiers_annotated.py:45:17 - error: List expression not allowed for this type argument (reportInvalidTypeForm)
-qualifiers_annotated.py:45:18 - error: Expected class but received "Generator[type[int], None, None]" (reportGeneralTypeIssues)
-qualifiers_annotated.py:46:17 - error: Expected class but received "dict[str, Unknown]" (reportGeneralTypeIssues)
-qualifiers_annotated.py:46:17 - error: Dictionary expression not allowed in type expression (reportInvalidTypeForm)
-qualifiers_annotated.py:46:24 - error: "b" is not defined (reportUndefinedVariable)
-qualifiers_annotated.py:47:17 - error: Call expression not allowed in type expression (reportInvalidTypeForm)
-qualifiers_annotated.py:48:17 - error: List expression not allowed in type expression
+qualifiers_annotated.py:38:17 - error: List expression not allowed for this type argument (reportInvalidTypeForm)
+qualifiers_annotated.py:39:17 - error: Expected class but received "tuple[tuple[type[int], type[str]]]" (reportGeneralTypeIssues)
+qualifiers_annotated.py:40:17 - error: List expression not allowed for this type argument (reportInvalidTypeForm)
+qualifiers_annotated.py:40:18 - error: Expected class but received "Generator[type[int], None, None]" (reportGeneralTypeIssues)
+qualifiers_annotated.py:41:17 - error: Expected class but received "dict[str, Unknown]" (reportGeneralTypeIssues)
+qualifiers_annotated.py:41:17 - error: Dictionary expression not allowed in type expression (reportInvalidTypeForm)
+qualifiers_annotated.py:41:24 - error: "b" is not defined (reportUndefinedVariable)
+qualifiers_annotated.py:42:17 - error: Call expression not allowed in type expression (reportInvalidTypeForm)
+qualifiers_annotated.py:43:17 - error: List expression not allowed in type expression
   Use list[T] to indicate a list type or T1 | T2 to indicate a union type (reportInvalidTypeForm)
-qualifiers_annotated.py:48:17 - error: Expected class but received "list[type[int]]" (reportGeneralTypeIssues)
-qualifiers_annotated.py:48:23 - error: Expected class but received "Literal[0]" (reportGeneralTypeIssues)
-qualifiers_annotated.py:49:17 - error: Ternary expression not allowed in type expression (reportInvalidTypeForm)
-qualifiers_annotated.py:50:17 - error: "var1" is not defined (reportUndefinedVariable)
-qualifiers_annotated.py:51:17 - error: Expected class but received "Literal[True]" (reportGeneralTypeIssues)
-qualifiers_annotated.py:52:18 - error: Expected class but received "Literal[1]" (reportGeneralTypeIssues)
-qualifiers_annotated.py:53:18 - error: Binary operator not allowed in type expression (reportInvalidTypeForm)
-qualifiers_annotated.py:54:18 - error: Type expressions cannot use format string literals (f-strings) (reportGeneralTypeIssues)
-qualifiers_annotated.py:64:8 - error: Expected one type argument and one or more annotations for "Annotated" (reportInvalidTypeForm)
-qualifiers_annotated.py:76:24 - error: Type "Annotated" is not assignable to declared type "type[Any]"
+qualifiers_annotated.py:43:17 - error: Expected class but received "list[type[int]]" (reportGeneralTypeIssues)
+qualifiers_annotated.py:43:23 - error: Expected class but received "Literal[0]" (reportGeneralTypeIssues)
+qualifiers_annotated.py:44:17 - error: Ternary expression not allowed in type expression (reportInvalidTypeForm)
+qualifiers_annotated.py:45:17 - error: "var1" is not defined (reportUndefinedVariable)
+qualifiers_annotated.py:46:17 - error: Expected class but received "Literal[True]" (reportGeneralTypeIssues)
+qualifiers_annotated.py:47:18 - error: Expected class but received "Literal[1]" (reportGeneralTypeIssues)
+qualifiers_annotated.py:48:18 - error: Binary operator not allowed in type expression (reportInvalidTypeForm)
+qualifiers_annotated.py:49:18 - error: Type expressions cannot use format string literals (f-strings) (reportGeneralTypeIssues)
+qualifiers_annotated.py:59:8 - error: Expected one type argument and one or more annotations for "Annotated" (reportInvalidTypeForm)
+qualifiers_annotated.py:71:24 - error: Type "Annotated" is not assignable to declared type "type[Any]"
   "Annotated" is not assignable to "type[Any]" (reportAssignmentType)
-qualifiers_annotated.py:77:24 - error: Type "SmallInt" is not assignable to declared type "type[Any]"
+qualifiers_annotated.py:72:24 - error: Type "SmallInt" is not assignable to declared type "type[Any]"
   "Annotated" is not assignable to "type[Any]" (reportAssignmentType)
-qualifiers_annotated.py:84:7 - error: Argument of type "Annotated" cannot be assigned to parameter "x" of type "type[T@func4]" in function "func4"
+qualifiers_annotated.py:79:7 - error: Argument of type "Annotated" cannot be assigned to parameter "x" of type "type[T@func4]" in function "func4"
   Type "Annotated" is not assignable to type "type[T@func4]" (reportArgumentType)
-qualifiers_annotated.py:85:7 - error: Argument of type "SmallInt" cannot be assigned to parameter "x" of type "type[T@func4]" in function "func4"
+qualifiers_annotated.py:80:7 - error: Argument of type "SmallInt" cannot be assigned to parameter "x" of type "type[T@func4]" in function "func4"
   Type "Annotated" is not assignable to type "type[T@func4]" (reportArgumentType)
-qualifiers_annotated.py:91:1 - error: "Annotated" cannot be instantiated (reportCallIssue)
-qualifiers_annotated.py:92:1 - error: Object of type "Annotated" is not callable
+qualifiers_annotated.py:86:1 - error: "Annotated" cannot be instantiated (reportCallIssue)
+qualifiers_annotated.py:87:1 - error: Object of type "Annotated" is not callable
   Attribute "__call__" is unknown (reportCallIssue)
-qualifiers_annotated.py:93:1 - error: Object of type "Annotated" is not callable (reportCallIssue)
+qualifiers_annotated.py:88:1 - error: Object of type "Annotated" is not callable (reportCallIssue)
 """
 conformance_automated = "Pass"
 errors_diff = """

--- a/conformance/results/zuban/qualifiers_annotated.toml
+++ b/conformance/results/zuban/qualifiers_annotated.toml
@@ -2,26 +2,26 @@ conformance_automated = "Pass"
 errors_diff = """
 """
 output = """
-qualifiers_annotated.py:43: error: Bracketed expression "[...]" is not valid as a type  [valid-type]
-qualifiers_annotated.py:43: note: Did you mean "List[...]"?
-qualifiers_annotated.py:44: error: Syntax error in type annotation  [valid-type]
-qualifiers_annotated.py:44: note: Suggestion: Is there a spurious trailing comma?
-qualifiers_annotated.py:45: error: Invalid type comment or annotation  [valid-type]
+qualifiers_annotated.py:38: error: Bracketed expression "[...]" is not valid as a type  [valid-type]
+qualifiers_annotated.py:38: note: Did you mean "List[...]"?
+qualifiers_annotated.py:39: error: Syntax error in type annotation  [valid-type]
+qualifiers_annotated.py:39: note: Suggestion: Is there a spurious trailing comma?
+qualifiers_annotated.py:40: error: Invalid type comment or annotation  [valid-type]
+qualifiers_annotated.py:41: error: Invalid type comment or annotation  [valid-type]
+qualifiers_annotated.py:42: error: Invalid type comment or annotation  [valid-type]
+qualifiers_annotated.py:43: error: Invalid type comment or annotation  [valid-type]
+qualifiers_annotated.py:44: error: Invalid type comment or annotation  [valid-type]
+qualifiers_annotated.py:45: error: Name "var1" is not defined  [name-defined]
 qualifiers_annotated.py:46: error: Invalid type comment or annotation  [valid-type]
-qualifiers_annotated.py:47: error: Invalid type comment or annotation  [valid-type]
+qualifiers_annotated.py:47: error: Invalid type: try using Literal[1] instead?  [valid-type]
 qualifiers_annotated.py:48: error: Invalid type comment or annotation  [valid-type]
 qualifiers_annotated.py:49: error: Invalid type comment or annotation  [valid-type]
-qualifiers_annotated.py:50: error: Name "var1" is not defined  [name-defined]
-qualifiers_annotated.py:51: error: Invalid type comment or annotation  [valid-type]
-qualifiers_annotated.py:52: error: Invalid type: try using Literal[1] instead?  [valid-type]
-qualifiers_annotated.py:53: error: Invalid type comment or annotation  [valid-type]
-qualifiers_annotated.py:54: error: Invalid type comment or annotation  [valid-type]
-qualifiers_annotated.py:64: error: Annotated[...] must have exactly one type argument and at least one annotation  [valid-type]
-qualifiers_annotated.py:76: error: Incompatible types in assignment (expression has type "_SpecialForm", variable has type "Type[Any]")  [assignment]
-qualifiers_annotated.py:77: error: Incompatible types in assignment (expression has type "_SpecialForm", variable has type "Type[Any]")  [assignment]
-qualifiers_annotated.py:84: error: Argument 1 to "func4" has incompatible type "_SpecialForm"; expected "Type[Never]"  [arg-type]
-qualifiers_annotated.py:85: error: Argument 1 to "func4" has incompatible type "_SpecialForm"; expected "Type[Never]"  [arg-type]
-qualifiers_annotated.py:91: error: "_SpecialForm" not callable  [operator]
-qualifiers_annotated.py:92: error: "_SpecialForm" not callable  [operator]
-qualifiers_annotated.py:93: error: "<typing special form>" not callable  [operator]
+qualifiers_annotated.py:59: error: Annotated[...] must have exactly one type argument and at least one annotation  [valid-type]
+qualifiers_annotated.py:71: error: Incompatible types in assignment (expression has type "_SpecialForm", variable has type "type[Any]")  [assignment]
+qualifiers_annotated.py:72: error: Incompatible types in assignment (expression has type "_SpecialForm", variable has type "type[Any]")  [assignment]
+qualifiers_annotated.py:79: error: Argument 1 to "func4" has incompatible type "_SpecialForm"; expected "type[Never]"  [arg-type]
+qualifiers_annotated.py:80: error: Argument 1 to "func4" has incompatible type "_SpecialForm"; expected "type[Never]"  [arg-type]
+qualifiers_annotated.py:86: error: "_SpecialForm" not callable  [operator]
+qualifiers_annotated.py:87: error: "_SpecialForm" not callable  [operator]
+qualifiers_annotated.py:88: error: "<typing special form>" not callable  [operator]
 """

--- a/conformance/src/type_checker.py
+++ b/conformance/src/type_checker.py
@@ -365,7 +365,7 @@ class PyreflyTypeChecker(TypeChecker):
 
     def run_tests(self, test_files: Sequence[str]) -> dict[str, str]:
         proc = run(
-            ["pyrefly", "check", "--output-format", "min-text", "--no-summary"],
+            ["pyrefly", "check", "--output-format", "min-text", "--summary=none"],
             stdout=PIPE,
             text=True,
             encoding="utf-8",

--- a/conformance/tests/qualifiers_annotated.py
+++ b/conformance/tests/qualifiers_annotated.py
@@ -33,11 +33,6 @@ Good5: Annotated[tuple[int, ...] | list[int], ""]
 Good6: Annotated[Callable[..., int], ""]
 Good7: Annotated["int | str", ""]
 Good8: Annotated[list["int | str"], ""]
-Good9: Annotated[Literal[3, 4, 5, None], x := 3]
-
-
-async def func3() -> None:
-    Good10: Annotated[str, await func3()]
 
 
 Bad1: Annotated[[int, str], ""]  # E: invalid type expression


### PR DESCRIPTION
The use of named expressions and await expressions results in syntax errors on Python 3.14 (see below). This PR therefore suggests to remove two tests from `conformance/tests/qualifiers_annotated.py` that were making use of this now-invalid syntax.

```
▶ uvx python@3.14               
Python 3.14.0 (main, Oct  7 2025, 15:35:21) [Clang 20.1.4 ] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from typing import Annotated, Literal
>>> Good9: Annotated[Literal[3, 4, 5, None], x := 3]
  File "<python-input-1>", line 1
    Good9: Annotated[Literal[3, 4, 5, None], x := 3]
                                             ^^^^^^
SyntaxError: named expression cannot be used within an annotation
>>> async def func3() -> None:
...     Good10: Annotated[str, await func3()]
...     
  File "<python-input-2>", line 2
    Good10: Annotated[str, await func3()]
                           ^^^^^^^^^^^^^
SyntaxError: await expression cannot be used within an annotation
>>> l
Traceback (most recent call last):
  File "<python-input-3>", line 1, in <module>
    l
NameError: name 'l' is not defined
```