### PR TITLE
`protocols_runtime_checkable.py`: change a multiline `isinstance()` call to be single-line

### DIFF
--- a/conformance/results/mypy/protocols_runtime_checkable.toml
+++ b/conformance/results/mypy/protocols_runtime_checkable.toml
@@ -12,6 +12,6 @@ protocols_runtime_checkable.py:61: note: Protocol "DataProtocol" has non-method 
 conformance_automated = "Fail"
 errors_diff = """
 Line 88: Expected 1 errors
-Line 92: Expected 1 errors
-Line 96: Expected 1 errors
+Line 91: Expected 1 errors
+Line 94: Expected 1 errors
 """

--- a/conformance/results/pyrefly/protocols_runtime_checkable.toml
+++ b/conformance/results/pyrefly/protocols_runtime_checkable.toml
@@ -7,8 +7,8 @@ ERROR protocols_runtime_checkable.py:23:22-28: Protocol `Proto1` is not decorate
 ERROR protocols_runtime_checkable.py:55:22-34: Protocol `DataProtocol` has non-method members and cannot be used with issubclass() [invalid-argument]
 ERROR protocols_runtime_checkable.py:61:22-53: Protocol `DataProtocol` has non-method members and cannot be used with issubclass() [invalid-argument]
 ERROR protocols_runtime_checkable.py:88:33-39: Runtime checkable protocol `Proto3` has an unsafe overlap with type `Concrete3A` [unsafe-overlap]
-ERROR protocols_runtime_checkable.py:92:23-48: Runtime checkable protocol `Proto3` has an unsafe overlap with type `Concrete3B` [unsafe-overlap]
-ERROR protocols_runtime_checkable.py:92:23-48: Runtime checkable protocol `NonDataProtocol` has an unsafe overlap with type `Concrete3B` [unsafe-overlap]
-ERROR protocols_runtime_checkable.py:96:31-56: Runtime checkable protocol `Proto3` has an unsafe overlap with type `Concrete3A` [unsafe-overlap]
-ERROR protocols_runtime_checkable.py:96:31-56: Runtime checkable protocol `NonDataProtocol` has an unsafe overlap with type `Concrete3A` [unsafe-overlap]
+ERROR protocols_runtime_checkable.py:91:33-58: Runtime checkable protocol `Proto3` has an unsafe overlap with type `Concrete3B` [unsafe-overlap]
+ERROR protocols_runtime_checkable.py:91:33-58: Runtime checkable protocol `NonDataProtocol` has an unsafe overlap with type `Concrete3B` [unsafe-overlap]
+ERROR protocols_runtime_checkable.py:94:31-56: Runtime checkable protocol `Proto3` has an unsafe overlap with type `Concrete3A` [unsafe-overlap]
+ERROR protocols_runtime_checkable.py:94:31-56: Runtime checkable protocol `NonDataProtocol` has an unsafe overlap with type `Concrete3A` [unsafe-overlap]
 """

--- a/conformance/results/pyright/protocols_runtime_checkable.toml
+++ b/conformance/results/pyright/protocols_runtime_checkable.toml
@@ -6,13 +6,13 @@ protocols_runtime_checkable.py:55:22 - error: Data protocols (which include non-
 protocols_runtime_checkable.py:61:22 - error: Data protocols (which include non-method attributes) are not allowed in issubclass calls (reportGeneralTypeIssues)
 protocols_runtime_checkable.py:88:19 - error: Class overlaps "Proto3" unsafely and could produce a match at runtime
   Attributes of "Concrete3A" have the same names as the protocol (reportGeneralTypeIssues)
-protocols_runtime_checkable.py:92:9 - error: Class overlaps "Proto3" unsafely and could produce a match at runtime
+protocols_runtime_checkable.py:91:19 - error: Class overlaps "Proto3" unsafely and could produce a match at runtime
   Attributes of "Concrete3B" have the same names as the protocol (reportGeneralTypeIssues)
-protocols_runtime_checkable.py:92:9 - error: Class overlaps "NonDataProtocol" unsafely and could produce a match at runtime
+protocols_runtime_checkable.py:91:19 - error: Class overlaps "NonDataProtocol" unsafely and could produce a match at runtime
   Attributes of "Concrete3B" have the same names as the protocol (reportGeneralTypeIssues)
-protocols_runtime_checkable.py:96:19 - error: Class overlaps "Proto3" unsafely and could produce a match at runtime
+protocols_runtime_checkable.py:94:19 - error: Class overlaps "Proto3" unsafely and could produce a match at runtime
   Attributes of "Concrete3A" have the same names as the protocol (reportGeneralTypeIssues)
-protocols_runtime_checkable.py:96:19 - error: Class overlaps "NonDataProtocol" unsafely and could produce a match at runtime
+protocols_runtime_checkable.py:94:19 - error: Class overlaps "NonDataProtocol" unsafely and could produce a match at runtime
   Attributes of "Concrete3A" have the same names as the protocol (reportGeneralTypeIssues)
 """
 conformance_automated = "Pass"

--- a/conformance/results/ty/protocols_runtime_checkable.toml
+++ b/conformance/results/ty/protocols_runtime_checkable.toml
@@ -5,8 +5,8 @@ Does not reject `isinstance()` or `issubclass()` calls against runtime-checkable
 """
 errors_diff = """
 Line 88: Expected 1 errors
-Line 92: Expected 1 errors
-Line 96: Expected 1 errors
+Line 91: Expected 1 errors
+Line 94: Expected 1 errors
 """
 output = """
 protocols_runtime_checkable.py:23:8: error[isinstance-against-protocol] Class `Proto1` cannot be used as the second argument to `isinstance`: This call will raise `TypeError` at runtime

--- a/conformance/results/zuban/protocols_runtime_checkable.toml
+++ b/conformance/results/zuban/protocols_runtime_checkable.toml
@@ -8,8 +8,8 @@ protocols_runtime_checkable.py:55: note: Protocol "DataProtocol" has non-method 
 protocols_runtime_checkable.py:61: error: Only protocols that don't have non-method members can be used with issubclass()  [misc]
 protocols_runtime_checkable.py:61: note: Protocol "DataProtocol" has non-method member(s): name
 protocols_runtime_checkable.py:88: error: Subclass of "Concrete3A" and "Proto3" cannot exist: would have incompatible method signatures  [unreachable]
-protocols_runtime_checkable.py:92: error: Subclass of "Concrete3B" and "Proto3" cannot exist: would have incompatible method signatures  [unreachable]
-protocols_runtime_checkable.py:92: error: Subclass of "Concrete3B" and "NonDataProtocol" cannot exist: would have incompatible method signatures  [unreachable]
-protocols_runtime_checkable.py:96: error: Subclass of "Concrete3A" and "Proto3" cannot exist: would have incompatible method signatures  [unreachable]
-protocols_runtime_checkable.py:96: error: Subclass of "Concrete3A" and "NonDataProtocol" cannot exist: would have incompatible method signatures  [unreachable]
+protocols_runtime_checkable.py:91: error: Subclass of "Concrete3B" and "Proto3" cannot exist: would have incompatible method signatures  [unreachable]
+protocols_runtime_checkable.py:91: error: Subclass of "Concrete3B" and "NonDataProtocol" cannot exist: would have incompatible method signatures  [unreachable]
+protocols_runtime_checkable.py:94: error: Subclass of "Concrete3A" and "Proto3" cannot exist: would have incompatible method signatures  [unreachable]
+protocols_runtime_checkable.py:94: error: Subclass of "Concrete3A" and "NonDataProtocol" cannot exist: would have incompatible method signatures  [unreachable]
 """

--- a/conformance/tests/protocols_runtime_checkable.py
+++ b/conformance/tests/protocols_runtime_checkable.py
@@ -88,9 +88,7 @@ def func3():
     if isinstance(Concrete3A(), Proto3):  # E: unsafe overlap
         pass
 
-    if isinstance(
-        Concrete3B(), (Proto3, NonDataProtocol)  # E: unsafe overlap
-    ):
+    if isinstance(Concrete3B(), (Proto3, NonDataProtocol)):  # E: unsafe overlap
         pass
 
     if issubclass(Concrete3A, (Proto3, NonDataProtocol)):  # E: unsafe overlap


### PR DESCRIPTION
My draft PR implementing this check in ty would cause us to emit an error on the first line of the `isinstance()` call expression, which doesn't align with this test's expectations currently. By moving it all onto one line, all other previously passing type checkers continue to pass this assertion, but ty will too.