### PR TITLE
Add conformance test for nested Optional behavior

### DIFF
--- a/conformance/tests/specialtypes_optional_nested.py
+++ b/conformance/tests/specialtypes_optional_nested.py
@@ -1,0 +1,16 @@
+"""
+Tests for behavior of nested Optional types collapsing.
+
+Optional[Optional[T]] should behave as Optional[T].
+"""
+
+from typing import Optional, assert_type
+
+
+def test_nested_optional(x: Optional[Optional[int]]) -> None:
+    # Should behave like Optional[int]
+    assert_type(x, Optional[int])
+
+
+def test_nested_optional_error(x: Optional[Optional[int]]) -> int:
+    return x  # E


### PR DESCRIPTION
This PR adds a conformance test for nested Optional types.

Specifically, it verifies that `Optional[Optional[T]]` behaves as `Optional[T]`, 
and ensures that such values are not treated as non-optional types without proper handling.

The test includes:
- Validation of type collapsing behavior for nested Optional types
- A negative case where `Optional[Optional[int]]` is incorrectly used as `int`

This helps improve coverage of edge cases related to Optional and None handling 
in the typing specification.