### PR TITLE
Restore a missing TypedDict subtyping requirement

### DIFF
--- a/docs/spec/typeddict.rst
+++ b/docs/spec/typeddict.rst
@@ -541,7 +541,7 @@ The conditions are as follows:
 
     - If it is mutable in ``A``:
 
-      - If ``B`` has an item with the same key, it must also be mutable, and its item type must be
+      - If ``B`` has an item with the same key, it must also be mutable and non-required, and its item type must be
         :term:`equivalent` to the item type in ``A``.
 
       - Else:


### PR DESCRIPTION
This requirement was present in previous version but was dropped in the most recent version.