### PR TITLE
Fix incorrect type name in TypedDict extra_items assignment test

### DIFF
--- a/conformance/tests/typeddicts_extra_items.py
+++ b/conformance/tests/typeddicts_extra_items.py
@@ -219,7 +219,7 @@ class MovieWithYear2(TypedDict, extra_items=int | None):
     year: int | None
 
 details3: MovieWithYear2 = {"name": "Kill Bill Vol. 1", "year": 2003}
-movie3: MovieBase2 = details3  # E:'year' is not required in 'MovieBase2', but it is required in 'MovieWithYear2'
+movie3: MovieBase2 = details3  # E: 'year' is not required in 'MovieBase2', but it is required in 'MovieWithYear2'
 
 # > When ``extra_items`` is specified to be read-only on a TypedDict type, it is
 # > possible for an item to have a :term:`narrower <narrow>` type than the


### PR DESCRIPTION
The test references Movie, but the assignment target is MovieBase2. This appears to be a leftover from a previous test variant.