### PR TITLE
added variance inference test with method scoped type variable

### DIFF
--- a/conformance/results/mypy/generics_variance_inference.toml
+++ b/conformance/results/mypy/generics_variance_inference.toml
@@ -1,4 +1,9 @@
-conformant = "Pass"
+conformant = "Partial"
+notes = """
+polymorphic functions with bound self type influence variance inference,
+which is not part of the variance inference algorithm as described in the spec.
+See gh-2281 for details.
+"""
 output = """
 generics_variance_inference.py:24: error: Incompatible types in assignment (expression has type "ClassA[float, int, int]", variable has type "ClassA[int, int, int]")  [assignment]
 generics_variance_inference.py:25: error: Incompatible types in assignment (expression has type "ClassA[float, int, int]", variable has type "ClassA[float, float, int]")  [assignment]
@@ -23,7 +28,10 @@ generics_variance_inference.py:169: error: Incompatible types in assignment (exp
 generics_variance_inference.py:170: error: Incompatible types in assignment (expression has type "ShouldBeInvariant6[int]", variable has type "ShouldBeInvariant6[float]")  [assignment]
 generics_variance_inference.py:181: error: Incompatible types in assignment (expression has type "ShouldBeCovariant6[float]", variable has type "ShouldBeCovariant6[int]")  [assignment]
 generics_variance_inference.py:194: error: Incompatible types in assignment (expression has type "ShouldBeContravariant2[int]", variable has type "ShouldBeContravariant2[float]")  [assignment]
+generics_variance_inference.py:204: error: Incompatible types in assignment (expression has type "ShouldBeCovariant7[int]", variable has type "ShouldBeCovariant7[object]")  [assignment]
+generics_variance_inference.py:205: error: Incompatible types in assignment (expression has type "ShouldBeCovariant7[object]", variable has type "ShouldBeCovariant7[int]")  [assignment]
 """
-conformance_automated = "Pass"
+conformance_automated = "Fail"
 errors_diff = """
+Line 204: Unexpected errors ['generics_variance_inference.py:204: error: Incompatible types in assignment (expression has type "ShouldBeCovariant7[int]", variable has type "ShouldBeCovariant7[object]")  [assignment]']
 """

--- a/conformance/results/pycroscope/generics_variance_inference.toml
+++ b/conformance/results/pycroscope/generics_variance_inference.toml
@@ -25,4 +25,5 @@ output = """
 ./generics_variance_inference.py:170:0: Incompatible assignment: expected generics_variance_inference.ShouldBeInvariant6[float | int], got generics_variance_inference.ShouldBeInvariant6[int] [incompatible_assignment]
 ./generics_variance_inference.py:181:0: Incompatible assignment: expected generics_variance_inference.ShouldBeCovariant6[int], got generics_variance_inference.ShouldBeCovariant6[float | int] [incompatible_assignment]
 ./generics_variance_inference.py:194:0: Incompatible assignment: expected generics_variance_inference.ShouldBeContravariant2[float | int], got generics_variance_inference.ShouldBeContravariant2[int] [incompatible_assignment]
+./generics_variance_inference.py:205:0: Incompatible assignment: expected generics_variance_inference.ShouldBeCovariant7[int], got generics_variance_inference.ShouldBeCovariant7[object] [incompatible_assignment]
 """

--- a/conformance/results/pyrefly/generics_variance_inference.toml
+++ b/conformance/results/pyrefly/generics_variance_inference.toml
@@ -26,4 +26,5 @@ ERROR generics_variance_inference.py:169:31-58: `ShouldBeInvariant6[float]` is n
 ERROR generics_variance_inference.py:170:33-58: `ShouldBeInvariant6[int]` is not assignable to `ShouldBeInvariant6[float]` [bad-assignment]
 ERROR generics_variance_inference.py:181:31-58: `ShouldBeCovariant6[float]` is not assignable to `ShouldBeCovariant6[int]` [bad-assignment]
 ERROR generics_variance_inference.py:194:37-66: `ShouldBeContravariant2[int]` is not assignable to `ShouldBeContravariant2[float]` [bad-assignment]
+ERROR generics_variance_inference.py:205:31-59: `ShouldBeCovariant7[object]` is not assignable to `ShouldBeCovariant7[int]` [bad-assignment]
 """

--- a/conformance/results/pyright/generics_variance_inference.toml
+++ b/conformance/results/pyright/generics_variance_inference.toml
@@ -79,6 +79,10 @@ generics_variance_inference.py:194:37 - error: Type "ShouldBeContravariant2[int]
   "ShouldBeContravariant2[int]" is not assignable to "ShouldBeContravariant2[float]"
     Type parameter "T@ShouldBeContravariant2" is contravariant, but "int" is not a supertype of "float"
       "float" is not assignable to "int" (reportAssignmentType)
+generics_variance_inference.py:205:31 - error: Type "ShouldBeCovariant7[object]" is not assignable to declared type "ShouldBeCovariant7[int]"
+  "ShouldBeCovariant7[object]" is not assignable to "ShouldBeCovariant7[int]"
+    Type parameter "T@ShouldBeCovariant7" is covariant, but "object" is not a subtype of "int"
+      "object" is not assignable to "int" (reportAssignmentType)
 """
 conformance_automated = "Pass"
 errors_diff = """

--- a/conformance/results/results.html
+++ b/conformance/results/results.html
@@ -924,21 +924,35 @@
                     </tr>
                     <tr>
                         <th scope="row">generics_variance_inference</th>
+                        <td class="partially-conformant tooltip">
+                            Partial
+                            <ul class="notes">
+                                <li>polymorphic functions with bound self type influence variance inference,</li>
+                                <li>which is not part of the variance inference algorithm as described in the spec.</li>
+                                <li>See gh-2281 for details.</li>
+                            </ul>
+                        </td>
                         <td class="conformant">Pass</td>
                         <td class="conformant">Pass</td>
                         <td class="conformant">Pass</td>
                         <td class="conformant">Pass</td>
-                        <td class="conformant">Pass</td>
-                        <td class="conformant">Pass</td>
+                        <td class="partially-conformant tooltip">
+                            Partial
+                            <ul class="notes">
+                                <li>polymorphic functions with bound self type influence variance inference,</li>
+                                <li>which is not part of the variance inference algorithm as described in the spec.</li>
+                                <li>See gh-2281 for details.</li>
+                            </ul>
+                        </td>
                     </tr>
                     <tr class="summary">
                         <td></td>
-                        <td>23 / 30 • 76.7%</td>
+                        <td>22.5 / 30 • 75.0%</td>
                         <td>28.5 / 30 • 95.0%</td>
                         <td>30 / 30 • 100.0%</td>
                         <td>28.5 / 30 • 95.0%</td>
                         <td>27 / 30 • 90.0%</td>
-                        <td>30 / 30 • 100.0%</td>
+                        <td>29.5 / 30 • 98.3%</td>
                     </tr>
                 </tbody>
                 <tbody>
@@ -2632,12 +2646,12 @@
                 <tfoot>
                     <tr>
                         <td></td>
-                        <td>108.5 / 142 • 76.4%</td>
+                        <td>108 / 142 • 76.1%</td>
                         <td>130.5 / 142 • 91.9%</td>
                         <td>141 / 142 • 99.3%</td>
                         <td>136 / 142 • 95.8%</td>
                         <td>125.5 / 142 • 88.4%</td>
-                        <td>140.5 / 142 • 98.9%</td>
+                        <td>140 / 142 • 98.6%</td>
                     </tr>
                 </tfoot>
             </table>

--- a/conformance/results/ty/generics_variance_inference.toml
+++ b/conformance/results/ty/generics_variance_inference.toml
@@ -25,4 +25,5 @@ generics_variance_inference.py:169:31: error[invalid-assignment] Object of type 
 generics_variance_inference.py:170:33: error[invalid-assignment] Object of type `ShouldBeInvariant6[int]` is not assignable to `ShouldBeInvariant6[int | float]`
 generics_variance_inference.py:181:31: error[invalid-assignment] Object of type `ShouldBeCovariant6[int | float]` is not assignable to `ShouldBeCovariant6[int]`
 generics_variance_inference.py:194:37: error[invalid-assignment] Object of type `ShouldBeContravariant2[int]` is not assignable to `ShouldBeContravariant2[int | float]`
+generics_variance_inference.py:205:31: error[invalid-assignment] Object of type `ShouldBeCovariant7[object]` is not assignable to `ShouldBeCovariant7[int]`
 """

--- a/conformance/results/zuban/generics_variance_inference.toml
+++ b/conformance/results/zuban/generics_variance_inference.toml
@@ -1,5 +1,12 @@
-conformance_automated = "Pass"
+conformant = "Partial"
+notes = """
+polymorphic functions with bound self type influence variance inference,
+which is not part of the variance inference algorithm as described in the spec.
+See gh-2281 for details.
+"""
+conformance_automated = "Fail"
 errors_diff = """
+Line 200: Unexpected errors ['generics_variance_inference.py:200: error: Name "S" is not defined  [name-defined]', 'generics_variance_inference.py:200: error: Name "S" is not defined  [name-defined]']
 """
 output = """
 generics_variance_inference.py:24: error: Incompatible types in assignment (expression has type "ClassA[float, int, int]", variable has type "ClassA[int, int, int]")  [assignment]
@@ -25,4 +32,7 @@ generics_variance_inference.py:169: error: Incompatible types in assignment (exp
 generics_variance_inference.py:170: error: Incompatible types in assignment (expression has type "ShouldBeInvariant6[int]", variable has type "ShouldBeInvariant6[float]")  [assignment]
 generics_variance_inference.py:181: error: Incompatible types in assignment (expression has type "ShouldBeCovariant6[float]", variable has type "ShouldBeCovariant6[int]")  [assignment]
 generics_variance_inference.py:194: error: Incompatible types in assignment (expression has type "ShouldBeContravariant2[int]", variable has type "ShouldBeContravariant2[float]")  [assignment]
+generics_variance_inference.py:200: error: Name "S" is not defined  [name-defined]
+generics_variance_inference.py:200: error: Name "S" is not defined  [name-defined]
+generics_variance_inference.py:205: error: Incompatible types in assignment (expression has type "ShouldBeCovariant7[object]", variable has type "ShouldBeCovariant7[int]")  [assignment]
 """

--- a/conformance/tests/generics_variance_inference.py
+++ b/conformance/tests/generics_variance_inference.py
@@ -192,3 +192,14 @@ class ShouldBeContravariant2[T](Parent_Contravariant[T]):
 
 c1: ShouldBeContravariant2[int] = ShouldBeContravariant2[float]()  # OK
 c2: ShouldBeContravariant2[float] = ShouldBeContravariant2[int]()  # E
+
+class ShouldBeCovariant7[T]:
+    def get(self) -> T:
+        raise NotImplementedError
+
+    def add[S](self: "ShouldBeCovariant7[S]", other: list[S]) -> "ShouldBeCovariant7[S]":
+        raise NotImplementedError
+
+
+d1: ShouldBeCovariant7[object] = ShouldBeCovariant7[int]()  # OK
+d2: ShouldBeCovariant7[int] = ShouldBeCovariant7[object]()  # E


### PR DESCRIPTION
Fixes #2281

This adds a conformance test checking that method scoped type-variables do not influence variance inference, in accordance with the spec.
