### PR TITLE
Conformance suite: fix classes with metaclasses to not fail at runtime

### DIFF
--- a/conformance/tests/dataclasses_transform_meta.py
+++ b/conformance/tests/dataclasses_transform_meta.py
@@ -25,8 +25,8 @@ def model_field(
 class ModelMeta(type):
     not_a_field: str
 
-    def __init__(self, not_a_field: str) -> None:
-        self.not_a_field = not_a_field
+    def __init__(self, *args, **kwargs) -> None:
+        self.not_a_field: str = "not a field"
 
 
 class ModelBase(metaclass=ModelMeta):

--- a/conformance/tests/protocols_class_objects.py
+++ b/conformance/tests/protocols_class_objects.py
@@ -93,8 +93,8 @@ class ConcreteC2:
 class CMeta(type):
     attr1: int
 
-    def __init__(self, attr1: int) -> None:
-        self.attr1 = attr1
+    def __init__(self, *args, **kwargs) -> None:
+        self.attr1: int = 1
 
 
 class ConcreteC3(metaclass=CMeta):


### PR DESCRIPTION
The creation of the class `ModelBase` in `dataclass_transform_meta.py` fails at runtime:

```pycon
>>> from typing import Any, dataclass_transform
... 
... class ModelField:
...     def __init__(self, *, init: bool = True, default: Any | None = None) -> None:
...         ...
... 
... 
... def model_field(
...     *, init: bool = True, default: Any | None = None, alias: str | None = None
... ) -> Any:
...     raise NotImplementedError
... 
... 
... @dataclass_transform(
...     kw_only_default=True,
...     field_specifiers=(ModelField, model_field),
... )
... class ModelMeta(type):
...     not_a_field: str
... 
...     def __init__(self, not_a_field: str) -> None:
...         self.not_a_field = not_a_field
... 
... 
... class ModelBase(metaclass=ModelMeta):
...     def __init_subclass__(
...         cls,
...         *,
...         frozen: bool = False,
...         kw_only: bool = True,
...         order: bool = True,
...     ) -> None:
...         ...
...         
Traceback (most recent call last):
  File "<python-input-0>", line 25, in <module>
    class ModelBase(metaclass=ModelMeta):
    ...<7 lines>...
            ...
TypeError: ModelMeta.__init__() takes 2 positional arguments but 4 were given
```

This is because the `class` statement in Python desugars to an implicit call to the constructor of the class's metaclass. A metaclass's `__init__` and `__new__` methods are expected to receive four parameters: `cls`, `name`, `bases`, and `namespace`. `ModelMeta.__init__` doesn't, so the class creation fails. I have a [ty PR](https://github.com/astral-sh/ruff/pull/24550) that detects these errors, and it causes ty to regress its conformance score because of this invalidly defined class in the conformance suite.

The same issue exists with `Concrete3` and `CMeta` in `protocol_class_objects.py`.

The precise signature of the metaclass `__init__` methods appears irrelevant in both cases to what the tests are trying to assert. This PR alters the signatures so that the class creation now succeeds at runtime:

 ```pycon
>>> from typing import Any, dataclass_transform
... 
... class ModelField:
...     def __init__(self, *, init: bool = True, default: Any | None = None) -> None:
...         ...
... 
... 
... def model_field(
...     *, init: bool = True, default: Any | None = None, alias: str | None = None
... ) -> Any:
...     return 42
... 
... 
... @dataclass_transform(
...     kw_only_default=True,
...     field_specifiers=(ModelField, model_field),
... )
... class ModelMeta(type):
...     not_a_field: str
... 
...     def __init__(self, *args, **kwargs) -> None:
...         self.not_a_field: str = "not a field"
... 
... 
... class ModelBase(metaclass=ModelMeta):
...     def __init_subclass__(
...         cls,
...         *,
...         frozen: bool = False,
...         kw_only: bool = True,
...         order: bool = True,
...     ) -> None:
...         ...
... 
... 
... class Customer1(ModelBase, frozen=True):
...     id: int = model_field()
...     name: str = model_field()
...     name2: str = model_field(alias="other_name", default="None")
...     
>>> class CMeta(type):
...     attr1: int
... 
...     def __init__(self, *args, **kwargs) -> None:
...         self.attr1: int = 1
... 
... 
... class ConcreteC3(metaclass=CMeta):
...     pass
... 
>>> 
```