### PR TITLE
[conformance suite] Fix inaccurate comment in `protocols_generic.py`

### DIFF
--- a/conformance/tests/protocols_generic.py
+++ b/conformance/tests/protocols_generic.py
@@ -40,7 +40,7 @@ p1: Proto1[str, int] = Concrete1()  # OK
 p2: Proto1[int, str] = Concrete1()  # E: incompatible type
 
 
-# Runtime error: Protocol and Generic cannot be used together as base classes.
+# > It is an error to combine the shorthand with Generic[T, S, ...]
 class Proto2(Protocol[T_co], Generic[T_co]):  # E
     ...
 


### PR DESCRIPTION
This comment states that this class fails at runtime, but that isn't true:

```pycon
>>> from typing import *
>>> T_co = TypeVar("T_co")
>>> class Proto2(Protocol[T_co], Generic[T_co]): ...
... 
>>>
```

The comment should instead quote the spec [here](https://typing.python.org/en/latest/spec/protocol.html#generic-protocols), which states that type checkers should consider it an error (even though it does not fail at runtime)