### PR TITLE
conformance: allow consistent treatment of kwargs: Unpack[TD]

### DIFF
--- a/conformance/results/ty/callables_kwargs.toml
+++ b/conformance/results/ty/callables_kwargs.toml
@@ -2,7 +2,6 @@ conformance_automated = "Fail"
 conformant = "Unsupported"
 errors_diff = """
 Line 46: Expected 1 errors
-Line 51: Expected 1 errors
 Line 58: Expected 1 errors
 Line 63: Expected 1 errors
 Line 65: Expected 1 errors

--- a/conformance/tests/callables_kwargs.py
+++ b/conformance/tests/callables_kwargs.py
@@ -48,7 +48,7 @@ def func3() -> None:
 
     td2 = TD2(v1=2, v3="4")
     func1(**td2)  # OK
-    func1(v1=1, v2="", v3="5", v4=5)  # E: v4 is not in TD2
+    func1(v1=1, v2="", v3="5", v4=5)  # E?: v4 is not in TD2, but could be in a  subtype
     func1(1, "", "5")  # E: args not passed by position
 
     # > Passing a dictionary of type dict[str, object] as a **kwargs argument


### PR DESCRIPTION
The conformance suite currently asserts this (simplified for clarity):

```py
class TD(TypedDict):
	v1: int

def f(**kwargs: Unpack[TD]): ...

f(v1=1, v2=2) # E: TD doesn't contain `v2`
```

This implies that the signature of `f` de-sugars to `f(*, v1: int)`. But the current conformance suite simultaneously also requires that callable assignability behave as if it de-sugars to `f(*, v1: int, **kwargs: object)`. That addition to the conformance suite was justified by this call, which is allowed by pyright and pyrefly:

```py
class TD2(TD1):
    v2: int

def _(td2: TD2):
    f(**td2)
```

It seems reasonable to allow this call, because TD2 is a subtype of TD1 and assignable to it, so `**td2` should therefore be acceptable for `**kwargs: Unpack[TD1]`. But if this call (which definitely provides a keyword argument `v2`) is allowed, then we should also allow the above call  that explicitly provides `v2`.

I think we could defensibly pick either of the interpretations of the signature of `f` (with or without `**kwargs: object`), but type checkers should be allowed to pick a consistent interpretation, not be required to implement an inconsistent hybrid behavior.

The interpretation with `**kwargs: object` is IMO more consistent and better supported by the spec. The spec says that if `TD` has `extra_items`, then arbitrary additional keyword arguments of that type should be accepted. And it also says that a `TypedDict` without an explicit `closed` or `extra_items` parameter usually behaves as if it has `extra_items` of type `ReadOnly[object]`.

The interpretation without `**kwargs: object` would effectively be saying that `**kwargs: Unpack[TD]` is one of these special cases (along with `TypedDict` constructor calls) where an unmarked TypedDict is (inconsistent with its "open" semantics) _not_ treated as having `extra_items` of type `ReadOnly[object]`.

We can have a discussion about which of these interpretations should be preferred, but given the lack of clarity about this in the spec, I think for now a conformant implementation should be allowed to choose either interpretation and implement it consistently.