### PR TITLE
Update typeddicts_class_syntax.py test to use a custom metaclass.

### DIFF
--- a/conformance/results/basilisk/typeddicts_class_syntax.toml
+++ b/conformance/results/basilisk/typeddicts_class_syntax.toml
@@ -6,7 +6,7 @@ output = """
 typeddicts_class_syntax.py:30:9: error: Method `method1` is not allowed in TypedDict class `BadTypedDict1` [typeddicts_class_syntax]
 typeddicts_class_syntax.py:35:9: error: Method `method2` is not allowed in TypedDict class `BadTypedDict1` [typeddicts_class_syntax]
 typeddicts_class_syntax.py:40:9: error: Method `method3` is not allowed in TypedDict class `BadTypedDict1` [typeddicts_class_syntax]
-typeddicts_class_syntax.py:45:7: error: TypedDict class `BadTypedDict2` uses unrecognised keyword `metaclass` [typeddicts_class_syntax_2]
-typeddicts_class_syntax.py:50:7: error: TypedDict class `BadTypedDict3` uses unrecognised keyword `other` [typeddicts_class_syntax_2]
-typeddicts_class_syntax.py:65:1: error: Unrecognized item `z` for `ConditionalField`: extra items are not allowed [typeddicts_extra_items]
+typeddicts_class_syntax.py:49:7: error: TypedDict class `BadTypedDict2` uses unrecognised keyword `metaclass` [typeddicts_class_syntax_2]
+typeddicts_class_syntax.py:54:7: error: TypedDict class `BadTypedDict3` uses unrecognised keyword `other` [typeddicts_class_syntax_2]
+typeddicts_class_syntax.py:69:1: error: Unrecognized item `z` for `ConditionalField`: extra items are not allowed [typeddicts_extra_items]
 """

--- a/conformance/results/mypy/typeddicts_class_syntax.toml
+++ b/conformance/results/mypy/typeddicts_class_syntax.toml
@@ -6,16 +6,16 @@ output = """
 typeddicts_class_syntax.py:30: error: Invalid statement in TypedDict definition; expected "field_name: field_type"  [misc]
 typeddicts_class_syntax.py:34: error: Invalid statement in TypedDict definition; expected "field_name: field_type"  [misc]
 typeddicts_class_syntax.py:39: error: Invalid statement in TypedDict definition; expected "field_name: field_type"  [misc]
-typeddicts_class_syntax.py:45: error: Unexpected keyword argument "metaclass" for "__init_subclass__" of "TypedDict"  [call-arg]
-typeddicts_class_syntax.py:50: error: Unexpected keyword argument "other" for "__init_subclass__" of "TypedDict"  [call-arg]
-typeddicts_class_syntax.py:58: error: Invalid statement in TypedDict definition; expected "field_name: field_type"  [misc]
-typeddicts_class_syntax.py:60: error: Invalid statement in TypedDict definition; expected "field_name: field_type"  [misc]
-typeddicts_class_syntax.py:64: error: Extra key "y" for TypedDict "ConditionalField"  [typeddict-unknown-key]
-typeddicts_class_syntax.py:65: error: Extra keys ("y", "z") for TypedDict "ConditionalField"  [typeddict-unknown-key]
+typeddicts_class_syntax.py:49: error: Unexpected keyword argument "metaclass" for "__init_subclass__" of "TypedDict"  [call-arg]
+typeddicts_class_syntax.py:54: error: Unexpected keyword argument "other" for "__init_subclass__" of "TypedDict"  [call-arg]
+typeddicts_class_syntax.py:62: error: Invalid statement in TypedDict definition; expected "field_name: field_type"  [misc]
+typeddicts_class_syntax.py:64: error: Invalid statement in TypedDict definition; expected "field_name: field_type"  [misc]
+typeddicts_class_syntax.py:68: error: Extra key "y" for TypedDict "ConditionalField"  [typeddict-unknown-key]
+typeddicts_class_syntax.py:69: error: Extra keys ("y", "z") for TypedDict "ConditionalField"  [typeddict-unknown-key]
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 58: Unexpected errors ['typeddicts_class_syntax.py:58: error: Invalid statement in TypedDict definition; expected "field_name: field_type"  [misc]']
-Line 60: Unexpected errors ['typeddicts_class_syntax.py:60: error: Invalid statement in TypedDict definition; expected "field_name: field_type"  [misc]']
-Line 64: Unexpected errors ['typeddicts_class_syntax.py:64: error: Extra key "y" for TypedDict "ConditionalField"  [typeddict-unknown-key]']
+Line 62: Unexpected errors ['typeddicts_class_syntax.py:62: error: Invalid statement in TypedDict definition; expected "field_name: field_type"  [misc]']
+Line 64: Unexpected errors ['typeddicts_class_syntax.py:64: error: Invalid statement in TypedDict definition; expected "field_name: field_type"  [misc]']
+Line 68: Unexpected errors ['typeddicts_class_syntax.py:68: error: Extra key "y" for TypedDict "ConditionalField"  [typeddict-unknown-key]']
 """

--- a/conformance/results/pycroscope/typeddicts_class_syntax.toml
+++ b/conformance/results/pycroscope/typeddicts_class_syntax.toml
@@ -5,7 +5,7 @@ output = """
 ./typeddicts_class_syntax.py:30:4: Methods are not allowed in TypedDict definitions [invalid_typeddict]
 ./typeddicts_class_syntax.py:35:4: Methods are not allowed in TypedDict definitions [invalid_typeddict]
 ./typeddicts_class_syntax.py:40:4: Methods are not allowed in TypedDict definitions [invalid_typeddict]
-./typeddicts_class_syntax.py:45:31: TypedDict definitions cannot specify a metaclass [invalid_typeddict]
-./typeddicts_class_syntax.py:50:31: Unexpected keyword argument 'other' in TypedDict definition [invalid_typeddict]
-./typeddicts_class_syntax.py:65:0: Got an unexpected keyword argument 'z' [incompatible_call]
+./typeddicts_class_syntax.py:49:31: TypedDict definitions cannot specify a metaclass [invalid_typeddict]
+./typeddicts_class_syntax.py:54:31: Unexpected keyword argument 'other' in TypedDict definition [invalid_typeddict]
+./typeddicts_class_syntax.py:69:0: Got an unexpected keyword argument 'z' [incompatible_call]
 """

--- a/conformance/results/pyrefly/typeddicts_class_syntax.toml
+++ b/conformance/results/pyrefly/typeddicts_class_syntax.toml
@@ -6,7 +6,7 @@ output = """
 ERROR typeddicts_class_syntax.py:30:9-16: TypedDict members must be declared in the form `field: Annotation` with no assignment [bad-class-definition]
 ERROR typeddicts_class_syntax.py:35:9-16: TypedDict members must be declared in the form `field: Annotation` with no assignment [bad-class-definition]
 ERROR typeddicts_class_syntax.py:40:9-16: TypedDict members must be declared in the form `field: Annotation` with no assignment [bad-class-definition]
-ERROR typeddicts_class_syntax.py:45:7-20: Metaclass of `BadTypedDict2` has type `type[Any]` that is not a simple class type [invalid-inheritance]
-ERROR typeddicts_class_syntax.py:50:7-20: TypedDict does not support keyword argument `other` [bad-typed-dict]
-ERROR typeddicts_class_syntax.py:65:17-32: No matching overload found for function `ConditionalField.__init__` called with arguments: (x=Literal[1], y=Literal[2], z=Literal[3]) [no-matching-overload]
+ERROR typeddicts_class_syntax.py:49:7-20: Typed dictionary definitions may not specify a metaclass [invalid-inheritance]
+ERROR typeddicts_class_syntax.py:54:7-20: TypedDict does not support keyword argument `other` [bad-typed-dict]
+ERROR typeddicts_class_syntax.py:69:17-32: No matching overload found for function `ConditionalField.__init__` called with arguments: (x=Literal[1], y=Literal[2], z=Literal[3]) [no-matching-overload]
 """

--- a/conformance/results/pyright/typeddicts_class_syntax.toml
+++ b/conformance/results/pyright/typeddicts_class_syntax.toml
@@ -6,15 +6,15 @@ output = """
 typeddicts_class_syntax.py:30:5 - error: TypedDict classes can contain only type annotations (reportGeneralTypeIssues)
 typeddicts_class_syntax.py:34:5 - error: TypedDict classes can contain only type annotations (reportGeneralTypeIssues)
 typeddicts_class_syntax.py:39:5 - error: TypedDict classes can contain only type annotations (reportGeneralTypeIssues)
-typeddicts_class_syntax.py:45:32 - error: TypedDict does not support __init_subclass__ parameter "metaclass" (reportGeneralTypeIssues)
-typeddicts_class_syntax.py:50:32 - error: TypedDict does not support __init_subclass__ parameter "other" (reportGeneralTypeIssues)
-typeddicts_class_syntax.py:58:5 - error: TypedDict classes can contain only type annotations (reportGeneralTypeIssues)
-typeddicts_class_syntax.py:60:5 - error: TypedDict classes can contain only type annotations (reportGeneralTypeIssues)
-typeddicts_class_syntax.py:65:1 - error: No overloads for "__init__" match the provided arguments
+typeddicts_class_syntax.py:49:32 - error: TypedDict does not support __init_subclass__ parameter "metaclass" (reportGeneralTypeIssues)
+typeddicts_class_syntax.py:54:32 - error: TypedDict does not support __init_subclass__ parameter "other" (reportGeneralTypeIssues)
+typeddicts_class_syntax.py:62:5 - error: TypedDict classes can contain only type annotations (reportGeneralTypeIssues)
+typeddicts_class_syntax.py:64:5 - error: TypedDict classes can contain only type annotations (reportGeneralTypeIssues)
+typeddicts_class_syntax.py:69:1 - error: No overloads for "__init__" match the provided arguments
   Argument types: (Literal[1], Literal[2], Literal[3]) (reportCallIssue)
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 58: Unexpected errors ['typeddicts_class_syntax.py:58:5 - error: TypedDict classes can contain only type annotations (reportGeneralTypeIssues)']
-Line 60: Unexpected errors ['typeddicts_class_syntax.py:60:5 - error: TypedDict classes can contain only type annotations (reportGeneralTypeIssues)']
+Line 62: Unexpected errors ['typeddicts_class_syntax.py:62:5 - error: TypedDict classes can contain only type annotations (reportGeneralTypeIssues)']
+Line 64: Unexpected errors ['typeddicts_class_syntax.py:64:5 - error: TypedDict classes can contain only type annotations (reportGeneralTypeIssues)']
 """

--- a/conformance/results/ty/typeddicts_class_syntax.toml
+++ b/conformance/results/ty/typeddicts_class_syntax.toml
@@ -8,7 +8,7 @@ output = """
 typeddicts_class_syntax.py:30:5: error[invalid-typed-dict-statement] TypedDict class cannot have methods
 typeddicts_class_syntax.py:34:5: error[invalid-typed-dict-statement] TypedDict class cannot have methods
 typeddicts_class_syntax.py:39:5: error[invalid-typed-dict-statement] TypedDict class cannot have methods
-typeddicts_class_syntax.py:45:32: error[invalid-typed-dict-header] Custom metaclasses are not supported in `TypedDict` definitions
-typeddicts_class_syntax.py:50:32: error[unknown-argument] Unknown keyword argument `other` in `TypedDict` definition
-typeddicts_class_syntax.py:65:28: error[invalid-key] Unknown key "z" for TypedDict `ConditionalField`
+typeddicts_class_syntax.py:49:32: error[invalid-typed-dict-header] Custom metaclasses are not supported in `TypedDict` definitions
+typeddicts_class_syntax.py:54:32: error[unknown-argument] Unknown keyword argument `other` in `TypedDict` definition
+typeddicts_class_syntax.py:69:28: error[invalid-key] Unknown key "z" for TypedDict `ConditionalField`
 """

--- a/conformance/results/zuban/typeddicts_class_syntax.toml
+++ b/conformance/results/zuban/typeddicts_class_syntax.toml
@@ -5,7 +5,7 @@ output = """
 typeddicts_class_syntax.py:30: error: Invalid statement in TypedDict definition; expected "field_name: field_type"  [misc]
 typeddicts_class_syntax.py:34: error: Invalid statement in TypedDict definition; expected "field_name: field_type"  [misc]
 typeddicts_class_syntax.py:39: error: Invalid statement in TypedDict definition; expected "field_name: field_type"  [misc]
-typeddicts_class_syntax.py:45: error: Unexpected keyword argument "metaclass" for "TypedDict"  [call-arg]
-typeddicts_class_syntax.py:50: error: Unexpected keyword argument "other" for "TypedDict"  [call-arg]
-typeddicts_class_syntax.py:65: error: Extra key "z" for TypedDict "ConditionalField"  [typeddict-unknown-key]
+typeddicts_class_syntax.py:49: error: Unexpected keyword argument "metaclass" for "TypedDict"  [call-arg]
+typeddicts_class_syntax.py:54: error: Unexpected keyword argument "other" for "TypedDict"  [call-arg]
+typeddicts_class_syntax.py:69: error: Extra key "z" for TypedDict "ConditionalField"  [typeddict-unknown-key]
 """

--- a/conformance/tests/typeddicts_class_syntax.py
+++ b/conformance/tests/typeddicts_class_syntax.py
@@ -41,8 +41,12 @@ class BadTypedDict1(TypedDict):
         pass
 
 
-# > Specifying a metaclass is not allowed.
-class BadTypedDict2(TypedDict, metaclass=type):  # E
+class CustomMeta(type):
+    pass
+
+
+# > Specifying a custom metaclass is not allowed.
+class BadTypedDict2(TypedDict, metaclass=CustomMeta):  # E
     name: str
 
 


### PR DESCRIPTION
The TypedDict chapter of the spec says (emphasis mine):
> It is invalid to specify a base class other than TypedDict, Generic, or another TypedDict type in a class-based TypedDict definition. **It is also invalid to specify a custom metaclass.**

It looks like most type checkers interpret this to mean that the appearance of `metaclass=...` is illegal in a TypedDict definition.

Pyrefly interprets this to mean that a non-`type` metaclass is illegal, so a redundant `metaclass=type` is fine.

IMO either interpretation is defensible, but the conformance test currently uses `metaclass=type`, which only accommodates the first. This PR changes the test to use a non-`type` metaclass, which is unambiguously an error.

This doesn't actually change pyrefly's conformance results because pyrefly has a bug that causes it to emit a different, nonsensical error on the `metaclass=type` line, which was mistakenly taken as pyrefly passing the test. I'm in the process of fixing that bug, which is how I discovered that pyrefly behaves slightly differently from the other checkers here.