### PR TITLE
Add references to relevant Pyrefly sub-commands in tooling sections

### DIFF
--- a/docs/guides/writing_stubs.rst
+++ b/docs/guides/writing_stubs.rst
@@ -40,6 +40,17 @@ stubs serve more as a starting point.
 
 For more details, see `pyright docs <https://github.com/microsoft/pyright/blob/main/docs/type-stubs.md#generating-type-stubs-from-command-line>`__.
 
+pyrefly
+-------
+
+Pyrefly also contains a tool to generate stubs. Unlike stubgen and pyright, this tool will aggressively infer types for un-annotated code, including function parameters, resulting in stubs that contain more non-``Any`` annotations.
+
+.. code-block:: console
+
+    pyrefly stubgen path/to/directory/
+
+For more details, see `pyrefly docs <https://pyrefly.org/en/docs/stubgen/>`__.
+
 monkeytype
 ----------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -105,7 +105,7 @@ Development Environments
 * `PyCharm <https://www.jetbrains.com/pycharm/>`_, an IDE that supports
   type stubs both for type checking and code completion.
 * `Visual Studio Code <https://code.visualstudio.com/>`_, a code editor that
-  supports type checking using mypy, pyright, or the
+  supports type checking using mypy, pyrefly, pyright, ty, Zuban, or the
   `Pylance <https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance>`_
   extension.
 
@@ -130,3 +130,5 @@ Type-Hint and Stub Integration
   a thin wrapper around ``ApplyTypeAnnotationsVisitor`` from
   `libCST <https://libcst.readthedocs.io/en/latest/>`_ that integrates .pyi
   signatures as inline type-hints in Python source code.
+* `pyrefly infer <https://pyrefly.org/en/docs/autotype/>`_, a sub-command of Pyrefly which
+  inserts the types that Pyrefly infers as inline type-hints.

--- a/docs/reference/quality.rst
+++ b/docs/reference/quality.rst
@@ -221,3 +221,13 @@ Mypy reports
 Mypy offers several options for generating reports on its analysis.
 See `the mypy documentation on report generation
 <https://mypy.readthedocs.io/en/stable/command_line.html#report-generation>`_ for details.
+
+
+Pyrefly coverage
+----------------
+
+Pyrefly offers a sub-command for measuring and checking type coverage.
+- ``pyrefly coverage check`` fails when coverage is below a threshold, useful as a CI gate.
+- ``pyrefly coverage report`` emits a JSON report with per-module statistics.
+See `the Pyrefly docs on measuring type coverage
+<https://pyrefly.org/en/docs/report/>`_ for details.

--- a/docs/reference/quality.rst
+++ b/docs/reference/quality.rst
@@ -227,7 +227,9 @@ Pyrefly coverage
 ----------------
 
 Pyrefly offers a sub-command for measuring and checking type coverage.
+
 - ``pyrefly coverage check`` fails when coverage is below a threshold, useful as a CI gate.
 - ``pyrefly coverage report`` emits a JSON report with per-module statistics.
+
 See `the Pyrefly docs on measuring type coverage
 <https://pyrefly.org/en/docs/report/>`_ for details.


### PR DESCRIPTION
- `pyrefly coverage` for measuring/checking type coverage
- `pyrefly infer` for applying inferred types as annotations
- `pyrefly stubgen` for generating type stubs with inferred types