### PR TITLE
Clarify that variadic positional parameters can be expressed with Callable

### DIFF
--- a/docs/spec/callables.rst
+++ b/docs/spec/callables.rst
@@ -536,10 +536,11 @@ to be :term:`consistent` with any input parameters::
         f4: CallbackWithStr[...] = cb  # Error
 
 
-Variadic positional parameter types can be defined with ``...`` in combination
-with an unpacked tuple of the form ``tuple[int, ...]``. The first argument
-specifies the type of the variadic parameters. For example, the following
-defines a callable that accepts any number of integer arguments::
+Variadic positional parameter types can be defined with with an unpacked tuple
+of the form ``*tuple[int, ...]`` in the parameter list. The first argument
+specifies the type of the variadic parameters.
+For example, the following defines a callable that accepts any number of integer
+arguments::
 
     type VarCallback = Callable[[*tuple[int, ...]], None]
 


### PR DESCRIPTION
As @JelleZijlstra noted [here](https://github.com/python/peps/pull/4764#discussion_r2734695090) the [current notion](https://typing.python.org/en/latest/spec/callables.html#callable) of

> The Callable form provides no way to specify [...] variadic parameters [...]

is not correct as we can express variadic positional parameters with an unpacked tuple, e.g. `Callable[[*tuple[int, ...]], str]`.
This PR adds clarification for this case.

I've removed the notion about variadics completely in that paragraph, an alternative would be 

> no way to specify keyword-only parameters, variadic keyword-only parameters, or ..." 

which feels redundant. Feel free to share other suggestions

Resolves: #2162