### PR TITLE
Best Practices: Split an example

### DIFF
--- a/docs/reference/best_practices.rst
+++ b/docs/reference/best_practices.rst
@@ -52,12 +52,18 @@ with the current type system or using the correct type is unergonomic.
 
 If a function accepts every possible object as an argument, for example
 because it's only passed to ``str()``, use ``object`` instead of ``Any`` as
-type annotation. Similarly, if the return value of a callback is ignored,
-annotate it with ``object``::
+type annotation::
 
-    def call_cb_if_int(cb: Callable[[int], object], o: object) -> None:
+    def print_formatted(o: object) -> None:
         if isinstance(o, int):
-            cb(o)
+            o = f"{o:02}"
+        print(o)
+
+Similarly, if the return value of a callback is ignored,
+annotate it with ``object``, not ``Any`` or ``None``::
+
+    def call_cb(cb: Callable[[int], object]) -> None:
+        cb(42)
 
 .. _argument-return-practices:
 


### PR DESCRIPTION
Split the text and examples for `Any` vs `object` into one for arguments and one for callback return types. This separated these two related, but separate suggestions. It should make the examples a bit clearer and less convoluted.