### PR TITLE
Make deferred-annotation errors optional (depends on version)

### DIFF
--- a/conformance/tests/annotations_forward_refs.py
+++ b/conformance/tests/annotations_forward_refs.py
@@ -19,8 +19,8 @@ def func1(
     assert_type(p4, list[ClassA | int])
 
 
-bad1: ClassA  # E: Runtime error: requires quotes
-bad2: list[ClassA]  # E: Runtime error: requires quotes
+bad1: ClassA  # E?: Runtime error prior to 3.14: requires quotes
+bad2: list[ClassA]  # E?: Runtime error prior to 3.14: requires quotes
 bad3: "ClassA" | int  # E: Runtime error
 bad4: int | "ClassA"  # E: Runtime error
 
@@ -63,7 +63,7 @@ def invalid_annotations(
 
 
 class ClassB:
-    def method1(self) -> ClassB:  # E: Runtime error
+    def method1(self) -> ClassB:  # E?: Runtime error prior to 3.14
         return ClassB()
 
     def method2(self) -> "ClassB":  # OK


### PR DESCRIPTION
The forward references in `conformance/tests/annotations_forward_refs.py` are no longer errors on Python 3.14, so it seems reasonable to me to mark them as `E?` instead of `E`, because whether or not this is an error depends on how the type checkers are configured (what Python version are they targeting?).

I saw that a similar pattern was used in `typeddicts_alt_syntax.py` to mark version-depend errors with `E?`, but I'm obviously open to other suggestions (e.g. removing these test assertions alltogether, if possible).