### PR TITLE
Add ty and Zuban to the list of type checkers that exist

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -79,14 +79,11 @@ Typing-related Tools
 Type Checkers
 -------------
 
-* `mypy <http://mypy-lang.org/>`_, the reference implementation for type
-  checkers.
-* `pyrefly <https://pyrefly.org/>`_, a fast type checker and language
-  server.
-* `pyright <https://github.com/microsoft/pyright>`_, a type checker that
-  emphasizes speed.
-* `ty <https://docs.astral.sh/ty/>`_, a fast type checker and language
-  server.
+* `mypy <http://mypy-lang.org/>`_
+* `pyrefly <https://pyrefly.org/>`_
+* `pyright <https://github.com/microsoft/pyright>`_
+* `ty <https://docs.astral.sh/ty/>`_
+* `Zuban <https://docs.zubanls.com/en/latest/>`_
 
 Development Environments
 ------------------------


### PR DESCRIPTION
Unfortunately, this leads to 3/4 type checkers in this list advertising themselves as "fast", which feels a bit silly... ideally I'd put more information here about how ty tries to distinguish itself from the other two fast type checkers, but it feels unfair to have a more verbose description for ty than is afforded to the other three type checkers here :-)

We could also just get rid of the descriptions for all four type checkers; I think it would probably be fine to say that readers of these docs have to go elsewhere to try to decide which tool is right for them