### PR TITLE
docs: remove broken LiteralString overloads example (closes #2090)

### DIFF
--- a/docs/spec/literal.rst
+++ b/docs/spec/literal.rst
@@ -309,7 +309,7 @@ Literal types. For example::
 
 **Note:** If the user wants their API to support accepting both literals
 *and* the original type -- perhaps for legacy purposes -- they should
-implement a fallback overload. See :ref:`literalstring-overloads`.
+implement a fallback overload.
 
 Interactions with other types and features
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -777,28 +777,3 @@ Standard containers like ``List`` work as expected:
 ::
 
     xs: List[LiteralString] = ["foo", "bar", "baz"]
-
-
-.. _literalstring-overloads:
-
-Interactions with Overloads
-"""""""""""""""""""""""""""
-
-Literal strings and overloads do not need to interact in a special
-way: the existing rules work fine. ``LiteralString`` can be used as a
-fallback overload where a specific ``Literal["foo"]`` type does not
-match:
-
-::
-
-    @overload
-    def foo(x: Literal["foo"]) -> int: ...
-    @overload
-    def foo(x: LiteralString) -> bool: ...
-    @overload
-    def foo(x: str) -> str: ...
-
-    x1: int = foo("foo")  # First overload.
-    x2: bool = foo("bar")  # Second overload.
-    s: str
-    x3: str = foo(s)  # Third overload.


### PR DESCRIPTION
## Summary

Fixes #2090.

The `LiteralString` "Interactions with Overloads" section contained an overload example that type checkers flag as unsafe overlaps (e.g. pyright errors because `Literal["foo"]` is a subtype of `LiteralString`, making the two overloads ambiguous). The section specified no normative behaviour — it was purely illustrative — so the simplest correct fix is removal, as suggested by @JelleZijlstra in the issue.

Also removes the `See :ref:\`literalstring-overloads\`` cross-reference in the preceding `Literal` note (the target no longer exists).

## Changes

- `docs/spec/literal.rst`: delete the 24-line "Interactions with Overloads" sub-section and its anchor; drop the stale `See :ref:` from the Literal note.

## Test plan

- [ ] `make html` (or ReadTheDocs build) succeeds with no broken-reference warnings