### PR TITLE
Clarify that `tuple` should not be prohibited as an argument to `type`

### DIFF
--- a/docs/spec/special-types.rst
+++ b/docs/spec/special-types.rst
@@ -188,9 +188,8 @@ concrete class object, e.g. in the above example::
 ``type[T]`` where ``T`` is a type variable is allowed when annotating the
 first argument of a class method (see the relevant section).
 
-Any other special constructs like ``Callable`` are not allowed
-as an argument to ``type``,
-but ``tuple`` is allowed as an argument to ``type``.
+Any other :term:`special forms <special form>` like ``Callable`` are not
+allowed as an argument to ``type``.
 
 There are some concerns with this feature: for example when
 ``new_user()`` calls ``user_class()`` this implies that all subclasses


### PR DESCRIPTION
Closes #2145

This spec change reconciles the typing spec and the conformance testsuite. `tuple` is an object of the `type` class, so it should be accepted as a value of `type`.