### PR TITLE
Fix `pre-commit` hook `end-of-file-fixer` interfering with CI.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,6 @@ repos:
       - id: trailing-whitespace
         exclude: conformance/results/.*/.*\.toml
       - id: end-of-file-fixer
-        exclude: conformance/results/results\.html
       - id: check-yaml
       - id: check-toml
       - id: check-merge-conflict

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
       - id: trailing-whitespace
         exclude: conformance/results/.*/.*\.toml
       - id: end-of-file-fixer
+        exclude: conformance/results/results\.html
       - id: check-yaml
       - id: check-toml
       - id: check-merge-conflict

--- a/conformance/results/results.html
+++ b/conformance/results/results.html
@@ -234,6 +234,7 @@
                     border-color: inherit;
                 }
             }
+
         </style>
         <link rel="icon" href="data:image/svg+xml,%3csvg%20xmlns=%22http://www.w3.org/2000/svg%22%20viewBox=%220%200%20100%20100%22%3e%3ctext%20y=%22.9em%22%20font-size=%2290%22%3e📘%3c/text%3e%3c/svg%3e">
     </head>

--- a/conformance/src/reporting.py
+++ b/conformance/src/reporting.py
@@ -58,6 +58,7 @@ def generate_summary(root_dir: Path):
     env = jinja2.Environment(
         loader=jinja2.FileSystemLoader(root_dir.joinpath("src/templates")),
         autoescape=jinja2.select_autoescape(),
+        keep_trailing_newline=True,
     )
     env.filters["conformance_class"] = _conformance_class
 

--- a/conformance/tests/enums_definition.py
+++ b/conformance/tests/enums_definition.py
@@ -90,4 +90,3 @@ class Color12(Enum):
 assert_type(Color12.RED, Literal[Color12.RED])
 assert_type(Color12.GREEN, Literal[Color12.GREEN])
 Color12.BLUE  # E
-

--- a/conformance/tests/overloads_basic.py
+++ b/conformance/tests/overloads_basic.py
@@ -58,4 +58,3 @@ def map(
 
 def map(func: Any, iter1: Any, iter2: Any = ...) -> Any:
     raise NotImplementedError
-

--- a/conformance/tests/overloads_consistency.py
+++ b/conformance/tests/overloads_consistency.py
@@ -115,4 +115,3 @@ def decorated(x: str, /) -> str:
 @_deco_2
 def decorated(y: bytes, z: bytes) -> bytes:
     return b""
-

--- a/docs/spec/callables.rst
+++ b/docs/spec/callables.rst
@@ -453,7 +453,7 @@ a function within a type expression. The syntax is
 
 Parameters specified using ``Callable`` are assumed to be positional-only.
 The ``Callable`` form provides no way to specify keyword-only parameters,
-or default argument values. For these use cases, see the section on 
+or default argument values. For these use cases, see the section on
 `Callback protocols`_.
 
 Meaning of ``...`` in ``Callable``


### PR DESCRIPTION
Encountered this in https://github.com/python/typing/actions/runs/29147006108/job/86530507754:  `uv run --python 3.12 --frozen python src/main.py` produces `results.html` without trailing newline, which then gets added by  `end-of-file-fixer`, which then causes `Assert conformance results are up to date` CI to fail.

1. ~~excluded `conformance/results/results.html` from `end-of-file-fixer`~~
Set `keep_trailing_newline=True` in `jinja2.Environment` in `reporting.py`
2. ran `pre-commit run -a` which applied `end-of-file-fixer` and `trailing-whitespace` to some files.