### PR TITLE
Conformance tests: change another empty body to `raise NotImplementedError`

### DIFF
--- a/conformance/tests/generics_paramspec_basic.py
+++ b/conformance/tests/generics_paramspec_basic.py
@@ -21,7 +21,7 @@ TA5: TypeAlias = Callable[..., None]  # OK
 
 
 def func1(x: P) -> P:  # E
-    ...
+    raise NotImplementedError
 
 
 def func2(x: Concatenate[int, P]) -> int:  # E


### PR DESCRIPTION
ty emits an error on this line but for the wrong reason (due to the fact that it implicitly returns `None`, which contradicts the return annotation), so the test is showing up as passing for us when it actually shouldn't