### PR TITLE
Fix two tiny bugs in the conformance suite

### DIFF
--- a/conformance/results/mypy/aliases_recursive.toml
+++ b/conformance/results/mypy/aliases_recursive.toml
@@ -3,7 +3,7 @@ output = """
 aliases_recursive.py:19: error: Dict entry 1 has incompatible type "str": "complex"; expected "str": "int | str | float | list[Json] | dict[str, Json] | None"  [dict-item]
 aliases_recursive.py:20: error: List item 1 has incompatible type "complex"; expected "int | str | float | list[Json] | dict[str, Json] | None"  [list-item]
 aliases_recursive.py:38: error: Incompatible types in assignment (expression has type "tuple[int, tuple[str, int], tuple[int, tuple[int, list[int]]]]", variable has type "RecursiveTuple")  [assignment]
-aliases_recursive.py:39: error: Name "t6" already defined on line 38  [no-redef]
+aliases_recursive.py:39: error: Incompatible types in assignment (expression has type "tuple[int, list[int]]", variable has type "RecursiveTuple")  [assignment]
 aliases_recursive.py:50: error: Dict entry 0 has incompatible type "str": "list[int]"; expected "str": "str | int | Mapping[str, RecursiveMapping]"  [dict-item]
 aliases_recursive.py:51: error: Dict entry 2 has incompatible type "str": "list[int]"; expected "str": "str | int | Mapping[str, RecursiveMapping]"  [dict-item]
 aliases_recursive.py:52: error: Dict entry 2 has incompatible type "str": "list[int]"; expected "str": "str | int | Mapping[str, RecursiveMapping]"  [dict-item]

--- a/conformance/tests/aliases_recursive.py
+++ b/conformance/tests/aliases_recursive.py
@@ -36,7 +36,7 @@ t3: RecursiveTuple = (1, "1", 1, "2")  # OK
 t4: RecursiveTuple = (1, ("1", 1), "2")  # OK
 t5: RecursiveTuple = (1, ("1", 1), (1, (1, 2)))  # OK
 t6: RecursiveTuple = (1, ("1", 1), (1, (1, [2])))  # E
-t6: RecursiveTuple = (1, [1])  # E
+t7: RecursiveTuple = (1, [1])  # E
 
 
 RecursiveMapping = str | int | Mapping[str, "RecursiveMapping"]

--- a/conformance/tests/enums_members.py
+++ b/conformance/tests/enums_members.py
@@ -72,7 +72,7 @@ class Pet4(Enum):
         return "mammal"
 
     def speak(self) -> None:  # Non-member method
-        print("meow" if self is Pet.CAT else "woof")
+        print("meow" if self is Pet4.CAT else "woof")
 
     class Nested: ...  # Non-member nested class
 


### PR DESCRIPTION
Mypy emitted an error, as expected, on line 39 of `conformance/tests/aliases_recursive.py`. But it wasn't emitting an error for the right reason -- the `t6` variable here shadows a previously declared `t6` variable on the previous line.

And on line 75 of `conformance/tests/enums_members.py`, the `self is Pet.CAT` condition will always evaluate to `True`, because this is a method on the `Pet4` class, not the `Pet` class.