### PR TITLE
Update `Color` enum in `overloads_evaluation.py` to have >1 member

### DIFF
--- a/conformance/tests/overloads_evaluation.py
+++ b/conformance/tests/overloads_evaluation.py
@@ -142,7 +142,7 @@ def check_expand_bool(v: bool) -> None:
 
 class Color(Enum):
     RED = 1
-    BLUE = 1
+    BLUE = 2
 
 
 @overload


### PR DESCRIPTION
This enum looks like it has two members, but it actually has only one, because `Color.RED` and `Color.BLUE` have the same value; `Color.BLUE` here is actually just an alias for `Color.RED`:

```pycon
>>> from enum import Enum
>>> class Color(Enum):
...     RED = 1
...     BLUE = 1
...     
>>> list(Color)
[<Color.RED: 1>]
>>> Color.RED is Color.BLUE
True
```

ty is able to understand that, and this leads to ty failing the assertion a few lines below:

https://github.com/python/typing/blob/b40321ce2037f67e1976e1b03a7766636ae54dc7/conformance/tests/overloads_evaluation.py#L160-L162

because it is able to infer that the second overload will never be taken, and therefore infers the more precise type of `Literal[0]` as a result of the `expand_enum()` call.

I don't think that's what the assertion was trying to test, so this PR updates the enum to have >1 member.