### PR TITLE
Update dataclass definitions in `protocols_definition.py` to not fail at class-creation time

### DIFF
--- a/conformance/tests/protocols_definition.py
+++ b/conformance/tests/protocols_definition.py
@@ -196,7 +196,7 @@ class Concrete4_Good6(NamedTuple):
 
 @dataclass(frozen=False)
 class Concrete4_Good7:
-    val1: Sequence[float] = [0]
+    val1: Sequence[float] = (0,)
 
 
 class Concrete4_Bad1:
@@ -315,7 +315,7 @@ class Concrete6_Good2:
 
 @dataclass(frozen=False)
 class Concrete6_Good3:
-    val1: Sequence[float] = [0]
+    val1: Sequence[float] = (0,)
 
 
 class Concrete6_Bad1:
@@ -330,7 +330,7 @@ class Concrete6_Bad2(NamedTuple):
 
 @dataclass(frozen=True)
 class Concrete6_Bad3:
-    val1: Sequence[float] = [0]
+    val1: Sequence[float] = (0,)
 
 
 v6_good1: Template6 = Concrete6_Good1()  # OK


### PR DESCRIPTION
Fixes https://github.com/python/typing/issues/2087