### PR TITLE
Fix code block on NamedTuple doc

### DIFF
--- a/docs/spec/namedtuples.rst
+++ b/docs/spec/namedtuples.rst
@@ -21,7 +21,7 @@ Type checkers should support the class syntax::
         units: str = "meters"
 
 Fields must be annotated attributes - methods and un-annotated attributes are not
-considered fields. Field names may not start with an underscore.
+considered fields. Field names may not start with an underscore::
 
     class MyTuple(NamedTuple):
         x1 = 1  # Not a field


### PR DESCRIPTION
Fix a code block that wasn't being rendered properly

This is what the site looked like before:

<img width="840" height="188" alt="Screenshot 2025-10-16 at 11 00 04 AM" src="https://github.com/user-attachments/assets/29ab56a6-27c6-4f94-b936-f192cb4fa18b" />

GH Markdown preview renders it as a regular quoted section. Afterwards, the markdown preview renders the code block correctly.
