### PR TITLE
Use `pyproject.toml` instead of `setup.py`

### DIFF
--- a/docs/guides/libraries.rst
+++ b/docs/guides/libraries.rst
@@ -88,10 +88,7 @@ A typical directory structure would look like:
       stuff.py
       py.typed
 
-It's important to ensure that the ``py.typed`` marker file is included in the
-distributed package. Modern build backends such as ``hatchling`` include it
-by default.
-
+Note the py.typed should be located inside the package, along with ``__init__.py``.
 
 Type stub files included in the package
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The main motivation for this change is to migrate from the non-standard `setup.py` to the standard PEP 517 `setup.py`. The secondary motivation is to use a build backend that's easier to use and harder to get wrong than setuptools.

Modern build backends and much easier to use than setuptools, and will generally include `py.typed` and `.pyi` files automatically. This means we can remove the setuptools-specific documentation. We use `uv_build` for the stubs package example since it works out of the box with it.

packaging.python.org has a tab system to show different build backends (https://packaging.python.org/en/latest/guides/writing-pyproject-toml/). Afaik typing.python.org doesn't, so we only show one build backend.

Fixes #2121