### PR TITLE
Allow protocol variance errors at usage site or class definition

### DIFF
--- a/conformance/results/mypy/historical_positional.toml
+++ b/conformance/results/mypy/historical_positional.toml
@@ -7,17 +7,17 @@ Applies legacy positional-only rules when PEP 570 syntax is used.
 output = """
 historical_positional.py:13: note: "f1" defined here
 historical_positional.py:18: error: Unexpected keyword argument "__x" for "f1"  [call-arg]
-historical_positional.py:29: note: "f3" defined here
-historical_positional.py:32: error: Unexpected keyword argument "__y" for "f3"  [call-arg]
-historical_positional.py:36: note: "m1" of "A" defined here
-historical_positional.py:43: error: Unexpected keyword argument "__x" for "m1" of "A"  [call-arg]
-historical_positional.py:50: note: "f4" defined here
-historical_positional.py:53: error: Unexpected keyword argument "__y" for "f4"  [call-arg]
+historical_positional.py:45: note: "f3" defined here
+historical_positional.py:48: error: Unexpected keyword argument "__y" for "f3"  [call-arg]
+historical_positional.py:52: note: "m1" of "A" defined here
+historical_positional.py:59: error: Unexpected keyword argument "__x" for "m1" of "A"  [call-arg]
+historical_positional.py:66: note: "f4" defined here
+historical_positional.py:69: error: Unexpected keyword argument "__y" for "f4"  [call-arg]
 """
 conformance_automated = "Fail"
 errors_diff = """
 Line 26: Expected 1 errors
-Line 38: Expected 1 errors
-Line 32: Unexpected errors ['historical_positional.py:32: error: Unexpected keyword argument "__y" for "f3"  [call-arg]']
-Line 53: Unexpected errors ['historical_positional.py:53: error: Unexpected keyword argument "__y" for "f4"  [call-arg]']
+Line 54: Expected 1 errors
+Line 48: Unexpected errors ['historical_positional.py:48: error: Unexpected keyword argument "__y" for "f3"  [call-arg]']
+Line 69: Unexpected errors ['historical_positional.py:69: error: Unexpected keyword argument "__y" for "f4"  [call-arg]']
 """

--- a/conformance/results/pyrefly/historical_positional.toml
+++ b/conformance/results/pyrefly/historical_positional.toml
@@ -5,6 +5,6 @@ errors_diff = """
 output = """
 ERROR historical_positional.py:18:4-7: Expected argument `__x` to be positional in function `f1` [unexpected-keyword]
 ERROR historical_positional.py:26:16-19: Positional-only parameter `__y` cannot appear after keyword parameters [bad-function-definition]
-ERROR historical_positional.py:38:26-29: Positional-only parameter `__y` cannot appear after keyword parameters [bad-function-definition]
-ERROR historical_positional.py:43:6-9: Expected argument `__x` to be positional in function `A.m1` [unexpected-keyword]
+ERROR historical_positional.py:54:26-29: Positional-only parameter `__y` cannot appear after keyword parameters [bad-function-definition]
+ERROR historical_positional.py:59:6-9: Expected argument `__x` to be positional in function `A.m1` [unexpected-keyword]
 """

--- a/conformance/results/pyrefly/protocols_variance.toml
+++ b/conformance/results/pyrefly/protocols_variance.toml
@@ -4,10 +4,10 @@ errors_diff = """
 Line 21: Expected 1 errors
 Line 40: Expected 1 errors
 Line 56: Expected 1 errors
-Line 61: Expected 1 errors
 Line 66: Expected 1 errors
-Line 71: Expected 1 errors
 Line 104: Expected 1 errors
+Lines 61, 62: Expected error (tag 'covariant_in_input')
+Lines 71, 72: Expected error (tag 'contravariant_in_output')
 """
 output = """
 """

--- a/conformance/results/pyright/historical_positional.toml
+++ b/conformance/results/pyright/historical_positional.toml
@@ -2,8 +2,8 @@ conformant = "Pass"
 output = """
 historical_positional.py:18:8 - error: Expected 1 more positional argument (reportCallIssue)
 historical_positional.py:26:16 - error: Position-only parameter not allowed after parameter that is not position-only (reportGeneralTypeIssues)
-historical_positional.py:38:26 - error: Position-only parameter not allowed after parameter that is not position-only (reportGeneralTypeIssues)
-historical_positional.py:43:10 - error: Expected 1 more positional argument (reportCallIssue)
+historical_positional.py:54:26 - error: Position-only parameter not allowed after parameter that is not position-only (reportGeneralTypeIssues)
+historical_positional.py:59:10 - error: Expected 1 more positional argument (reportCallIssue)
 """
 conformance_automated = "Pass"
 errors_diff = """

--- a/conformance/results/zuban/historical_positional.toml
+++ b/conformance/results/zuban/historical_positional.toml
@@ -4,6 +4,6 @@ errors_diff = """
 output = """
 historical_positional.py:18: error: Unexpected keyword argument "__x" for "f1"  [call-arg]
 historical_positional.py:26: error: A positional only param starting with two underscores is not allowed after a positional or keyword param  [misc]
-historical_positional.py:38: error: A positional only param starting with two underscores is not allowed after a positional or keyword param  [misc]
-historical_positional.py:43: error: Unexpected keyword argument "__x" for "m1" of "A"  [call-arg]
+historical_positional.py:54: error: A positional only param starting with two underscores is not allowed after a positional or keyword param  [misc]
+historical_positional.py:59: error: Unexpected keyword argument "__x" for "m1" of "A"  [call-arg]
 """

--- a/conformance/tests/protocols_variance.py
+++ b/conformance/tests/protocols_variance.py
@@ -58,8 +58,8 @@ class Protocol4(Protocol[T1]):  # E: T1 should be contravariant
         ...
 
 
-class Protocol5(Protocol[T1_co]):  # E: T1_co should be contravariant
-    def m1(self, p0: T1_co) -> None:  # E?: Incorrect use of covariant TypeVar
+class Protocol5(Protocol[T1_co]):  # E[covariant_in_input+]
+    def m1(self, p0: T1_co) -> None:  # E[covariant_in_input+]
         ...
 
 
@@ -68,8 +68,8 @@ class Protocol6(Protocol[T1]):  # E: T1 should be covariant
         ...
 
 
-class Protocol7(Protocol[T1_contra]):  # E: T1_contra should be covariant
-    def m1(self) -> T1_contra:  # E?: Incorrect use of contravariant TypeVar
+class Protocol7(Protocol[T1_contra]):  # E[contravariant_in_output+]
+    def m1(self) -> T1_contra:  # E[contravariant_in_output+]
         ...
 
 


### PR DESCRIPTION
### Summary: 
Changed protocol variance conformance tests to allow errors at either the class definition or the usage site (or both) for cases where the declared variance is wrong.  The full discussion is here: https://github.com/python/typing/issues/2171

### Test plan:
I pinned the pre-existing versions of all the typecheckers because the versioning updates were generating too large of a change, which was muddying the PR. It seemed like a good idea to do the version updates as a separate change, but happy to change follow the latest versions if this is not ok

Results: 
- It seems that historical_positional.toml updates are from a recent upstream change (line number shifts)
- mypy, pyright, zuban: Pass the protocol variance (unchanged) and pyrefly still unsupported but the expected results have new line numbers due to our change.
