### PR TITLE
Conformance: broaden enum-expansion tests

### DIFF
--- a/conformance/results/basilisk/enums_expansion.toml
+++ b/conformance/results/basilisk/enums_expansion.toml
@@ -1,8 +1,13 @@
-conformant = "Pass"
-conformance_automated = "Pass"
+conformant = "Partial"
+notes = """
+Does not accept an enum-typed value where a complete union of all literal members is declared, although it treats the two as equivalent for `assert_type`.
+"""
+conformance_automated = "Fail"
 errors_diff = """
+Line 85: Unexpected errors ['enums_expansion.py:85:5: error: Type mismatch: `x` is annotated `Literal[Answer.Yes, Answer.No]` (answer.yes | answer.no) but assigned answer [assignment_compatibility]']
 """
 output = """
-enums_expansion.py:25:9: error: Redundant `assert_type` with `Literal[Color.GREEN]` on enum-typed parameter [enums_expansion]
-enums_expansion.py:53:9: error: Redundant `assert_type` with `Literal[CustomFlags.FLAG3]` on enum-typed parameter [enums_expansion]
+enums_expansion.py:28:9: error: Redundant `assert_type` with `Literal[Color.GREEN]` on enum-typed parameter [enums_expansion]
+enums_expansion.py:56:9: error: Redundant `assert_type` with `Literal[CustomFlags.FLAG3]` on enum-typed parameter [enums_expansion]
+enums_expansion.py:85:5: error: Type mismatch: `x` is annotated `Literal[Answer.Yes, Answer.No]` (answer.yes | answer.no) but assigned answer [assignment_compatibility]
 """

--- a/conformance/results/mypy/enums_expansion.toml
+++ b/conformance/results/mypy/enums_expansion.toml
@@ -4,9 +4,9 @@ Improperly applies narrowing to `Flag` subclass.
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 53: Expected 1 errors
-Line 52: Unexpected errors ['enums_expansion.py:52: error: Expression is of type "Literal[CustomFlags.FLAG3]", not "CustomFlags"  [assert-type]']
+Line 56: Expected 1 errors
+Line 55: Unexpected errors ['enums_expansion.py:55: error: Expression is of type "Literal[CustomFlags.FLAG3]", not "CustomFlags"  [assert-type]']
 """
 output = """
-enums_expansion.py:52: error: Expression is of type "Literal[CustomFlags.FLAG3]", not "CustomFlags"  [assert-type]
+enums_expansion.py:55: error: Expression is of type "Literal[CustomFlags.FLAG3]", not "CustomFlags"  [assert-type]
 """

--- a/conformance/results/pycroscope/enums_expansion.toml
+++ b/conformance/results/pycroscope/enums_expansion.toml
@@ -2,5 +2,5 @@ conformance_automated = "Pass"
 errors_diff = """
 """
 output = """
-./enums_expansion.py:53:20:   enums_expansion.CustomFlags is not equivalent to Literal[<CustomFlags.FLAG3: 4>]
+./enums_expansion.py:56:20:   enums_expansion.CustomFlags is not equivalent to Literal[<CustomFlags.FLAG3: 4>]
 """

--- a/conformance/results/pyrefly/enums_expansion.toml
+++ b/conformance/results/pyrefly/enums_expansion.toml
@@ -3,5 +3,5 @@ conformance_automated = "Pass"
 errors_diff = """
 """
 output = """
-ERROR enums_expansion.py:53:20-51: assert_type(CustomFlags, Literal[CustomFlags.FLAG3]) failed [assert-type]
+ERROR enums_expansion.py:56:20-51: assert_type(CustomFlags, Literal[CustomFlags.FLAG3]) failed [assert-type]
 """

--- a/conformance/results/pyright/enums_expansion.toml
+++ b/conformance/results/pyright/enums_expansion.toml
@@ -1,7 +1,17 @@
-conformant = "Pass"
-conformance_automated = "Pass"
+conformant = "Partial"
+notes = """
+Does not treat a complete union of all literal members as equivalent to the enum type.
+"""
+conformance_automated = "Fail"
 errors_diff = """
+Line 85: Unexpected errors ['enums_expansion.py:85:41 - error: Type "Answer" is not assignable to declared type "Literal[Answer.Yes, Answer.No]"']
+Line 86: Unexpected errors ['enums_expansion.py:86:17 - error: "assert_type" mismatch: expected "Literal[Answer.Yes, Answer.No]" but received "Answer" (reportAssertTypeFailure)']
 """
 output = """
-enums_expansion.py:53:21 - error: "assert_type" mismatch: expected "Literal[CustomFlags.FLAG3]" but received "CustomFlags" (reportAssertTypeFailure)
+enums_expansion.py:56:21 - error: "assert_type" mismatch: expected "Literal[CustomFlags.FLAG3]" but received "CustomFlags" (reportAssertTypeFailure)
+enums_expansion.py:85:41 - error: Type "Answer" is not assignable to declared type "Literal[Answer.Yes, Answer.No]"
+  Type "Answer" is not assignable to type "Literal[Answer.Yes, Answer.No]"
+    "Answer" is not assignable to type "Literal[Answer.Yes]"
+    "Answer" is not assignable to type "Literal[Answer.No]" (reportAssignmentType)
+enums_expansion.py:86:17 - error: "assert_type" mismatch: expected "Literal[Answer.Yes, Answer.No]" but received "Answer" (reportAssertTypeFailure)
 """

--- a/conformance/results/results.html
+++ b/conformance/results/results.html
@@ -2451,7 +2451,12 @@
                     </tr>
                     <tr>
                         <th scope="row">enums_expansion</th>
-                        <td class="conformant">Pass</td>
+                        <td class="partially-conformant tooltip">
+                            Partial
+                            <ul class="notes">
+                                <li>Does not accept an enum-typed value where a complete union of all literal members is declared, although it treats the two as equivalent for <code>assert_type</code>.</li>
+                            </ul>
+                        </td>
                         <td class="partially-conformant tooltip">
                             Partial
                             <ul class="notes">
@@ -2460,9 +2465,19 @@
                         </td>
                         <td class="conformant">Pass</td>
                         <td class="conformant">Pass</td>
+                        <td class="partially-conformant tooltip">
+                            Partial
+                            <ul class="notes">
+                                <li>Does not treat a complete union of all literal members as equivalent to the enum type.</li>
+                            </ul>
+                        </td>
                         <td class="conformant">Pass</td>
-                        <td class="conformant">Pass</td>
-                        <td class="conformant">Pass</td>
+                        <td class="partially-conformant tooltip">
+                            Partial
+                            <ul class="notes">
+                                <li>Does not treat a complete union of all literal members as equivalent to the enum type.</li>
+                            </ul>
+                        </td>
                     </tr>
                     <tr>
                         <th scope="row">enums_member_names</th>
@@ -2522,13 +2537,13 @@
                     </tr>
                     <tr class="summary">
                         <td></td>
-                        <td>6 / 6 • 100.0%</td>
+                        <td>5.5 / 6 • 91.7%</td>
                         <td>4.5 / 6 • 75.0%</td>
                         <td>5.5 / 6 • 91.7%</td>
                         <td>6 / 6 • 100.0%</td>
+                        <td>5.5 / 6 • 91.7%</td>
                         <td>6 / 6 • 100.0%</td>
-                        <td>6 / 6 • 100.0%</td>
-                        <td>6 / 6 • 100.0%</td>
+                        <td>5.5 / 6 • 91.7%</td>
                     </tr>
                 </tbody>
                 <tbody>
@@ -2776,13 +2791,13 @@
                 <tfoot>
                     <tr>
                         <td></td>
-                        <td>141 / 141 • 100.0%</td>
+                        <td>140.5 / 141 • 99.6%</td>
                         <td>109 / 141 • 77.3%</td>
                         <td>130 / 141 • 92.2%</td>
                         <td>138 / 141 • 97.9%</td>
-                        <td>136.5 / 141 • 96.8%</td>
+                        <td>136 / 141 • 96.5%</td>
                         <td>123.5 / 141 • 87.6%</td>
-                        <td>140.5 / 141 • 99.6%</td>
+                        <td>140 / 141 • 99.3%</td>
                     </tr>
                 </tfoot>
             </table>

--- a/conformance/results/ty/enums_expansion.toml
+++ b/conformance/results/ty/enums_expansion.toml
@@ -2,5 +2,5 @@ conformance_automated = "Pass"
 errors_diff = """
 """
 output = """
-enums_expansion.py:53:9: error[type-assertion-failure] Type `CustomFlags & ~Literal[CustomFlags.FLAG1] & ~Literal[CustomFlags.FLAG2]` does not match asserted type `Literal[CustomFlags.FLAG3]`
+enums_expansion.py:56:9: error[type-assertion-failure] Type `CustomFlags & ~Literal[CustomFlags.FLAG1] & ~Literal[CustomFlags.FLAG2]` does not match asserted type `Literal[CustomFlags.FLAG3]`
 """

--- a/conformance/results/zuban/enums_expansion.toml
+++ b/conformance/results/zuban/enums_expansion.toml
@@ -1,7 +1,15 @@
-conformance_automated = "Pass"
+conformant = "Partial"
+notes = """
+Does not treat a complete union of all literal members as equivalent to the enum type.
+"""
+conformance_automated = "Fail"
 errors_diff = """
+Line 85: Unexpected errors ['enums_expansion.py:85: error: Incompatible types in assignment (expression has type "Answer", variable has type "Literal[Answer.Yes, Answer.No]")  [assignment]']
+Line 86: Unexpected errors ['enums_expansion.py:86: error: Expression is of type "Answer", not "Literal[Answer.Yes, Answer.No]"  [misc]']
 """
 output = """
-enums_expansion.py:35: error: Statement is unreachable  [unreachable]
-enums_expansion.py:53: error: Expression is of type "CustomFlags", not "Literal[CustomFlags.FLAG3]"  [misc]
+enums_expansion.py:38: error: Statement is unreachable  [unreachable]
+enums_expansion.py:56: error: Expression is of type "CustomFlags", not "Literal[CustomFlags.FLAG3]"  [misc]
+enums_expansion.py:85: error: Incompatible types in assignment (expression has type "Answer", variable has type "Literal[Answer.Yes, Answer.No]")  [assignment]
+enums_expansion.py:86: error: Expression is of type "Answer", not "Literal[Answer.Yes, Answer.No]"  [misc]
 """

--- a/conformance/tests/enums_expansion.py
+++ b/conformance/tests/enums_expansion.py
@@ -8,8 +8,11 @@ from enum import Enum, Flag
 from typing import Literal, Never, assert_type
 
 # > From the perspective of the type system, most enum classes are equivalent
-# > to the union of the literal members within that enum. Type checkers may
-# > therefore expand an enum type
+# > to the union of the literal members within that enum. [...] Because of the
+# > equivalency between an enum class and the union of literal members within
+# > that enum, the two types may be used interchangeably. Type checkers may
+# > therefore expand an enum type (that does not derive from enum.Flag) into a
+# > union of literal values during type narrowing and exhaustion detection
 
 
 class Color(Enum):
@@ -35,8 +38,8 @@ def print_color2(c: Color):
             assert_type(c, Never)  # E?
 
 
-# > This rule does not apply to classes that derive from enum. Flag because
-# > these enums allow flags to be combined in arbitrary ways.
+# > (This rule does not apply to classes that derive from enum.Flag because
+# > these enums allow flags to be combined in arbitrary ways.)
 
 
 class CustomFlags(Flag):
@@ -64,7 +67,7 @@ def test2(f: CustomFlags):
 
 
 # > A type checker should treat a complete union of all literal members as
-# > compatible with the enum type.
+# > equivalent to the enum type.
 
 
 class Answer(Enum):
@@ -76,3 +79,8 @@ def test3(val: object) -> list[Answer]:
     assert val is Answer.Yes or val is Answer.No
     x = [val]
     return x
+
+
+def test4(a: Answer) -> None:
+    x: Literal[Answer.Yes, Answer.No] = a
+    assert_type(a, Literal[Answer.Yes, Answer.No])


### PR DESCRIPTION
The spec's Enum Literal Expansion section states that a type checker
should treat a complete union of all literal members as equivalent to
the enum type. Add test to cover cases failing in some checkers.

Also refreshes all three quoted spec passages, which had drifted from
the section as rewritten in https://github.com/python/typing/commit/a6eeccf4870f95357c7cc37332e350d147966b35 ("new type system concepts section",

Fixes https://github.com/python/typing/issues/2323.