### PR TITLE
docs: remove unnecessary PEP references in libraries guide

### DIFF
--- a/docs/guides/libraries.rst
+++ b/docs/guides/libraries.rst
@@ -353,8 +353,8 @@ Overloads
 
 If a function or method can return multiple different types and those
 types can be determined based on the presence or types of certain
-parameters, use the ``@overload`` mechanism defined in `PEP
-484 <https://www.python.org/dev/peps/pep-0484/#id45>`__. When overloads
+parameters, use the ``@overload`` mechanism described in the
+:py:data:`typing.overload` documentation. When overloads
 are used within a “.py” file, they must appear prior to the function
 implementation, which should not have an ``@overload`` decorator.
 
@@ -471,8 +471,8 @@ Generic Classes and Functions
 -----------------------------
 
 Classes and functions that can operate in a generic manner on various
-types should declare themselves as generic using the mechanisms
-described in :pep:`484`.
+types should declare themselves as generic using standard typing
+mechanisms such as ``TypeVar``.
 This includes the use of ``TypeVar`` symbols. Typically, a ``TypeVar``
 should be private to the file that declares it, and should therefore
 begin with an underscore.
@@ -499,7 +499,7 @@ annotation.
    # Recursive type alias
    TreeNode = LeafNode | list["TreeNode"]
 
-   # Explicit type alias using PEP 613 syntax
+   # Explicit type alias using TypeAlias
    StrOrInt: TypeAlias = str | int
 
 Abstract Classes and Methods


### PR DESCRIPTION
## Summary

This PR removes a few unnecessary PEP references from the Typing Python Libraries guide and replaces them with more user-focused wording and documentation references.

### Changes made

* Replaced the `PEP 484` overload reference with `typing.overload` documentation wording.
* Reworded the generic classes/functions section to refer to standard typing mechanisms instead of `PEP 484`.
* Replaced the `PEP 613` wording in the type alias example with direct `TypeAlias` terminology.

These changes align with the goal of preferring documentation-oriented references over direct PEP references where appropriate, while keeping important specification-related PEP references intact.

Related to #2150
