### PR TITLE
`directives_type_checking.py`: do not assert that type checkers must ignore all type errors in `if not TYPE_CHECKING` blocks

### DIFF
--- a/conformance/results/mypy/directives_type_checking.toml
+++ b/conformance/results/mypy/directives_type_checking.toml
@@ -1,6 +1,6 @@
 conformant = "Pass"
 output = """
-directives_type_checking.py:22: error: Incompatible types in assignment (expression has type "str", variable has type "int")  [assignment]
+directives_type_checking.py:14: error: List item 0 has incompatible type "str"; expected "int"  [list-item]
 """
 conformance_automated = "Pass"
 errors_diff = """

--- a/conformance/results/pyrefly/directives_type_checking.toml
+++ b/conformance/results/pyrefly/directives_type_checking.toml
@@ -3,5 +3,5 @@ conformance_automated = "Pass"
 errors_diff = """
 """
 output = """
-ERROR directives_type_checking.py:22:14-16: `Literal['']` is not assignable to `int` [bad-assignment]
+ERROR directives_type_checking.py:14:20-27: `list[str]` is not assignable to `list[int]` [bad-assignment]
 """

--- a/conformance/results/pyright/directives_type_checking.toml
+++ b/conformance/results/pyright/directives_type_checking.toml
@@ -1,7 +1,7 @@
 conformant = "Pass"
 output = """
-directives_type_checking.py:22:14 - error: Type "Literal['']" is not assignable to declared type "int"
-  "Literal['']" is not assignable to "int" (reportAssignmentType)
+directives_type_checking.py:14:21 - error: Type "list[str]" is not assignable to declared type "list[int]"
+  "Literal['foo']" is not assignable to "int" (reportAssignmentType)
 """
 conformance_automated = "Pass"
 errors_diff = """

--- a/conformance/results/ty/directives_type_checking.toml
+++ b/conformance/results/ty/directives_type_checking.toml
@@ -2,5 +2,5 @@ conformance_automated = "Pass"
 errors_diff = """
 """
 output = """
-directives_type_checking.py:22:14: error[invalid-assignment] Object of type `Literal[""]` is not assignable to `int`
+directives_type_checking.py:14:20: error[invalid-assignment] Object of type `list[int | str]` is not assignable to `list[int]`
 """

--- a/conformance/results/zuban/directives_type_checking.toml
+++ b/conformance/results/zuban/directives_type_checking.toml
@@ -2,5 +2,5 @@ conformance_automated = "Pass"
 errors_diff = """
 """
 output = """
-directives_type_checking.py:22: error: Incompatible types in assignment (expression has type "str", variable has type "int")  [assignment]
+directives_type_checking.py:14: error: List item 0 has incompatible type "str"; expected "int"  [list-item]
 """

--- a/conformance/tests/directives_type_checking.py
+++ b/conformance/tests/directives_type_checking.py
@@ -7,6 +7,15 @@ Tests the typing.TYPE_CHECKING constant.
 from typing import TYPE_CHECKING, assert_type
 
 
+if not TYPE_CHECKING:
+    a: int = ""  # E? Many type checkers suppress all errors in `if not TYPE_CHECKING` blocks, though this is not currently specified
+
+if TYPE_CHECKING:
+    x: list[int] = ["foo"]  # E: In a `if TYPE_CHECKING` block, type checkers should report all errors as normal
+else:
+    x: list[str] = [42]  # E? Many type checkers suppress all errors in `else` blocks of `if TYPE_CHECKING`, though this is not currently specified
+
+
 def foo(x: list[int], y: list[str]) -> None:
     z: list[int] | list[str]
 
@@ -16,12 +25,3 @@ def foo(x: list[int], y: list[str]) -> None:
         z = y
 
     assert_type(z, list[int])
-
-
-if TYPE_CHECKING:
-    x: int = ""  # E: In a `if TYPE_CHECKING` block, type checkers should report all errors as normal
-else:
-    x: int = ""  # E? Many type checkers suppress all errors in `else` blocks of `if TYPE_CHECKING`, though this is not currently specified
-
-if not TYPE_CHECKING:
-    x: int = ""  # E? Many type checkers suppress all errors in `if not TYPE_CHECKING` blocks, though this is not currently specified


### PR DESCRIPTION
This test currently asserts that type checkers should not emit errors for clearly incorrect code in `if not TYPE_CHECKING` blocks. Maybe that's reasonable behaviour, and maybe it's not, but it's never been specified in any PEP and it's not currently mandated by the spec. If we want to enforce that type checkers have to have this behaviour, then I think it should go via the normal process for modifications to the spec. In the meantime, I don't think it should be something asserted by the conformance suite.

This PR changes `directives_type_checking.py` so that it still asserts that type checkers should understand the `TYPE_CHECKING` constant as always-true, but so that it no longer asserts that type checkers should silence all diagnostics in these code regions, which goes far beyond what the spec mandates.