### PR TITLE
don't state that `type[Callable]` is invalid

### DIFF
--- a/conformance/results/mypy/generics_paramspec_basic.toml
+++ b/conformance/results/mypy/generics_paramspec_basic.toml
@@ -1,4 +1,4 @@
-conformant = "Pass"
+conformant = "Partial"
 output = """
 generics_paramspec_basic.py:10: error: String argument 1 "NotIt" to ParamSpec(...) does not match variable name "WrongName"  [misc]
 generics_paramspec_basic.py:15: error: Invalid location for ParamSpec "P"  [valid-type]

--- a/conformance/results/mypy/specialtypes_type.toml
+++ b/conformance/results/mypy/specialtypes_type.toml
@@ -17,6 +17,9 @@ specialtypes_type.py:143: error: "<typing special form>" has no attribute "unkno
 specialtypes_type.py:144: error: "<typing special form>" has no attribute "unknown"  [attr-defined]
 specialtypes_type.py:145: error: "type[type]" has no attribute "unknown"  [attr-defined]
 specialtypes_type.py:146: error: "<typing special form>" has no attribute "unknown"  [attr-defined]
+specialtypes_type.py:179: error: Variable "typing.TypedDict" is not valid as a type  [valid-type]
+specialtypes_type.py:179: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
+specialtypes_type.py:180: error: type[...] can't contain "Literal[...]"  [valid-type]
 """
 conformance_automated = "Fail"
 errors_diff = """

--- a/conformance/results/pyrefly/specialtypes_type.toml
+++ b/conformance/results/pyrefly/specialtypes_type.toml
@@ -1,6 +1,7 @@
-conformant = "Pass"
-conformance_automated = "Pass"
+conformant = "Partial"
+conformance_automated = "Fail"
 errors_diff = """
+Line 180: Expected 1 errors
 """
 output = """
 ERROR specialtypes_type.py:56:7-15: Argument `type[TeamUser]` is not assignable to parameter `user_class` with type `type[BasicUser | ProUser]` in function `func4` [bad-argument-type]
@@ -12,4 +13,5 @@ ERROR specialtypes_type.py:143:1-12: Class `type` has no class attribute `unknow
 ERROR specialtypes_type.py:144:1-12: Class `type` has no class attribute `unknown` [missing-attribute]
 ERROR specialtypes_type.py:145:1-12: Class `type` has no class attribute `unknown` [missing-attribute]
 ERROR specialtypes_type.py:146:1-12: Class `type` has no class attribute `unknown` [missing-attribute]
+ERROR specialtypes_type.py:179:9-18: `TypedDict` is not allowed in this context [invalid-annotation]
 """

--- a/conformance/results/pyright/specialtypes_type.toml
+++ b/conformance/results/pyright/specialtypes_type.toml
@@ -1,4 +1,4 @@
-conformant = "Pass"
+conformant = "Fail"
 output = """
 specialtypes_type.py:56:7 - error: Argument of type "type[TeamUser]" cannot be assigned to parameter "user_class" of type "type[BasicUser] | type[ProUser]" in function "func4"
   Type "type[TeamUser]" is not assignable to type "type[BasicUser] | type[ProUser]"
@@ -20,7 +20,11 @@ specialtypes_type.py:145:5 - error: Cannot access attribute "unknown" for class 
   Attribute "unknown" is unknown (reportAttributeAccessIssue)
 specialtypes_type.py:146:5 - error: Cannot access attribute "unknown" for class "TA4"
   Attribute "unknown" is unknown (reportAttributeAccessIssue)
+specialtypes_type.py:178:9 - error: Type argument for "type" must be a class; callables are not supported (reportInvalidTypeForm)
+specialtypes_type.py:179:9 - error: "TypedDict" cannot be used in this context (reportInvalidTypeForm)
 """
-conformance_automated = "Pass"
+conformance_automated = "Fail"
 errors_diff = """
+Line 180: Expected 1 errors
+Line 178: Unexpected errors ['specialtypes_type.py:178:9 - error: Type argument for "type" must be a class; callables are not supported (reportInvalidTypeForm)']
 """

--- a/conformance/results/results.html
+++ b/conformance/results/results.html
@@ -243,9 +243,9 @@
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;specialtypes_type</th>
 <th class="column col2 partially-conformant"><div class="hover-text">Partial<span class="tooltip-text" id="bottom"><p>Does not treat `type` same as `type[Any]` for assert_type.</p><p>Does not allow access to unknown attributes from object of type `type[Any]`.</p></span></div></th>
+<th class="column col2 not-conformant">Fail</th>
 <th class="column col2 conformant">Pass</th>
-<th class="column col2 conformant">Pass</th>
-<th class="column col2 conformant">Pass</th>
+<th class="column col2 partially-conformant">Partial</th>
 </tr>
 <tr><th class="column" colspan="5">
 <a class="test_group" href="https://typing.readthedocs.io/en/latest/spec/generics.html">Generics</a>
@@ -281,7 +281,7 @@
 <th class="column col2 conformant">Pass</th>
 </tr>
 <tr><th class="column col1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;generics_paramspec_basic</th>
-<th class="column col2 conformant">Pass</th>
+<th class="column col2 partially-conformant">Partial</th>
 <th class="column col2 conformant">Pass</th>
 <th class="column col2 conformant">Pass</th>
 <th class="column col2 conformant">Pass</th>

--- a/conformance/results/zuban/specialtypes_type.toml
+++ b/conformance/results/zuban/specialtypes_type.toml
@@ -11,4 +11,6 @@ specialtypes_type.py:143: error: "_SpecialForm" has no attribute "unknown"  [att
 specialtypes_type.py:144: error: "_SpecialForm" has no attribute "unknown"  [attr-defined]
 specialtypes_type.py:145: error: "_SpecialForm" has no attribute "unknown"  [attr-defined]
 specialtypes_type.py:146: error: "_SpecialForm" has no attribute "unknown"  [attr-defined]
+specialtypes_type.py:179: error: Invalid type  [valid-type]
+specialtypes_type.py:180: error: type[...] can't contain "Literal[...]"  [misc]
 """

--- a/conformance/tests/specialtypes_type.py
+++ b/conformance/tests/specialtypes_type.py
@@ -5,7 +5,7 @@ Tests the handling of builtins.type[T].
 # Specification: https://typing.readthedocs.io/en/latest/spec/special-types.html#type
 
 
-from typing import Any, Callable, Generic, Type, TypeAlias, TypeVar, assert_type
+from typing import Any, Callable, Generic, Type, TypeAlias, TypeVar, assert_type, Literal, TypedDict
 
 
 class User:
@@ -173,3 +173,8 @@ def func13(v: type):
 class ClassA(Generic[T]):
     def method1(self, v: type) -> type[T]:
         return v  # OK
+
+# > Some other special forms like Literal and TypedDict are not allowed as an argument to type.
+c: type[Callable]  # OK
+t: type[TypedDict]  # E
+l: type[Literal[1]]  # E

--- a/docs/spec/special-types.rst
+++ b/docs/spec/special-types.rst
@@ -188,8 +188,8 @@ concrete class object, e.g. in the above example::
 ``type[T]`` where ``T`` is a type variable is allowed when annotating the
 first argument of a class method (see the relevant section).
 
-Any other :term:`special forms <special form>` like ``Callable`` are not
-allowed as an argument to ``type``.
+Some other :term:`special forms <special form>` like ``Literal`` and
+`TypedDict` are not allowed as an argument to ``type``.
 
 There are some concerns with this feature: for example when
 ``new_user()`` calls ``user_class()`` this implies that all subclasses


### PR DESCRIPTION
see: https://discuss.python.org/t/callable-isnt-a-special-form/106407

there is no reason to disallow `type[Callable]`, i can understand the motivation for disallowing `type[Literal[1]]` (although i disagree with it), i can't see any reason why `type[Callable]` isn't allowed when `type[tuple[int]]` is

this is true regardless of whether or not `Callable` is a special form (it's not, see https://github.com/python/typing/pull/2214)

motivation:
- https://github.com/astral-sh/ruff/pull/23753


