### PR TITLE
Update conformance results for pyrefly 0.43.1 and zuban 0.2.3.

### DIFF
--- a/conformance/results/pyrefly/dataclasses_final.toml
+++ b/conformance/results/pyrefly/dataclasses_final.toml
@@ -1,14 +1,10 @@
-conformant = "Partial"
-notes = """
-Allows assignment to final attributes that are not initialized on the class
-"""
-conformance_automated = "Fail"
+conformance_automated = "Pass"
 errors_diff = """
-Line 35: Expected 1 errors
-Line 37: Expected 1 errors
 """
 output = """
 ERROR dataclasses_final.py:27:1-17: Cannot set field `final_classvar` [read-only]
+ERROR dataclasses_final.py:35:1-19: Cannot set field `final_no_default` [read-only]
 ERROR dataclasses_final.py:36:1-21: Cannot set field `final_with_default` [read-only]
+ERROR dataclasses_final.py:37:1-19: Cannot set field `final_no_default` [read-only]
 ERROR dataclasses_final.py:38:1-21: Cannot set field `final_with_default` [read-only]
 """

--- a/conformance/results/pyrefly/dataclasses_transform_converter.toml
+++ b/conformance/results/pyrefly/dataclasses_transform_converter.toml
@@ -4,9 +4,7 @@ errors_diff = """
 """
 output = """
 ERROR dataclasses_transform_converter.py:48:41-55: Argument `() -> int` is not assignable to parameter `converter` with type `(@_) -> int` in function `model_field` [bad-argument-type]
-ERROR dataclasses_transform_converter.py:48:41-55: Argument `() -> int` is not assignable to parameter `converter` with type `(@_) -> @_` in function `model_field` [bad-argument-type]
 ERROR dataclasses_transform_converter.py:49:41-55: Argument `(*, x: int) -> int` is not assignable to parameter `converter` with type `(@_) -> int` in function `model_field` [bad-argument-type]
-ERROR dataclasses_transform_converter.py:49:41-55: Argument `(*, x: int) -> int` is not assignable to parameter `converter` with type `(@_) -> @_` in function `model_field` [bad-argument-type]
 ERROR dataclasses_transform_converter.py:107:5-6: Argument `Literal[1]` is not assignable to parameter `field0` with type `str` in function `DC2.__init__` [bad-argument-type]
 ERROR dataclasses_transform_converter.py:108:23-24: Argument `Literal[1]` is not assignable to parameter `field3` with type `bytes | str` in function `DC2.__init__` [bad-argument-type]
 ERROR dataclasses_transform_converter.py:109:29-31: Argument `complex` is not assignable to parameter `field4` with type `list[str] | str` in function `DC2.__init__` [bad-argument-type]

--- a/conformance/results/pyrefly/generics_defaults.toml
+++ b/conformance/results/pyrefly/generics_defaults.toml
@@ -11,7 +11,7 @@ ERROR generics_defaults.py:24:7-31: Type parameter `T` without a default cannot 
 ERROR generics_defaults.py:50:1-20: Expected 5 type arguments for `AllTheDefaults`, got 1 [bad-specialization]
 ERROR generics_defaults.py:107:51-54: Expected default `int` of `Invalid1` to be assignable to the upper bound of `str` [invalid-type-var]
 ERROR generics_defaults.py:114:52-55: Expected default `int` of `Invalid2` to be one of the following constraints: `float`, `str` [invalid-type-var]
-ERROR generics_defaults.py:130:12-27: assert_type(Any, int) failed [assert-type]
+ERROR generics_defaults.py:131:12-27: assert_type(int, Any) failed [assert-type]
 ERROR generics_defaults.py:142:7-11: TypeVar `T5` with a default cannot follow TypeVarTuple `Ts` [invalid-type-var]
 ERROR generics_defaults.py:170:12-57: assert_type([DefaultIntT](Foo7[DefaultIntT]) -> Foo7[DefaultIntT], (Foo7[int]) -> Foo7[int]) failed [assert-type]
 """

--- a/conformance/results/pyrefly/generics_syntax_scoping.toml
+++ b/conformance/results/pyrefly/generics_syntax_scoping.toml
@@ -1,12 +1,5 @@
-conformant = "Partial"
-notes = """
-Does not implement some scoping restrictions for PEP695 generic syntax
-"""
-conformance_automated = "Fail"
+conformance_automated = "Pass"
 errors_diff = """
-Line 92: Expected 1 errors
-Line 95: Expected 1 errors
-Line 98: Expected 1 errors
 """
 output = """
 ERROR generics_syntax_scoping.py:14:20-31: Type variable bounds and constraints must be concrete [invalid-annotation]
@@ -14,4 +7,7 @@ ERROR generics_syntax_scoping.py:18:26-27: Expected a type form, got instance of
 ERROR generics_syntax_scoping.py:35:7-8: `T` is uninitialized [unbound-name]
 ERROR generics_syntax_scoping.py:44:17-18: `T` is uninitialized [unbound-name]
 ERROR generics_syntax_scoping.py:44:17-18: Expected a type form, got instance of `int` [not-a-type]
+ERROR generics_syntax_scoping.py:92:17-18: Type parameter `T` shadows a type parameter of the same name from an enclosing scope [invalid-type-var]
+ERROR generics_syntax_scoping.py:95:17-18: Type parameter `T` shadows a type parameter of the same name from an enclosing scope [invalid-type-var]
+ERROR generics_syntax_scoping.py:98:17-18: Type parameter `T` shadows a type parameter of the same name from an enclosing scope [invalid-type-var]
 """

--- a/conformance/results/pyrefly/generics_typevartuple_concat.toml
+++ b/conformance/results/pyrefly/generics_typevartuple_concat.toml
@@ -4,8 +4,8 @@ Fails to handle move_first_element_to_last example
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 56: Unexpected errors ['Returned type `tuple[*tuple[object | T, ...], object | T]` is not assignable to declared return type `tuple[*Ts, T]` [bad-return]']
+Line 56: Unexpected errors ['Returned type `tuple[*tuple[T | ElementOf[Ts], ...], T | ElementOf[Ts]]` is not assignable to declared return type `tuple[*Ts, T]` [bad-return]']
 """
 output = """
-ERROR generics_typevartuple_concat.py:56:12-30: Returned type `tuple[*tuple[object | T, ...], object | T]` is not assignable to declared return type `tuple[*Ts, T]` [bad-return]
+ERROR generics_typevartuple_concat.py:56:12-30: Returned type `tuple[*tuple[T | ElementOf[Ts], ...], T | ElementOf[Ts]]` is not assignable to declared return type `tuple[*Ts, T]` [bad-return]
 """

--- a/conformance/results/pyrefly/protocols_class_objects.toml
+++ b/conformance/results/pyrefly/protocols_class_objects.toml
@@ -4,16 +4,14 @@ Does not require concrete classes to be passed to type[Proto]
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 29: Expected 1 errors
-Line 34: Expected 1 errors
 Line 104: Expected 1 errors
 Line 106: Expected 1 errors
 Line 107: Expected 1 errors
 Line 108: Expected 1 errors
-Line 26: Unexpected errors ['Cannot instantiate `Proto` because it is a protocol [bad-instantiation]']
 """
 output = """
-ERROR protocols_class_objects.py:26:15-17: Cannot instantiate `Proto` because it is a protocol [bad-instantiation]
+ERROR protocols_class_objects.py:29:5-10: Argument `type[Proto]` is not assignable to parameter `cls` with type `type[Proto]` in function `fun` [bad-argument-type]
+ERROR protocols_class_objects.py:34:7-12: `type[Proto]` is not assignable to variable `var` with type `type[Proto]` [bad-assignment]
 ERROR protocols_class_objects.py:58:16-25: `type[ConcreteA]` is not assignable to `ProtoA1` [bad-assignment]
 ERROR protocols_class_objects.py:74:16-25: `type[ConcreteB]` is not assignable to `ProtoB1` [bad-assignment]
 """

--- a/conformance/results/pyrefly/protocols_explicit.toml
+++ b/conformance/results/pyrefly/protocols_explicit.toml
@@ -5,10 +5,10 @@ Does not detect stub methods inherited from protocols as abstract.
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 27: Expected 1 errors
 Line 89: Expected 1 errors
 """
 output = """
+ERROR protocols_explicit.py:27:16-28: Method `draw` inherited from class `PColor` has no implementation and cannot be accessed via `super()` [missing-attribute]
 ERROR protocols_explicit.py:56:20-36: `tuple[int, int, str]` is not assignable to attribute `rgb` with type `tuple[int, int, int]` [bad-assignment]
 ERROR protocols_explicit.py:60:10-20: Cannot instantiate `Point` because the following members are abstract: `intensity`, `transparency` [bad-instantiation]
 ERROR protocols_explicit.py:134:15-17: Cannot instantiate `Concrete5` because the following members are abstract: `method1` [bad-instantiation]

--- a/conformance/results/pyrefly/typeddicts_class_syntax.toml
+++ b/conformance/results/pyrefly/typeddicts_class_syntax.toml
@@ -3,9 +3,9 @@ conformance_automated = "Pass"
 errors_diff = """
 """
 output = """
-ERROR typeddicts_class_syntax.py:29:9-16: TypedDict item `method1` may not be initialized [bad-class-definition]
-ERROR typeddicts_class_syntax.py:34:9-16: TypedDict item `method2` may not be initialized [bad-class-definition]
-ERROR typeddicts_class_syntax.py:39:9-16: TypedDict item `method3` may not be initialized [bad-class-definition]
+ERROR typeddicts_class_syntax.py:29:9-16: TypedDict members must be declared in the form `field: Annotation` with no assignment [bad-class-definition]
+ERROR typeddicts_class_syntax.py:34:9-16: TypedDict members must be declared in the form `field: Annotation` with no assignment [bad-class-definition]
+ERROR typeddicts_class_syntax.py:39:9-16: TypedDict members must be declared in the form `field: Annotation` with no assignment [bad-class-definition]
 ERROR typeddicts_class_syntax.py:44:7-20: Typed dictionary definitions may not specify a metaclass [invalid-inheritance]
 ERROR typeddicts_class_syntax.py:49:7-20: TypedDict does not support keyword argument `other` [bad-typed-dict]
 """

--- a/conformance/results/pyrefly/typeddicts_readonly_inheritance.toml
+++ b/conformance/results/pyrefly/typeddicts_readonly_inheritance.toml
@@ -1,10 +1,5 @@
-conformant = "Partial"
-notes = """
-Does not restrictions around overriding for ReadOnly fields
-"""
-conformance_automated = "Fail"
+conformance_automated = "Pass"
 errors_diff = """
-Line 119: Expected 1 errors
 """
 output = """
 ERROR typeddicts_readonly_inheritance.py:36:4-10: Key `name` in TypedDict `Album2` is read-only [read-only]
@@ -16,5 +11,6 @@ ERROR typeddicts_readonly_inheritance.py:84:5-7: Missing required key `ident` fo
 ERROR typeddicts_readonly_inheritance.py:94:5-6: TypedDict field `a` in `F3` cannot be marked read-only; parent TypedDict `F1` defines it as mutable [bad-typed-dict-key]
 ERROR typeddicts_readonly_inheritance.py:98:5-6: TypedDict field `a` in `F4` must remain required because parent TypedDict `F1` defines it as required [bad-typed-dict-key]
 ERROR typeddicts_readonly_inheritance.py:106:5-6: TypedDict field `c` in `F6` cannot be made non-required; parent TypedDict `F1` defines it as required [bad-typed-dict-key]
+ERROR typeddicts_readonly_inheritance.py:119:7-11: Field `x` is declared `float` in ancestor `class TD_A2: ...
 ERROR typeddicts_readonly_inheritance.py:132:7-11: TypedDict field `x` in `TD_B` cannot be made non-required; parent TypedDict `TD_B2` defines it as required [bad-typed-dict-key]
 """

--- a/conformance/results/pyrefly/typeddicts_required.toml
+++ b/conformance/results/pyrefly/typeddicts_required.toml
@@ -1,10 +1,5 @@
-conformant = "Partial"
-notes = """
-Does not handle recursive typed dicts in functional syntax
-"""
-conformance_automated = "Fail"
+conformance_automated = "Pass"
 errors_diff = """
-Line 71: Unexpected errors ["Expected a type form, got instance of `Literal['RecursiveMovie']` [not-a-type]"]
 """
 output = """
 ERROR typeddicts_required.py:12:5-6: `Required` may only be used for TypedDict members [invalid-annotation]
@@ -12,5 +7,4 @@ ERROR typeddicts_required.py:16:8-19: `NotRequired` is only allowed inside a cla
 ERROR typeddicts_required.py:16:8-24: `NotRequired` is not allowed in this context [invalid-annotation]
 ERROR typeddicts_required.py:59:8-31: Duplicate qualifier `Required` [invalid-annotation]
 ERROR typeddicts_required.py:60:8-34: Cannot combine `Required` and `NotRequired` for a TypedDict field [invalid-annotation]
-ERROR typeddicts_required.py:71:75-91: Expected a type form, got instance of `Literal['RecursiveMovie']` [not-a-type]
 """

--- a/conformance/results/pyrefly/version.toml
+++ b/conformance/results/pyrefly/version.toml
@@ -1,1 +1,1 @@
-version = "pyrefly 0.39.4"
+version = "pyrefly 0.43.1"

--- a/conformance/results/pyright/namedtuples_define_functional.toml
+++ b/conformance/results/pyright/namedtuples_define_functional.toml
@@ -1,4 +1,3 @@
-conformant = "Partial"
 output = """
 namedtuples_define_functional.py:16:8 - error: Argument missing for parameter "y" (reportCallIssue)
 namedtuples_define_functional.py:21:8 - error: Arguments missing for parameters "x", "y" (reportCallIssue)

--- a/conformance/results/results.html
+++ b/conformance/results/results.html
@@ -162,9 +162,9 @@
 </th>
 <th class='tc-header'><div class='tc-name'>pyright 1.1.407</div>
 </th>
-<th class='tc-header'><div class='tc-name'>zuban 0.2.1</div>
+<th class='tc-header'><div class='tc-name'>zuban 0.2.3</div>
 </th>
-<th class='tc-header'><div class='tc-name'>pyrefly 0.39.4</div>
+<th class='tc-header'><div class='tc-name'>pyrefly 0.43.1</div>
 </th>
 </tr>
 <tr><th class="column" colspan="5">
@@ -348,7 +348,7 @@
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not following runtime scoping rules for type parameters in all cases.</p></span></div></th>
 <th class="column col2 conformant">Pass</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not following runtime scoping rules for type parameters in all cases.</p></span></div></th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not implement some scoping restrictions for PEP695 generic syntax</p></span></div></th>
+<th class="column col2 conformant">Pass</th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;generics_type_erasure</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Infers Node[Never] instead of Node[Any] when argument is not provided.</p><p>False negative on instance attribute access on type(node).</p></span></div></th>
@@ -714,7 +714,7 @@
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Wrongly requires a Final dataclass field to be initialized at class level.</p><p>Doesn't support Final nested inside ClassVar.</p></span></div></th>
 <th class="column col2 conformant">Pass</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Wrongly requires a Final dataclass field to be initialized at class level.</p><p>Doesn't support Final nested inside ClassVar.</p></span></div></th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Allows assignment to final attributes that are not initialized on the class</p></span></div></th>
+<th class="column col2 conformant">Pass</th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dataclasses_frozen</th>
 <th class="column col2 conformant">Pass</th>
@@ -855,7 +855,7 @@
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Incorrectly rejects non-ReadOnly override of ReadOnly item.</p><p>Incorrectly rejects override of ReadOnly item with another ReadOnly item with narrower type.</p><p>Incorrectly rejects override of NotRequired ReadOnly item with a Required ReadOnly item.</p></span></div></th>
 <th class="column col2 conformant">Pass</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Incorrectly rejects non-ReadOnly override of ReadOnly item.</p><p>Incorrectly rejects override of ReadOnly item with another ReadOnly item with narrower type.</p><p>Incorrectly rejects override of NotRequired ReadOnly item with a Required ReadOnly item.</p></span></div></th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not restrictions around overriding for ReadOnly fields</p></span></div></th>
+<th class="column col2 conformant">Pass</th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;typeddicts_readonly_kwargs</th>
 <th class="column col2 conformant">Pass</th>
@@ -873,7 +873,7 @@
 <th class="column col2 conformant">Pass</th>
 <th class="column col2 conformant">Pass</th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not handle recursive typed dicts in functional syntax</p></span></div></th>
+<th class="column col2 conformant">Pass</th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;typeddicts_type_consistency</th>
 <th class="column col2 conformant">Pass</th>
@@ -893,7 +893,7 @@
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tuples_type_compat</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not support tuple narrowing based on `len()` type guard (optional).</p></span></div></th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 conformant"><div class="hover-text">Pass*<span class="tooltip-text" id="bottom"><p>Does not support tuple narrowing based on `len()` type guard (optional).</p></span></div></th>
+<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Incorrectly marks a match case as unreachable.</p></span></div></th>
 <th class="column col2 conformant">Pass</th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tuples_type_form</th>
@@ -919,7 +919,7 @@
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;namedtuples_define_functional</th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 partially-conformant">Partial</th>
+<th class="column col2 conformant">Pass</th>
 <th class="column col2 conformant">Pass</th>
 <th class="column col2 conformant">Pass</th>
 </tr>

--- a/conformance/results/zuban/tuples_type_compat.toml
+++ b/conformance/results/zuban/tuples_type_compat.toml
@@ -1,6 +1,6 @@
-conformant = "Pass"
+conformant = "Partial"
 notes = """
-Does not support tuple narrowing based on `len()` type guard (optional).
+Incorrectly marks a match case as unreachable.
 """
 conformance_automated = "Fail"
 errors_diff = """

--- a/conformance/results/zuban/version.toml
+++ b/conformance/results/zuban/version.toml
@@ -1,1 +1,1 @@
-version = "zuban 0.2.1"
+version = "zuban 0.2.3"


### PR DESCRIPTION
* Updates conformance results for new pyrefly and zuban versions (mypy and pyright have not released new versions since the last update).
* Updates manual conformance fields, including fixing a couple preexisting incorrect values.