### PR TITLE
spec: clarify that passthrough __new__ is ignored when converting to callable

### DIFF
--- a/docs/spec/constructors.rst
+++ b/docs/spec/constructors.rst
@@ -387,7 +387,10 @@ constructor calls:
 2. If the class defines a ``__new__`` method or inherits a ``__new__`` method
    from a base class other than ``object``, a type checker should synthesize a
    callable from the parameters and return type of that method after it is bound
-   to the class.
+   to the class. If the ``__new__`` method's only non-``cls`` parameters are
+   ``*args`` and ``**kwargs`` (i.e. a passthrough), the method is considered
+   to not constrain the constructor signature, and this step produces no
+   callable type.
 
 3. If the return type of the method in step 2 evaluates to a type that is not a
    subclass of the class being constructed (or a union that includes such a
@@ -454,7 +457,7 @@ constructor calls:
 
 
     reveal_type(accepts_callable(A))  # ``def () -> A``
-    reveal_type(accepts_callable(B))  # ``def (*args, **kwargs) -> B | def (x: int) -> B``
+    reveal_type(accepts_callable(B))  # ``def (x: int) -> B``
     reveal_type(accepts_callable(C))  # ``def (x: int) -> int``
     reveal_type(accepts_callable(D))  # ``def () -> NoReturn``
     reveal_type(accepts_callable(E))  # ``def () -> A``


### PR DESCRIPTION
## Summary

Fixes #2158.

The spec's step 2 for converting a constructor to a `Callable` type said that a `__new__` method is always synthesized into a callable. The example for class `B` (which has `__new__(cls, *args, **kwargs) -> Self` and `__init__(self, x: int) -> None`) incorrectly showed:

```python
reveal_type(accepts_callable(B))  # `def (*args, **kwargs) -> B | def (x: int) -> B`
```

However, the conformance test (`Class3`) already specified the correct behaviour:

```python
reveal_type(r3)  # `def (x: int) -> Class3`
```

When `__new__` uses only `*args` and `**kwargs` as its non-`cls` parameters, it is a passthrough that defers all parameter constraints to `__init__`. Step 2 of the conversion algorithm should produce no callable type in this case. This is the behaviour already implemented by pyright, pycroscope, and zuban (all pass the conformance test).

## Changes

- `docs/spec/constructors.rst`: Added passthrough exception to step 2; corrected the `reveal_type` comment for class `B`.