### PR TITLE
don't assert type on invalid type expressions

### DIFF
--- a/conformance/results/mypy/enums_members.toml
+++ b/conformance/results/mypy/enums_members.toml
@@ -26,9 +26,7 @@ enums_members.py:35: error: Expression is of type "Literal[Pet2.genus]", not "st
 enums_members.py:36: error: Expression is of type "Literal[Pet2.species]", not "str"  [assert-type]
 enums_members.py:50: error: Enum members must be left unannotated  [misc]
 enums_members.py:50: note: See https://typing.readthedocs.io/en/latest/spec/enums.html#defining-members
-enums_members.py:84: error: Expression is of type "Callable[[Pet4], str]", not "Any"  [assert-type]
 enums_members.py:84: error: Parameter 1 of Literal[...] is invalid  [valid-type]
-enums_members.py:85: error: Expression is of type "Callable[[Pet4], None]", not "Any"  [assert-type]
 enums_members.py:85: error: Parameter 1 of Literal[...] is invalid  [valid-type]
 enums_members.py:100: error: Expression is of type "Literal[TrafficLight.AMBER]", not "Literal[TrafficLight.YELLOW]"  [assert-type]
 enums_members.py:116: error: Expression is of type "int", not "Literal[Example.b]"  [assert-type]

--- a/conformance/results/pyrefly/enums_members.toml
+++ b/conformance/results/pyrefly/enums_members.toml
@@ -8,14 +8,10 @@ Line 100: Unexpected errors ['assert_type(Literal[TrafficLight.AMBER], Literal[T
 """
 output = """
 ERROR enums_members.py:50:5-8: Enum member `DOG` may not be annotated directly. Instead, annotate the `_value_` attribute. [invalid-annotation]
-ERROR enums_members.py:82:12-53: assert_type((x: Any) -> str, Any) failed [assert-type]
-ERROR enums_members.py:82:37-51: `Pet4.converter` is not a valid enum member [invalid-literal]
-ERROR enums_members.py:83:12-53: assert_type((x: int) -> int, Any) failed [assert-type]
-ERROR enums_members.py:83:37-51: `Pet4.transform` is not a valid enum member [invalid-literal]
-ERROR enums_members.py:84:12-49: assert_type((self: Pet4) -> str, Any) failed [assert-type]
-ERROR enums_members.py:84:35-47: `Pet4.species` is not a valid enum member [invalid-literal]
-ERROR enums_members.py:85:12-45: assert_type((self: Pet4) -> None, Any) failed [assert-type]
-ERROR enums_members.py:85:33-43: `Pet4.speak` is not a valid enum member [invalid-literal]
+ERROR enums_members.py:82:20-34: `Pet4.converter` is not a valid enum member [invalid-literal]
+ERROR enums_members.py:83:20-34: `Pet4.transform` is not a valid enum member [invalid-literal]
+ERROR enums_members.py:84:18-30: `Pet4.species` is not a valid enum member [invalid-literal]
+ERROR enums_members.py:85:16-26: `Pet4.speak` is not a valid enum member [invalid-literal]
 ERROR enums_members.py:100:12-62: assert_type(Literal[TrafficLight.AMBER], Literal[TrafficLight.YELLOW]) failed [assert-type]
 ERROR enums_members.py:116:12-43: assert_type(nonmember[int], Any) failed [assert-type]
 ERROR enums_members.py:116:32-41: `Example.b` is not a valid enum member [invalid-literal]

--- a/conformance/results/pyrefly/overloads_evaluation.toml
+++ b/conformance/results/pyrefly/overloads_evaluation.toml
@@ -2,8 +2,8 @@ conformance_automated = "Pass"
 errors_diff = """
 """
 output = """
-ERROR overloads_evaluation.py:38:11-13: No matching overload found for function `example1_1` [no-matching-overload]
-ERROR overloads_evaluation.py:46:11-17: No matching overload found for function `example1_1` [no-matching-overload]
-ERROR overloads_evaluation.py:51:11-14: No matching overload found for function `example1_1` [no-matching-overload]
-ERROR overloads_evaluation.py:115:13-22: No matching overload found for function `example2` [no-matching-overload]
+ERROR overloads_evaluation.py:38:11-13: No matching overload found for function `example1_1` called with arguments: () [no-matching-overload]
+ERROR overloads_evaluation.py:46:11-17: No matching overload found for function `example1_1` called with arguments: (Literal[1], Literal[1]) [no-matching-overload]
+ERROR overloads_evaluation.py:51:11-14: No matching overload found for function `example1_1` called with arguments: (Literal[1]) [no-matching-overload]
+ERROR overloads_evaluation.py:115:13-22: No matching overload found for function `example2` called with arguments: (int | str, int | str, Literal[1]) [no-matching-overload]
 """

--- a/conformance/results/pyrefly/protocols_explicit.toml
+++ b/conformance/results/pyrefly/protocols_explicit.toml
@@ -7,10 +7,10 @@ conformance_automated = "Fail"
 errors_diff = """
 Line 27: Expected 1 errors
 Line 89: Expected 1 errors
-Line 134: Expected 1 errors
 """
 output = """
 ERROR protocols_explicit.py:56:20-36: `tuple[int, int, str]` is not assignable to attribute `rgb` with type `tuple[int, int, int]` [bad-assignment]
-ERROR protocols_explicit.py:60:10-20: Cannot instantiate `Point` because the following members are abstract: `intensity` [bad-instantiation]
+ERROR protocols_explicit.py:60:10-20: Cannot instantiate `Point` because the following members are abstract: `intensity`, `transparency` [bad-instantiation]
+ERROR protocols_explicit.py:134:15-17: Cannot instantiate `Concrete5` because the following members are abstract: `method1` [bad-instantiation]
 ERROR protocols_explicit.py:164:17-19: Cannot instantiate `Concrete7A` because the following members are abstract: `method1` [bad-instantiation]
 """

--- a/conformance/results/pyrefly/typeddicts_readonly_inheritance.toml
+++ b/conformance/results/pyrefly/typeddicts_readonly_inheritance.toml
@@ -4,10 +4,7 @@ Does not restrictions around overriding for ReadOnly fields
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 98: Expected 1 errors
-Line 106: Expected 1 errors
 Line 119: Expected 1 errors
-Line 132: Expected 1 errors
 """
 output = """
 ERROR typeddicts_readonly_inheritance.py:36:4-10: Key `name` in TypedDict `Album2` is read-only [read-only]
@@ -16,5 +13,8 @@ ERROR typeddicts_readonly_inheritance.py:65:19-21: Missing required key `name` f
 ERROR typeddicts_readonly_inheritance.py:82:14-15: `Literal[3]` is not assignable to TypedDict key `ident` with type `str` [bad-typed-dict-key]
 ERROR typeddicts_readonly_inheritance.py:83:15-16: `Literal[3]` is not assignable to TypedDict key `ident` with type `str` [bad-typed-dict-key]
 ERROR typeddicts_readonly_inheritance.py:84:5-7: Missing required key `ident` for TypedDict `User` [bad-typed-dict-key]
-ERROR typeddicts_readonly_inheritance.py:94:5-6: Class member `F3.a` overrides parent class `F1` in an inconsistent manner [bad-override]
+ERROR typeddicts_readonly_inheritance.py:94:5-6: TypedDict field `a` in `F3` cannot be marked read-only; parent TypedDict `F1` defines it as mutable [bad-typed-dict-key]
+ERROR typeddicts_readonly_inheritance.py:98:5-6: TypedDict field `a` in `F4` must remain required because parent TypedDict `F1` defines it as required [bad-typed-dict-key]
+ERROR typeddicts_readonly_inheritance.py:106:5-6: TypedDict field `c` in `F6` cannot be made non-required; parent TypedDict `F1` defines it as required [bad-typed-dict-key]
+ERROR typeddicts_readonly_inheritance.py:132:7-11: TypedDict field `x` in `TD_B` cannot be made non-required; parent TypedDict `TD_B2` defines it as required [bad-typed-dict-key]
 """

--- a/conformance/results/pyrefly/typeddicts_readonly_update.toml
+++ b/conformance/results/pyrefly/typeddicts_readonly_update.toml
@@ -3,5 +3,5 @@ conformance_automated = "Pass"
 errors_diff = """
 """
 output = """
-ERROR typeddicts_readonly_update.py:23:10-14: No matching overload found for function `A.update` [no-matching-overload]
+ERROR typeddicts_readonly_update.py:23:10-14: No matching overload found for function `A.update` called with arguments: (TypedDict[A]) [no-matching-overload]
 """

--- a/conformance/results/pyrefly/version.toml
+++ b/conformance/results/pyrefly/version.toml
@@ -1,1 +1,1 @@
-version = "pyrefly 0.38.1"
+version = "pyrefly 0.39.4"

--- a/conformance/results/pyright/enums_members.toml
+++ b/conformance/results/pyright/enums_members.toml
@@ -7,16 +7,12 @@ errors_diff = """
 """
 output = """
 enums_members.py:50:5 - error: Type annotations are not allowed for enum members (reportGeneralTypeIssues)
-enums_members.py:82:13 - error: "assert_type" mismatch: expected "Unknown" but received "(x: Unknown) -> str" (reportAssertTypeFailure)
-enums_members.py:82:37 - error: Type arguments for "Literal" must be None, a literal value (int, bool, str, or bytes), or an enum value (reportInvalidTypeForm)
-enums_members.py:82:42 - error: Variable not allowed in type expression (reportInvalidTypeForm)
-enums_members.py:83:13 - error: "assert_type" mismatch: expected "Unknown" but received "(x: int) -> int" (reportAssertTypeFailure)
-enums_members.py:83:37 - error: Type arguments for "Literal" must be None, a literal value (int, bool, str, or bytes), or an enum value (reportInvalidTypeForm)
-enums_members.py:83:42 - error: Variable not allowed in type expression (reportInvalidTypeForm)
-enums_members.py:84:13 - error: "assert_type" mismatch: expected "Unknown" but received "property" (reportAssertTypeFailure)
-enums_members.py:84:35 - error: Type arguments for "Literal" must be None, a literal value (int, bool, str, or bytes), or an enum value (reportInvalidTypeForm)
-enums_members.py:85:13 - error: "assert_type" mismatch: expected "Unknown" but received "(self: Pet4) -> None" (reportAssertTypeFailure)
-enums_members.py:85:33 - error: Type arguments for "Literal" must be None, a literal value (int, bool, str, or bytes), or an enum value (reportInvalidTypeForm)
+enums_members.py:82:20 - error: Type arguments for "Literal" must be None, a literal value (int, bool, str, or bytes), or an enum value (reportInvalidTypeForm)
+enums_members.py:82:25 - error: Variable not allowed in type expression (reportInvalidTypeForm)
+enums_members.py:83:20 - error: Type arguments for "Literal" must be None, a literal value (int, bool, str, or bytes), or an enum value (reportInvalidTypeForm)
+enums_members.py:83:25 - error: Variable not allowed in type expression (reportInvalidTypeForm)
+enums_members.py:84:18 - error: Type arguments for "Literal" must be None, a literal value (int, bool, str, or bytes), or an enum value (reportInvalidTypeForm)
+enums_members.py:85:16 - error: Type arguments for "Literal" must be None, a literal value (int, bool, str, or bytes), or an enum value (reportInvalidTypeForm)
 enums_members.py:116:13 - error: "assert_type" mismatch: expected "Unknown" but received "int" (reportAssertTypeFailure)
 enums_members.py:116:32 - error: Type arguments for "Literal" must be None, a literal value (int, bool, str, or bytes), or an enum value (reportInvalidTypeForm)
 enums_members.py:128:21 - information: Type of "Example2.__B" is "Literal[2]"

--- a/conformance/results/pyright/namedtuples_define_functional.toml
+++ b/conformance/results/pyright/namedtuples_define_functional.toml
@@ -16,12 +16,8 @@ namedtuples_define_functional.py:52:31 - error: Names within a named tuple must 
 namedtuples_define_functional.py:53:33 - error: Field names cannot be a keyword (reportGeneralTypeIssues)
 namedtuples_define_functional.py:54:33 - error: Field names cannot be a keyword (reportGeneralTypeIssues)
 namedtuples_define_functional.py:55:33 - error: Named tuple field names cannot start with an underscore (reportGeneralTypeIssues)
-namedtuples_define_functional.py:59:33 - error: Named tuple field names cannot start with an underscore (reportGeneralTypeIssues)
-namedtuples_define_functional.py:60:13 - error: No parameter named "_1" (reportCallIssue)
 namedtuples_define_functional.py:69:1 - error: Argument missing for parameter "a" (reportCallIssue)
 """
-conformance_automated = "Fail"
+conformance_automated = "Pass"
 errors_diff = """
-Line 59: Unexpected errors ['namedtuples_define_functional.py:59:33 - error: Named tuple field names cannot start with an underscore (reportGeneralTypeIssues)']
-Line 60: Unexpected errors ['namedtuples_define_functional.py:60:13 - error: No parameter named "_1" (reportCallIssue)']
 """

--- a/conformance/results/pyright/version.toml
+++ b/conformance/results/pyright/version.toml
@@ -1,1 +1,1 @@
-version = "pyright 1.1.406"
+version = "pyright 1.1.407"

--- a/conformance/results/results.html
+++ b/conformance/results/results.html
@@ -160,11 +160,11 @@
 <tr><th class="col1">&nbsp;</th>
 <th class='tc-header'><div class='tc-name'>mypy 1.18.2</div>
 </th>
-<th class='tc-header'><div class='tc-name'>pyright 1.1.406</div>
+<th class='tc-header'><div class='tc-name'>pyright 1.1.407</div>
 </th>
-<th class='tc-header'><div class='tc-name'>zuban 0.1.1</div>
+<th class='tc-header'><div class='tc-name'>zuban 0.2.1</div>
 </th>
-<th class='tc-header'><div class='tc-name'>pyrefly 0.38.1</div>
+<th class='tc-header'><div class='tc-name'>pyrefly 0.39.4</div>
 </th>
 </tr>
 <tr><th class="column" colspan="5">

--- a/conformance/results/zuban/aliases_recursive.toml
+++ b/conformance/results/zuban/aliases_recursive.toml
@@ -5,7 +5,6 @@ output = """
 aliases_recursive.py:19: error: Dict entry 1 has incompatible type "str": "complex"; expected "str": "None | int | str | float | list[Json] | dict[str, Json]"  [dict-item]
 aliases_recursive.py:20: error: List item 1 has incompatible type "complex"; expected "None | int | str | float | list[Json] | dict[str, Json]"  [list-item]
 aliases_recursive.py:38: error: Incompatible types in assignment (expression has type "tuple[int, tuple[str, int], tuple[int, tuple[int, list[int]]]]", variable has type "str | int | tuple[RecursiveTuple, ...]")  [assignment]
-aliases_recursive.py:39: error: Name "t6" already defined on line 38  [no-redef]
 aliases_recursive.py:39: error: Incompatible types in assignment (expression has type "tuple[int, list[int]]", variable has type "str | int | tuple[RecursiveTuple, ...]")  [assignment]
 aliases_recursive.py:50: error: Dict entry 0 has incompatible type "str": "list[int]"; expected "str": "str | int | Mapping[str, str | int | Mapping[str, RecursiveMapping]]"  [dict-item]
 aliases_recursive.py:51: error: Dict entry 2 has incompatible type "str": "list[int]"; expected "str": "str | int | Mapping[str, str | int | Mapping[str, RecursiveMapping]]"  [dict-item]

--- a/conformance/results/zuban/version.toml
+++ b/conformance/results/zuban/version.toml
@@ -1,1 +1,1 @@
-version = "zuban 0.1.1"
+version = "zuban 0.2.1"

--- a/conformance/tests/enums_members.py
+++ b/conformance/tests/enums_members.py
@@ -79,10 +79,10 @@ class Pet4(Enum):
 
 assert_type(Pet4.CAT, Literal[Pet4.CAT])
 assert_type(Pet4.DOG, Literal[Pet4.DOG])
-assert_type(Pet4.converter, Literal[Pet4.converter])  # E
-assert_type(Pet4.transform, Literal[Pet4.transform])  # E
-assert_type(Pet4.species, Literal[Pet4.species])  # E
-assert_type(Pet4.speak, Literal[Pet4.speak])  # E
+converter: Literal[Pet4.converter]  # E
+transform: Literal[Pet4.transform]  # E
+species: Literal[Pet4.species]  # E
+speak: Literal[Pet4.speak]  # E
 
 
 # > An attribute that is assigned the value of another member of the same


### PR DESCRIPTION
These lines look like they probably inherited an `assert_type` from prior lines via copy-paste, but it doesn't make sense to `assert_type` here; the spec doesn't specify the type resulting from an invalid type expression.