### PR TITLE
Conformance tests: fix minor comment typo in `typeddicts_extra_items.py`

### DIFF
--- a/conformance/tests/typeddicts_extra_items.py
+++ b/conformance/tests/typeddicts_extra_items.py
@@ -181,7 +181,7 @@ class Child(Parent, extra_items=int): # E: Cannot change 'extra_items' type unle
 class MovieBase2(TypedDict, extra_items=int | None):
     name: str
 
-class MovieRequiredYear(MovieBase2):  # E[MovieRequiredYear]: Required key 'year' is not known to 'MovieBase'
+class MovieRequiredYear(MovieBase2):  # E[MovieRequiredYear]: Required key 'year' is not known to 'MovieBase2'
     year: int | None  # E[MovieRequiredYear]
 
 class MovieNotRequiredYear(MovieBase2):  # E[MovieNotRequiredYear]: 'int | None' is not consistent with 'int'


### PR DESCRIPTION
this fixes a small typo in typeddicts_extra_items test inspection