### PR TITLE
Conformance: another update to `LiteralString` tests

### DIFF
--- a/conformance/tests/literals_literalstring.py
+++ b/conformance/tests/literals_literalstring.py
@@ -163,7 +163,7 @@ def func8(x: Any) -> Any:
 
 assert_type(func8("foo"), C)  # First overload
 assert_type(func8("bar"), B)  # Second overload
-assert_type(func8(str(1)), A)  # Third overload
+assert_type(func8(input()), A)  # Third overload
 
 
 def func9(val: list[LiteralString]):


### PR DESCRIPTION
This is another case where the conformance suite expects type checkers to infer `str(1)` as `str` (and prevents them from inferring a more precise type). I replaced `str(1)` with `input()`, which should always be of type `str`. The conformance results did not change.

This is basically a follow-up to https://github.com/python/typing/pull/2179. There was one more case further down the file, which I missed — apologies.