### PR TITLE
Fix generic default documentation

### DIFF
--- a/docs/spec/generics.rst
+++ b/docs/spec/generics.rst
@@ -1849,7 +1849,7 @@ and a type checker should flag this as an error.
        AllTheDefaults[int, complex, str, int, bool]
    )  # All valid
 
-With the new Python 3.13 syntax for generics (introduced by :pep:`695`), this can
+With the new Python 3.13 syntax for generics (introduced by :pep:`696`), this can
 be enforced at compile time::
 
    type Alias[DefaultT = int, T] = tuple[DefaultT, T]  # SyntaxError: non-default TypeVars cannot follow ones with defaults

--- a/docs/spec/generics.rst
+++ b/docs/spec/generics.rst
@@ -1849,7 +1849,7 @@ and a type checker should flag this as an error.
        AllTheDefaults[int, complex, str, int, bool]
    )  # All valid
 
-With the new Python 3.12 syntax for generics (introduced by :pep:`695`), this can
+With the new Python 3.13 syntax for generics (introduced by :pep:`695`), this can
 be enforced at compile time::
 
    type Alias[DefaultT = int, T] = tuple[DefaultT, T]  # SyntaxError: non-default TypeVars cannot follow ones with defaults


### PR DESCRIPTION
Change the version defaults were added from Python 3.12 to Python 3.13

Pep 0695: https://peps.python.org/pep-0695/ says that the Python version is 3.12; however, it says in the docs that this was added in Python 3.13 (at the bottom of this section https://docs.python.org/3/library/typing.html#typing.TypeVar), and I'm getting a syntax error when I test this in Python 3.12.