### PR TITLE
Accept reversed dataclass field-order warning

### DIFF
--- a/conformance/tests/dataclasses_usage.py
+++ b/conformance/tests/dataclasses_usage.py
@@ -57,19 +57,19 @@ v4 = InventoryItem("name", 3.1, 3, 4)  # E: too many arguments
 # > single class, or as a result of class inheritance.
 @dataclass  # E[DC1]
 class DC1:
-    a: int = 0
+    a: int = 0 # E[DC1]: field with default should follow a field with no default.
     b: int  # E[DC1]: field with no default cannot follow field with default.
 
 
 @dataclass  # E[DC2]
 class DC2:
-    a: int = field(default=1)
+    a: int = field(default=1) # E[DC2]: field with default should follow a field with no default.
     b: int  # E[DC2]: field with no default cannot follow field with default.
 
 
 @dataclass  # E[DC3]
 class DC3:
-    a: InitVar[int] = 0
+    a: InitVar[int] = 0 # E[DC3]: field with default should follow a field with no default.
     b: int  # E[DC3]: field with no default cannot follow field with default.
 
 


### PR DESCRIPTION
This is needed for PyCharm, where the dataclass field-order diagnostic can be emitted in the inverse form depending on
analysis order. 
The change makes the typing conformance test robust to both equivalent warnings.