### PR TITLE
Conformance: annotate module protocol globals

### DIFF
--- a/conformance/results/ty/protocols_modules.toml
+++ b/conformance/results/ty/protocols_modules.toml
@@ -4,11 +4,9 @@ notes = """
 Never considers a module as satisfying a protocol with a method member due to the fact that the method will never exist on the class `types.ModuleType`, only on a given specific module instance.
 """
 errors_diff = """
-Line 25: Unexpected errors ["protocols_modules.py:25:17: error[invalid-assignment] Object of type `<module '_protocols_modules1'>` is not assignable to `Options1`"]
 Line 47: Unexpected errors ["protocols_modules.py:47:18: error[invalid-assignment] Object of type `<module '_protocols_modules2'>` is not assignable to `Reporter1`"]
 """
 output = """
-protocols_modules.py:25:17: error[invalid-assignment] Object of type `<module '_protocols_modules1'>` is not assignable to `Options1`
 protocols_modules.py:26:17: error[invalid-assignment] Object of type `<module '_protocols_modules1'>` is not assignable to `Options2`
 protocols_modules.py:47:18: error[invalid-assignment] Object of type `<module '_protocols_modules2'>` is not assignable to `Reporter1`
 protocols_modules.py:48:18: error[invalid-assignment] Object of type `<module '_protocols_modules2'>` is not assignable to `Reporter2`

--- a/conformance/tests/_protocols_modules1.py
+++ b/conformance/tests/_protocols_modules1.py
@@ -2,6 +2,6 @@
 Support file for protocols_modules.py test.
 """
 
-timeout = 100
-one_flag = True
-other_flag = False
+timeout: int = 100
+one_flag: bool = True
+other_flag: bool = False


### PR DESCRIPTION
This test is intended to verify that a module can implement a protocol when its public interface is compatible. As written, though, it also prescribes how type checkers infer the public types of unannotated module globals.

The protocol attributes here are mutable, so their types are invariant. Some type checkers widen an assignment like `one_flag = True` to `bool` when accessed from another module, but in ty, we retain `Literal[True]`, in which case the attribute is _not_ writable as an arbitrary `bool`.

Explicitly annotating these variables as `int` and `bool` makes the intended public interface unambiguous (and should keep all existing implementations in-conformance).