### PR TITLE
conformance: make open TypedDict extra kwargs optional

### DIFF
--- a/conformance/results/ty/typeddicts_extra_items.toml
+++ b/conformance/results/ty/typeddicts_extra_items.toml
@@ -5,7 +5,6 @@ Line 49: Expected 1 errors
 Line 67: Expected 1 errors
 Line 73: Expected 1 errors
 Line 109: Expected 1 errors
-Line 143: Expected 1 errors
 Line 174: Expected 1 errors
 Line 215: Expected 1 errors
 Line 222: Expected 1 errors

--- a/conformance/tests/typeddicts_extra_items.py
+++ b/conformance/tests/typeddicts_extra_items.py
@@ -140,7 +140,7 @@ class MovieExtra(TypedDict, extra_items=int):
 def unpack_no_extra(**kwargs: Unpack[MovieNoExtra]) -> None: ...
 def unpack_extra(**kwargs: Unpack[MovieExtra]) -> None: ...
 
-unpack_no_extra(name="No Country for Old Men", year=2007) # E: Unrecognized item
+unpack_no_extra(name="No Country for Old Men", year=2007) # E?: Unrecognized item
 unpack_extra(name="No Country for Old Men", year=2007) # OK
 
 # > Notably, if the TypedDict type specifies ``extra_items`` to be read-only,


### PR DESCRIPTION
## Summary

#2272 made errors optional when an extra keyword is passed to `**kwargs: Unpack[OpenTypedDict]`, modifying the expectation in `callables_kwargs.py`. But `typeddicts_extra_items.py` contains the same case:

```py
class MovieNoExtra(TypedDict):
    name: str

def unpack_no_extra(**kwargs: Unpack[MovieNoExtra]) ->
None: ...

unpack_no_extra(name="No Country for Old Men",
year=2007)  # E?
```

This PR marks the duplicate case optional, for consistency with #2272.
