### PR TITLE
conformance: fix TypeIs case

### DIFF
--- a/conformance/tests/narrowing_typeis.py
+++ b/conformance/tests/narrowing_typeis.py
@@ -14,11 +14,11 @@ T = TypeVar("T")
 def is_two_element_tuple(val: tuple[T, ...]) -> TypeIs[tuple[T, T]]:
     return len(val) == 2
 
-def func1(names: tuple[str, ...]):
+def func1(names: tuple[str, str] | tuple[str, str, str]):
     if is_two_element_tuple(names):
         assert_type(names, tuple[str, str])
     else:
-        assert_type(names, tuple[str, ...])
+        assert_type(names, tuple[str, str, str])
 
 
 # > The final narrowed type may be narrower than **R**, due to the constraints of the


### PR DESCRIPTION
Strictly, the inferred type in the old code should be `tuple[str, ...] & ~tuple[str, str]`: that is,
a tuple full of strs of any length that is not 2. Currently no type checker actually infers this
type, but I'm working on a change to pycroscope (JelleZijlstra/pycroscope#505) that will make it fail this test.

ty also infers the negation type, but passes the test because the conformance suite turns off
the specific "assert-type-unspellable-subtype" error code.

The new code in the test case does not rely on ambiguous negation type behavior.