### PR TITLE
conformance: fix unrelated error in annotations_generators.py

### DIFF
--- a/conformance/results/pyrefly/annotations_generators.toml
+++ b/conformance/results/pyrefly/annotations_generators.toml
@@ -22,5 +22,5 @@ ERROR annotations_generators.py:119:5-19: Cannot yield from `Generator[int, None
 ERROR annotations_generators.py:135:5-29: Cannot yield from `Generator[None, int, None]`, which is not assignable to declared return type `Generator[None, str, Unknown]` [invalid-yield]
 ERROR annotations_generators.py:140:5-13: This `yield` expression is unreachable [unreachable]
 ERROR annotations_generators.py:145:5-13: This `yield` expression is unreachable [unreachable]
-ERROR annotations_generators.py:190:5-10: This `yield` expression is unreachable [unreachable]
+ERROR annotations_generators.py:190:5-12: This `yield` expression is unreachable [unreachable]
 """

--- a/conformance/results/results.html
+++ b/conformance/results/results.html
@@ -176,7 +176,7 @@
 </th>
 <th class='tc-header'><div class='tc-name'>pyright 1.1.408</div>
 </th>
-<th class='tc-header'><div class='tc-name'>zuban 0.5.1</div>
+<th class='tc-header'><div class='tc-name'>zuban 0.6.0</div>
 </th>
 <th class='tc-header'><div class='tc-name'>pyrefly 0.53.0</div>
 </th>

--- a/conformance/results/zuban/typeddicts_operations.toml
+++ b/conformance/results/zuban/typeddicts_operations.toml
@@ -9,7 +9,7 @@ typeddicts_operations.py:26: error: TypedDict "Movie" has no key "other"  [typed
 typeddicts_operations.py:28: error: Missing key "year" for TypedDict "Movie"  [typeddict-item]
 typeddicts_operations.py:29: error: Incompatible types (expression has type "float", TypedDict item "year" has type "int")  [typeddict-item]
 typeddicts_operations.py:32: error: Extra key "other" for TypedDict "Movie"  [typeddict-unknown-key]
-typeddicts_operations.py:37: error: Expected TypedDict key to be string literal  [misc]
+typeddicts_operations.py:37: error: Expected TypedDict key to be string literal  [literal-required]
 typeddicts_operations.py:47: error: "Movie" has no attribute "clear"  [attr-defined]
 typeddicts_operations.py:49: error: Key "name" of TypedDict "Movie" cannot be deleted  [misc]
 typeddicts_operations.py:62: error: "MovieOptional" has no attribute "clear"  [attr-defined]

--- a/conformance/results/zuban/version.toml
+++ b/conformance/results/zuban/version.toml
@@ -1,1 +1,1 @@
-version = "zuban 0.5.1"
+version = "zuban 0.6.0"

--- a/conformance/tests/annotations_generators.py
+++ b/conformance/tests/annotations_generators.py
@@ -187,7 +187,7 @@ v1: Callable[[], Coroutine[Any, Any, AsyncIterator[int]]] = generator29
 
 async def generator30() -> AsyncIterator[int]:
     raise NotImplementedError
-    yield
+    yield 1
 
 
 async def uses_generator30() -> None:


### PR DESCRIPTION
Pycroscope produces an error because the yield yields None rather
than an int. This seems like a reasonable error to give even if the
yield is unreachable.

Also picked up an update to Zuban.
