### PR TITLE
Conformance suite: update `generics_upper_bound.py` to not assume that `[1, 2]` will be inferred as `list[int]`

### DIFF
--- a/conformance/results/mypy/generics_upper_bound.toml
+++ b/conformance/results/mypy/generics_upper_bound.toml
@@ -4,8 +4,8 @@ Does not reject use of type variable within an upper bound.
 """
 output = """
 generics_upper_bound.py:43: error: Expression is of type "Collection[int]", not "list[int] | set[int]"  [assert-type]
-generics_upper_bound.py:51: error: Value of type variable "ST" of "longer" cannot be "int"  [type-var]
-generics_upper_bound.py:56: error: TypeVar cannot have both values and an upper bound  [misc]
+generics_upper_bound.py:52: error: Value of type variable "ST" of "longer" cannot be "int"  [type-var]
+generics_upper_bound.py:57: error: TypeVar cannot have both values and an upper bound  [misc]
 """
 conformance_automated = "Fail"
 errors_diff = """

--- a/conformance/results/pyrefly/generics_upper_bound.toml
+++ b/conformance/results/pyrefly/generics_upper_bound.toml
@@ -1,10 +1,19 @@
-conformance_automated = "Pass"
+conformance_automated = "Fail"
+conformant = "Partial"
+notes = """
+Cannot find a common supertype of `list[int]` and `set[int]` in order to solve a type variable bound to `Sized`.
+"""
 errors_diff = """
+Lines 43, 44: Expected exactly one error (tag 'mixed-collections')
+Line 43: Unexpected errors ['assert_type(list[int], list[int] | set[int]) failed [assert-type]', 'Argument `set[int]` is not assignable to parameter `y` with type `list[int]` in function `longer` [bad-argument-type]']
+Line 44: Unexpected errors ['assert_type(list[int], Collection[int]) failed [assert-type]', 'Argument `set[int]` is not assignable to parameter `y` with type `list[int]` in function `longer` [bad-argument-type]']
 """
 output = """
 ERROR generics_upper_bound.py:24:38-45: Type variable bounds and constraints must be concrete [invalid-annotation]
-ERROR generics_upper_bound.py:43:12-55: assert_type(list[int], list[int] | set[int]) failed [assert-type]
-ERROR generics_upper_bound.py:43:25-31: Argument `set[int]` is not assignable to parameter `y` with type `list[int]` in function `longer` [bad-argument-type]
-ERROR generics_upper_bound.py:51:7-13: `int` is not assignable to upper bound `Sized` of type variable `ST` [bad-specialization]
-ERROR generics_upper_bound.py:56:38-49: TypeVar cannot have both constraints and bound [invalid-type-var]
+ERROR generics_upper_bound.py:43:16-59: assert_type(list[int], list[int] | set[int]) failed [assert-type]
+ERROR generics_upper_bound.py:43:31-35: Argument `set[int]` is not assignable to parameter `y` with type `list[int]` in function `longer` [bad-argument-type]
+ERROR generics_upper_bound.py:44:16-54: assert_type(list[int], Collection[int]) failed [assert-type]
+ERROR generics_upper_bound.py:44:31-35: Argument `set[int]` is not assignable to parameter `y` with type `list[int]` in function `longer` [bad-argument-type]
+ERROR generics_upper_bound.py:52:7-13: `int` is not assignable to upper bound `Sized` of type variable `ST` [bad-specialization]
+ERROR generics_upper_bound.py:57:38-49: TypeVar cannot have both constraints and bound [invalid-type-var]
 """

--- a/conformance/results/pyright/generics_upper_bound.toml
+++ b/conformance/results/pyright/generics_upper_bound.toml
@@ -1,15 +1,16 @@
 conformant = "Pass"
 output = """
 generics_upper_bound.py:24:38 - error: TypeVar bound type cannot be generic (reportGeneralTypeIssues)
-generics_upper_bound.py:51:8 - error: Argument of type "Literal[3]" cannot be assigned to parameter "x" of type "ST@longer" in function "longer"
+generics_upper_bound.py:44:17 - error: "assert_type" mismatch: expected "Collection[int]" but received "list[int] | set[int]" (reportAssertTypeFailure)
+generics_upper_bound.py:52:8 - error: Argument of type "Literal[3]" cannot be assigned to parameter "x" of type "ST@longer" in function "longer"
   Type "Literal[3]" is not assignable to type "Sized"
     "Literal[3]" is incompatible with protocol "Sized"
       "__len__" is not present (reportArgumentType)
-generics_upper_bound.py:51:11 - error: Argument of type "Literal[3]" cannot be assigned to parameter "y" of type "ST@longer" in function "longer"
+generics_upper_bound.py:52:11 - error: Argument of type "Literal[3]" cannot be assigned to parameter "y" of type "ST@longer" in function "longer"
   Type "Literal[3]" is not assignable to type "Sized"
     "Literal[3]" is incompatible with protocol "Sized"
       "__len__" is not present (reportArgumentType)
-generics_upper_bound.py:56:44 - error: TypeVar cannot be both bound and constrained (reportGeneralTypeIssues)
+generics_upper_bound.py:57:44 - error: TypeVar cannot be both bound and constrained (reportGeneralTypeIssues)
 """
 conformance_automated = "Pass"
 errors_diff = """

--- a/conformance/results/results.html
+++ b/conformance/results/results.html
@@ -416,7 +416,7 @@
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not reject use of type variable within an upper bound.</p></span></div></th>
 <th class="column col2 conformant">Pass</th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 conformant">Pass</th>
+<th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Cannot find a common supertype of `list[int]` and `set[int]` in order to solve a type variable bound to `Sized`.</p></span></div></th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;generics_variance</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not reject use of class-scoped TypeVar used in a base class when variance is incompatible.</p></span></div></th>

--- a/conformance/results/zuban/generics_upper_bound.toml
+++ b/conformance/results/zuban/generics_upper_bound.toml
@@ -3,7 +3,8 @@ errors_diff = """
 """
 output = """
 generics_upper_bound.py:24: error: TypeVar bound must not contain type variables  [misc]
-generics_upper_bound.py:51: error: Value of type variable "ST" of "longer" cannot be "int"  [type-var]
-generics_upper_bound.py:51: error: Value of type variable "ST" of "longer" cannot be "int"  [type-var]
-generics_upper_bound.py:56: error: TypeVar cannot have both values and an upper bound  [misc]
+generics_upper_bound.py:44: error: Expression is of type "list[int] | set[int]", not "Collection[int]"  [misc]
+generics_upper_bound.py:52: error: Value of type variable "ST" of "longer" cannot be "int"  [type-var]
+generics_upper_bound.py:52: error: Value of type variable "ST" of "longer" cannot be "int"  [type-var]
+generics_upper_bound.py:57: error: TypeVar cannot have both values and an upper bound  [misc]
 """

--- a/conformance/tests/generics_upper_bound.py
+++ b/conformance/tests/generics_upper_bound.py
@@ -34,13 +34,14 @@ def longer(x: ST, y: ST) -> ST:
         return y
 
 
-assert_type(longer([1], [1, 2]), list[int])
-assert_type(longer({1}, {1, 2}), set[int])
+def f(list1: list[int], list2: list[int], set1: set[int], set2: set[int]):
+    assert_type(longer(list1, list2), list[int])
+    assert_type(longer(set1, set2), set[int])
 
-# Type checkers that use a join rather than a union (like mypy)
-# will produce Collection[int] here instead of list[int] | set[int].
-# Both answers are conformant with the spec.
-assert_type(longer([1], {1, 2}), list[int] | set[int])  # E?
+    # Either answer here is conformant with the spec;
+    # exactly one should pass:
+    assert_type(longer(list1, set1), list[int] | set[int])  # E[mixed-collections]
+    assert_type(longer(list1, set1), Collection[int])  # E[mixed-collections]
 
 
 def requires_collection(c: Collection[int]) -> None: ...


### PR DESCRIPTION
ty is able to solve the type variables on lines 37-38 of `generics_upper_bound.py`, but it currently infers `[1, 2]` as `list[int | Unknown]` unless it is an explicitly declared variable, and also infers `{1, 2}` as `set[int | Unknown]`. This led to the `assert_type` calls failing for ty, for reasons that were unrelated to what the test was trying to assert. We [plan to change this](https://github.com/astral-sh/ty/issues/1240) behaviour in ty soon, but it still seems best to update the assertion here so that it does not implicitly assume unspecified inference semantics.

This PR fixes that, and also turns an optional error a few lines below into a tagged error. This change makes the assertion more precise, revealing that pyrefly was emitting an error on that line for the wrong reason.