### PR TITLE
[conformance suite] Update an assertion in `historical_positional.py` to allow an optional error

### DIFF
--- a/conformance/tests/historical_positional.py
+++ b/conformance/tests/historical_positional.py
@@ -26,6 +26,22 @@ f1(__x=3)  # E
 def f2(x: int, __y: int) -> None: ...  # E
 
 
+# `x` is a positional-or-keyword parameter, so,
+# according to a literal reading of the above rule, `__y`
+# should be flagged as an error since it uses the historical
+# convention for positional-only parameters but appears after
+# a positional-or-keyword parameter that does not. We therefore
+# permit type checkers to emit an error on this definition.
+#
+# Note that `x` can only be passed with a keyword argument if
+# no arguments are passed positionally:
+#
+# ```pycon
+# >>> def f3(x: int, *args: int, __y: int) -> None: ...
+# ...
+# >>> f3(x=1, __y=2)
+# >>>
+# ```
 def f3(x: int, *args: int, __y: int) -> None: ...  # E?
 
 


### PR DESCRIPTION
The comment immediately above the `f3` definition states:

```py
# > Consistent with PEP 570 syntax, positional-only parameters cannot appear
# > after parameters that accept keyword arguments. Type checkers should
# > enforce this requirement:
```

But mandating that type checkers should permit the `f3` definition appears inconsistent with this comment. The `x` parameter of this function accepts keyword arguments, and comes before a parameter that uses the legacy convention for denoting positional-only parameters, so according to the portion of the spec quoted here I think type checkers *should* emit an error on it.

This PR updates the line to allow an optional error to be emitted by type checkers (though I'd personally also be okay with mandating an error).