### PR TITLE
Do not mandate a specific dead code policy in `NoReturn` conformance test

### DIFF
--- a/conformance/results/mypy/specialtypes_never.toml
+++ b/conformance/results/mypy/specialtypes_never.toml
@@ -1,10 +1,10 @@
 conformant = "Pass"
 output = """
 specialtypes_never.py:19: error: Implicit return in function which does not return  [misc]
-specialtypes_never.py:87: error: Incompatible types in assignment (expression has type "list[Never]", variable has type "list[int]")  [assignment]
-specialtypes_never.py:87: note: "list" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
-specialtypes_never.py:87: note: Consider using "Sequence" instead, which is covariant
-specialtypes_never.py:106: error: Incompatible return value type (got "ClassC[Never]", expected "ClassC[U]")  [return-value]
+specialtypes_never.py:85: error: Incompatible types in assignment (expression has type "list[Never]", variable has type "list[int]")  [assignment]
+specialtypes_never.py:85: note: "list" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
+specialtypes_never.py:85: note: Consider using "Sequence" instead, which is covariant
+specialtypes_never.py:104: error: Incompatible return value type (got "ClassC[Never]", expected "ClassC[U]")  [return-value]
 """
 conformance_automated = "Pass"
 errors_diff = """

--- a/conformance/results/pyrefly/specialtypes_never.toml
+++ b/conformance/results/pyrefly/specialtypes_never.toml
@@ -1,14 +1,9 @@
-conformant = "Partial"
-notes = """
-Does not detect invalid return is unreachable
-"""
-conformance_automated = "Fail"
+conformant = "Pass"
+conformance_automated = "Pass"
 errors_diff = """
-Line 33: Unexpected errors ["Returned type `Literal['whatever works']` is not assignable to declared return type `int` [bad-return]"]
 """
 output = """
 ERROR specialtypes_never.py:19:22-30: Function declared to return `NoReturn` but is missing an explicit `return` [bad-return]
-ERROR specialtypes_never.py:33:12-28: Returned type `Literal['whatever works']` is not assignable to declared return type `int` [bad-return]
-ERROR specialtypes_never.py:87:21-22: `list[Never]` is not assignable to `list[int]` [bad-assignment]
-ERROR specialtypes_never.py:106:12-27: Returned type `ClassC[Never]` is not assignable to declared return type `ClassC[U]` [bad-return]
+ERROR specialtypes_never.py:85:21-22: `list[Never]` is not assignable to `list[int]` [bad-assignment]
+ERROR specialtypes_never.py:104:12-27: Returned type `ClassC[Never]` is not assignable to declared return type `ClassC[U]` [bad-return]
 """

--- a/conformance/results/pyright/specialtypes_never.toml
+++ b/conformance/results/pyright/specialtypes_never.toml
@@ -1,11 +1,11 @@
 conformant = "Pass"
 output = """
 specialtypes_never.py:19:22 - error: Function with declared return type "NoReturn" cannot return "None" (reportReturnType)
-specialtypes_never.py:87:21 - error: Type "list[Never]" is not assignable to declared type "list[int]"
+specialtypes_never.py:85:21 - error: Type "list[Never]" is not assignable to declared type "list[int]"
   "list[Never]" is not assignable to "list[int]"
     Type parameter "_T@list" is invariant, but "Never" is not the same as "int"
     Consider switching from "list" to "Sequence" which is covariant (reportAssignmentType)
-specialtypes_never.py:106:12 - error: Type "ClassC[Never]" is not assignable to return type "ClassC[U@func10]"
+specialtypes_never.py:104:12 - error: Type "ClassC[Never]" is not assignable to return type "ClassC[U@func10]"
   "ClassC[Never]" is not assignable to "ClassC[U@func10]"
     Type parameter "T@ClassC" is invariant, but "Never" is not the same as "U@func10" (reportReturnType)
 """

--- a/conformance/results/results.html
+++ b/conformance/results/results.html
@@ -227,7 +227,7 @@
 <th class="column col2 conformant">Pass</th>
 <th class="column col2 conformant">Pass</th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not detect invalid return is unreachable</p></span></div></th>
+<th class="column col2 conformant">Pass</th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;specialtypes_none</th>
 <th class="column col2 conformant">Pass</th>

--- a/conformance/results/zuban/specialtypes_never.toml
+++ b/conformance/results/zuban/specialtypes_never.toml
@@ -3,9 +3,8 @@ errors_diff = """
 """
 output = """
 specialtypes_never.py:19: error: Implicit return in function which does not return  [misc]
-specialtypes_never.py:32: error: Statement is unreachable  [unreachable]
-specialtypes_never.py:87: error: Incompatible types in assignment (expression has type "list[Never]", variable has type "list[int]")  [assignment]
-specialtypes_never.py:87: note: "List" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
-specialtypes_never.py:87: note: Consider using "Sequence" instead, which is covariant
-specialtypes_never.py:106: error: Incompatible return value type (got "ClassC[Never]", expected "ClassC[U]")  [return-value]
+specialtypes_never.py:85: error: Incompatible types in assignment (expression has type "list[Never]", variable has type "list[int]")  [assignment]
+specialtypes_never.py:85: note: "List" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
+specialtypes_never.py:85: note: Consider using "Sequence" instead, which is covariant
+specialtypes_never.py:104: error: Incompatible return value type (got "ClassC[Never]", expected "ClassC[U]")  [return-value]
 """

--- a/conformance/tests/specialtypes_never.py
+++ b/conformance/tests/specialtypes_never.py
@@ -24,13 +24,11 @@ def func1(x: int) -> NoReturn:  # E: implicitly returns None
 # > The checkers will also recognize that the code after calls to such functions
 # > is unreachable and will behave accordingly.
 
-
+# No error on implicit None return after stop()
 def func2(x: int) -> int:
     if x > 0:
         return x
     stop()
-    ...  # E?: This statement can be marked unreachable
-    return "whatever works"  # No type error
 
 
 # The spec previously said that NoReturn is only valid in a function return type,


### PR DESCRIPTION
### Summary:
Changed conformance test to prevent mandating a specific policy for dead code, since the spec does not require one. 
The full discussion is here https://github.com/python/typing/issues/2174.


### Test plan:
I pinned the existing versions of all existing type checkers and followed the instructions otherwise, so we do not get unrelated changes in the PR.