### PR TITLE
Conformance: remove non-data-descriptor tests in dataclasses_descriptors.py

### DIFF
--- a/conformance/results/mypy/dataclasses_descriptors.toml
+++ b/conformance/results/mypy/dataclasses_descriptors.toml
@@ -1,18 +1,6 @@
-conformant = "Partial"
-notes = """
-Assumes descriptor behavior only when field is assigned in class body.
-Does not correctly evaluate type of descriptor access.
-"""
+conformant = "Pass"
 output = """
-dataclasses_descriptors.py:61: error: Cannot access instance-only attribute "x" on class object  [misc]
-dataclasses_descriptors.py:62: error: Cannot access instance-only attribute "y" on class object  [misc]
-dataclasses_descriptors.py:66: error: Expression is of type "Desc2[int]", not "int"  [assert-type]
-dataclasses_descriptors.py:67: error: Expression is of type "Desc2[str]", not "str"  [assert-type]
 """
-conformance_automated = "Fail"
+conformance_automated = "Pass"
 errors_diff = """
-Line 61: Unexpected errors ['dataclasses_descriptors.py:61: error: Cannot access instance-only attribute "x" on class object  [misc]']
-Line 62: Unexpected errors ['dataclasses_descriptors.py:62: error: Cannot access instance-only attribute "y" on class object  [misc]']
-Line 66: Unexpected errors ['dataclasses_descriptors.py:66: error: Expression is of type "Desc2[int]", not "int"  [assert-type]']
-Line 67: Unexpected errors ['dataclasses_descriptors.py:67: error: Expression is of type "Desc2[str]", not "str"  [assert-type]']
 """

--- a/conformance/results/pycroscope/dataclasses_descriptors.toml
+++ b/conformance/results/pycroscope/dataclasses_descriptors.toml
@@ -1,23 +1,6 @@
-conformant = "Partial"
-notes = """
-Conformance suite is questionable; see <https://github.com/python/typing/issues/2259>
-"""
-conformance_automated = "Fail"
+conformant = "Pass"
+conformance_automated = "Pass"
 errors_diff = """
-Line 61: Unexpected errors ['./dataclasses_descriptors.py:61:12:   Any[error] is not equivalent to list[int]', "./dataclasses_descriptors.py:61:12: <class 'DC2'> has no attribute 'x' [undefined_attribute]"]
-Line 62: Unexpected errors ['./dataclasses_descriptors.py:62:12:   Any[error] is not equivalent to list[str]', "./dataclasses_descriptors.py:62:12: <class 'DC2'> has no attribute 'y' [undefined_attribute]"]
-Line 63: Unexpected errors ['./dataclasses_descriptors.py:63:12:   list[Any[generic_argument]] is not equivalent to list[str]']
-Line 66: Unexpected errors ['./dataclasses_descriptors.py:66:12:   ./dataclasses_descriptors.py.Desc2[int] is not equivalent to int']
-Line 67: Unexpected errors ['./dataclasses_descriptors.py:67:12:   ./dataclasses_descriptors.py.Desc2[str] is not equivalent to str']
-Line 68: Unexpected errors ['./dataclasses_descriptors.py:68:12:   Any[generic_argument] is not equivalent to str']
 """
 output = """
-./dataclasses_descriptors.py:61:12:   Any[error] is not equivalent to list[int]
-./dataclasses_descriptors.py:61:12: <class 'DC2'> has no attribute 'x' [undefined_attribute]
-./dataclasses_descriptors.py:62:12:   Any[error] is not equivalent to list[str]
-./dataclasses_descriptors.py:62:12: <class 'DC2'> has no attribute 'y' [undefined_attribute]
-./dataclasses_descriptors.py:63:12:   list[Any[generic_argument]] is not equivalent to list[str]
-./dataclasses_descriptors.py:66:12:   ./dataclasses_descriptors.py.Desc2[int] is not equivalent to int
-./dataclasses_descriptors.py:67:12:   ./dataclasses_descriptors.py.Desc2[str] is not equivalent to str
-./dataclasses_descriptors.py:68:12:   Any[generic_argument] is not equivalent to str
 """

--- a/conformance/results/pyrefly/dataclasses_descriptors.toml
+++ b/conformance/results/pyrefly/dataclasses_descriptors.toml
@@ -5,10 +5,8 @@ Doesn't allow non-data descriptors or data descriptors with differing `__get__` 
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 32: Unexpected errors ['Cannot set field `y` to data descriptor `Desc1` with inconsistent types [bad-class-definition]']
-Line 58: Unexpected errors ['Cannot set field `z` to non-data descriptor `Desc2` [bad-class-definition]']
+Line 30: Unexpected errors ['Cannot set field `y` to data descriptor `Desc1` with inconsistent types [bad-class-definition]']
 """
 output = """
-ERROR dataclasses_descriptors.py:32:5-6: Cannot set field `y` to data descriptor `Desc1` with inconsistent types [bad-class-definition]
-ERROR dataclasses_descriptors.py:58:5-6: Cannot set field `z` to non-data descriptor `Desc2` [bad-class-definition]
+ERROR dataclasses_descriptors.py:30:5-6: Cannot set field `y` to data descriptor `Desc1` with inconsistent types [bad-class-definition]
 """

--- a/conformance/results/results.html
+++ b/conformance/results/results.html
@@ -1883,19 +1883,8 @@
                     <tr>
                         <th scope="row">dataclasses_descriptors</th>
                         <td class="conformant">Pass</td>
-                        <td class="partially-conformant tooltip">
-                            Partial
-                            <ul class="notes">
-                                <li>Assumes descriptor behavior only when field is assigned in class body.</li>
-                                <li>Does not correctly evaluate type of descriptor access.</li>
-                            </ul>
-                        </td>
-                        <td class="partially-conformant tooltip">
-                            Partial
-                            <ul class="notes">
-                                <li>Conformance suite is questionable; see <a href="https://github.com/python/typing/issues/2259">https://github.com/python/typing/issues/2259</a></li>
-                            </ul>
-                        </td>
+                        <td class="conformant">Pass</td>
+                        <td class="conformant">Pass</td>
                         <td class="partially-conformant tooltip">
                             Partial
                             <ul class="notes">
@@ -1904,12 +1893,7 @@
                             </ul>
                         </td>
                         <td class="conformant">Pass</td>
-                        <td class="partially-conformant tooltip">
-                            Partial
-                            <ul class="notes">
-                                <li>Only infers a descriptor <code>__get__</code> method as being called when a descriptor attribute is accessed on an instance if the descriptor attribute is present in the class namespace.</li>
-                            </ul>
-                        </td>
+                        <td class="conformant">Pass</td>
                         <td class="conformant">Pass</td>
                     </tr>
                     <tr>
@@ -2114,11 +2098,11 @@
                     <tr class="summary">
                         <td></td>
                         <td>16 / 16 • 100.0%</td>
-                        <td>11.5 / 16 • 71.9%</td>
-                        <td>15.5 / 16 • 96.9%</td>
+                        <td>12 / 16 • 75.0%</td>
+                        <td>16 / 16 • 100.0%</td>
                         <td>15.5 / 16 • 96.9%</td>
                         <td>16 / 16 • 100.0%</td>
-                        <td>14.5 / 16 • 90.6%</td>
+                        <td>15 / 16 • 93.8%</td>
                         <td>16 / 16 • 100.0%</td>
                     </tr>
                 </tbody>
@@ -2807,11 +2791,11 @@
                     <tr>
                         <td></td>
                         <td>141 / 141 • 100.0%</td>
-                        <td>109 / 141 • 77.3%</td>
-                        <td>130 / 141 • 92.2%</td>
+                        <td>109.5 / 141 • 77.7%</td>
+                        <td>130.5 / 141 • 92.6%</td>
                         <td>138 / 141 • 97.9%</td>
                         <td>136.5 / 141 • 96.8%</td>
-                        <td>116 / 141 • 82.3%</td>
+                        <td>116.5 / 141 • 82.6%</td>
                         <td>140.5 / 141 • 99.6%</td>
                     </tr>
                 </tfoot>

--- a/conformance/results/ty/dataclasses_descriptors.toml
+++ b/conformance/results/ty/dataclasses_descriptors.toml
@@ -1,13 +1,6 @@
-conformance_automated = "Fail"
-conformant = "Partial"
-notes = """
-Only infers a descriptor `__get__` method as being called when a descriptor attribute is accessed on an instance if the descriptor attribute is present in the class namespace.
-"""
+conformance_automated = "Pass"
+conformant = "Pass"
 errors_diff = """
-Line 66: Unexpected errors ['dataclasses_descriptors.py:66:1: error[type-assertion-failure] Type `int | Desc2[int]` does not match asserted type `int`']
-Line 67: Unexpected errors ['dataclasses_descriptors.py:67:1: error[type-assertion-failure] Type `str | Desc2[str]` does not match asserted type `str`']
 """
 output = """
-dataclasses_descriptors.py:66:1: error[type-assertion-failure] Type `int | Desc2[int]` does not match asserted type `int`
-dataclasses_descriptors.py:67:1: error[type-assertion-failure] Type `str | Desc2[str]` does not match asserted type `str`
 """

--- a/conformance/tests/dataclasses_descriptors.py
+++ b/conformance/tests/dataclasses_descriptors.py
@@ -6,9 +6,7 @@ Tests the handling of descriptors within a dataclass.
 # but its behavior can be determined from the runtime implementation.
 
 from dataclasses import dataclass
-from typing import Any, Generic, TypeVar, assert_type, overload
-
-T = TypeVar("T")
+from typing import Any, assert_type, overload
 
 
 class Desc1:
@@ -37,32 +35,8 @@ dc1 = DC1(3)
 assert_type(dc1.y, int)
 assert_type(DC1.y, Desc1)
 
-
-class Desc2(Generic[T]):
-    @overload
-    def __get__(self, instance: None, owner: Any) -> list[T]:
-        ...
-
-    @overload
-    def __get__(self, instance: object, owner: Any) -> T:
-        ...
-
-    def __get__(self, instance: object | None, owner: Any) -> list[T] | T:
-        raise NotImplementedError
-
-
-@dataclass
-class DC2:
-    x: Desc2[int]
-    y: Desc2[str]
-    z: Desc2[str] = Desc2()
-
-
-assert_type(DC2.x, list[int])
-assert_type(DC2.y, list[str])
-assert_type(DC2.z, list[str])
-
-dc2 = DC2(Desc2(), Desc2(), Desc2())
-assert_type(dc2.x, int)
-assert_type(dc2.y, str)
-assert_type(dc2.z, str)
+# Note: a previous version of this test also covered non-data descriptors
+# (objects implementing only __get__, no __set__) used as dataclass fields.
+# That case was removed because the assertions did not match actual runtime
+# behavior; see https://github.com/python/typing/issues/2259. The correct
+# behavior for non-data descriptors in dataclasses is not yet specified.


### PR DESCRIPTION
## Summary
- The `Desc2`/`DC2` test in `dataclasses_descriptors.py` asserted type-checker behavior for non-data descriptors (objects with `__get__` but no `__set__`) used as dataclass fields.
- Those assertions don't match runtime behavior: fields typed with a non-data descriptor are stored as plain instance attributes on init, so the descriptor's `__get__` never actually fires on instance access.
- Per the issue, pyrefly gets this right (and thus fails the test), while mypy/pyright pass the test but implement the wrong behavior.
- Removed the incorrect assertions; kept the `Desc1` (data descriptor) case, which is correctly specified and confirmed against runtime.
- Regenerated conformance results for `dataclasses_descriptors.toml` across all checkers and `results.html`; reconciled `conformant` flags that referenced the now-removed behavior.

Fixes #2259

## Test plan
- [x] `uv run python src/main.py` — reran full conformance suite, confirmed only `dataclasses_descriptors` results changed for the intended checkers
- [x] `uv run python src/validate_results.py` — 987 files validated, 0 invariant violations
- [x] Diff scoped to `conformance/tests/dataclasses_descriptors.py`, the 4 affected `results/*/dataclasses_descriptors.toml`, and `results.html`