### PR TITLE
docs: add concrete type definition and update protocol references

### DIFF
--- a/docs/spec/concepts.rst
+++ b/docs/spec/concepts.rst
@@ -169,6 +169,17 @@ is a subtype of ``str``, because ``MyStr`` represents a subset of the values
 represented by ``str``. Such types can be called "nominal types" and this is
 "nominal subtyping."
 
+.. _`concrete-type`:
+
+Concrete types
+--------------
+
+A **concrete type** is a type specified by the name of a Python class, for
+example, ``int``, ``str``, ``list``, or any user-defined class. Concrete types
+represent actual Python objects and are distinct from protocols, type
+variables, or type forms. They are used in type annotations where a specific
+class is intended.
+
 Other types (e.g. :ref:`Protocols` and :ref:`TypedDict`) instead describe a set
 of values by the types of their attributes and methods, or the types of their
 dictionary keys and values. These are called "structural types". A structural

--- a/docs/spec/protocol.rst
+++ b/docs/spec/protocol.rst
@@ -385,8 +385,8 @@ Protocols cannot be instantiated, so there are no values whose
 runtime type is a protocol. For variables and parameters with protocol types,
 assignability relationships are subject to the following rules:
 
-* A protocol is never assignable to a concrete type.
-* A concrete type ``X`` is assignable to a protocol ``P`` if and only if ``X``
+* A protocol is never assignable to a :ref:`concrete-type`.
+* A :ref:`concrete-type` ``X`` is assignable to a protocol ``P`` if and only if ``X``
   implements all protocol members of ``P`` with assignable types. In other
   words, :term:`assignability <assignable>` with respect to a protocol is
   always :term:`structural`.
@@ -465,7 +465,7 @@ Example::
 ``type[]`` and class objects vs protocols
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Variables and parameters annotated with ``type[Proto]`` accept only concrete
+Variables and parameters annotated with ``type[Proto]`` accept only :ref:`concrete-types <concrete-type>`
 (non-protocol) :term:`consistent subtypes <consistent subtype>` of ``Proto``.
 The main reason for this is to allow instantiation of parameters with such
 types. For example::


### PR DESCRIPTION
## Summary

This PR introduces a formal definition for **concrete types** in the typing specification and updates protocol-related references to point to the new definition.

## Changes

- Added a new **Concrete types** section to `docs/spec/concepts.rst`.
- Defined a concrete type as a type specified by the name of a Python class (e.g. `int`, `str`, `list`, or a user-defined class).
- Updated references in `docs/spec/protocol.rst` to use the new `:ref:\`concrete-type\`` reference.
- Clarified protocol assignability rules by linking the term "concrete type" to its definition.

## Related Issues

Closes #1781

Related to #1779