### PR TITLE
Remove class-object assertion from referential defaults test

### DIFF
--- a/conformance/results/mypy/generics_defaults_referential.toml
+++ b/conformance/results/mypy/generics_defaults_referential.toml
@@ -3,20 +3,18 @@ notes = """
 Does not correctly handle defaults referencing other `TypeVar`s.
 """
 output = """
-generics_defaults_referential.py:23: error: Expression is of type "type[slice[StartT, StopT, StepT]]", not "type[slice[int, int, int | None]]"  [assert-type]
-generics_defaults_referential.py:38: error: Argument 1 to "Foo" has incompatible type "str"; expected "int"  [arg-type]
-generics_defaults_referential.py:54: error: Type parameter "Start2T" has a default type that refers to one or more type variables that are out of scope  [misc]
-generics_defaults_referential.py:61: error: Type variable S1 referenced in the default of S2 is unbound  [misc]
-generics_defaults_referential.py:75: error: TypeVar default must be one of the constraint types  [misc]
+generics_defaults_referential.py:37: error: Argument 1 to "Foo" has incompatible type "str"; expected "int"  [arg-type]
+generics_defaults_referential.py:53: error: Type parameter "Start2T" has a default type that refers to one or more type variables that are out of scope  [misc]
+generics_defaults_referential.py:60: error: Type variable S1 referenced in the default of S2 is unbound  [misc]
+generics_defaults_referential.py:74: error: TypeVar default must be one of the constraint types  [misc]
+generics_defaults_referential.py:77: error: TypeVar default must be one of the constraint types  [misc]
 generics_defaults_referential.py:78: error: TypeVar default must be one of the constraint types  [misc]
-generics_defaults_referential.py:79: error: TypeVar default must be one of the constraint types  [misc]
-generics_defaults_referential.py:104: error: Expression is of type "Bar[int, list[Never]]", not "Bar[int, list[int]]"  [assert-type]
+generics_defaults_referential.py:103: error: Expression is of type "Bar[int, list[Never]]", not "Bar[int, list[int]]"  [assert-type]
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 37: Expected 1 errors
-Line 69: Expected 1 errors
-Line 23: Unexpected errors ['generics_defaults_referential.py:23: error: Expression is of type "type[slice[StartT, StopT, StepT]]", not "type[slice[int, int, int | None]]"  [assert-type]']
-Line 78: Unexpected errors ['generics_defaults_referential.py:78: error: TypeVar default must be one of the constraint types  [misc]']
-Line 104: Unexpected errors ['generics_defaults_referential.py:104: error: Expression is of type "Bar[int, list[Never]]", not "Bar[int, list[int]]"  [assert-type]']
+Line 36: Expected 1 errors
+Line 68: Expected 1 errors
+Line 77: Unexpected errors ['generics_defaults_referential.py:77: error: TypeVar default must be one of the constraint types  [misc]']
+Line 103: Unexpected errors ['generics_defaults_referential.py:103: error: Expression is of type "Bar[int, list[Never]]", not "Bar[int, list[int]]"  [assert-type]']
 """

--- a/conformance/results/pycroscope/generics_defaults_referential.toml
+++ b/conformance/results/pycroscope/generics_defaults_referential.toml
@@ -4,19 +4,17 @@ Fails to apply default specializations in some cases.
 """
 conformance_automated = "Fail"
 errors_diff = """
-Line 23: Unexpected errors ["./generics_defaults_referential.py:23:12:   type 'generics_defaults_referential.slice' is not equivalent to type[generics_defaults_referential.slice[int, int, int | None]]"]
-Line 98: Unexpected errors ['./generics_defaults_referential.py:98:16:   ~Z1@generics_defaults_referential.Bar is not equivalent to Any[explicit]']
-Line 99: Unexpected errors ['./generics_defaults_referential.py:99:16:   ~ListDefaultT@generics_defaults_referential.Bar is not equivalent to list[Any[explicit]]']
+Line 97: Unexpected errors ['./generics_defaults_referential.py:97:16:   ~Z1@generics_defaults_referential.Bar is not equivalent to Any[explicit]']
+Line 98: Unexpected errors ['./generics_defaults_referential.py:98:16:   ~ListDefaultT@generics_defaults_referential.Bar is not equivalent to list[Any[explicit]]']
 """
 output = """
-./generics_defaults_referential.py:23:12:   type 'generics_defaults_referential.slice' is not equivalent to type[generics_defaults_referential.slice[int, int, int | None]]
-./generics_defaults_referential.py:37:16: Incompatible argument type for b: expected int but got str [incompatible_argument]
-./generics_defaults_referential.py:38:13: Incompatible argument type for a: expected int but got str [incompatible_argument]
-./generics_defaults_referential.py:54:0: Type parameter defaults can reference only earlier type parameters from the same class [invalid_type_parameter]
-./generics_defaults_referential.py:61:4: Type parameter defaults can reference only earlier type parameters from the same class [invalid_type_parameter]
-./generics_defaults_referential.py:69:39: TypeVar default must be assignable to its bound [incompatible_call]
-./generics_defaults_referential.py:75:51: TypeVar default must be one of its constraints [incompatible_call]
-./generics_defaults_referential.py:79:62: TypeVar default must be one of its constraints [incompatible_call]
-./generics_defaults_referential.py:98:16:   ~Z1@generics_defaults_referential.Bar is not equivalent to Any[explicit]
-./generics_defaults_referential.py:99:16:   ~ListDefaultT@generics_defaults_referential.Bar is not equivalent to list[Any[explicit]]
+./generics_defaults_referential.py:36:16: Incompatible argument type for b: expected int but got str [incompatible_argument]
+./generics_defaults_referential.py:37:13: Incompatible argument type for a: expected int but got str [incompatible_argument]
+./generics_defaults_referential.py:53:0: Type parameter defaults can reference only earlier type parameters from the same class [invalid_type_parameter]
+./generics_defaults_referential.py:60:4: Type parameter defaults can reference only earlier type parameters from the same class [invalid_type_parameter]
+./generics_defaults_referential.py:68:39: TypeVar default must be assignable to its bound [incompatible_call]
+./generics_defaults_referential.py:74:51: TypeVar default must be one of its constraints [incompatible_call]
+./generics_defaults_referential.py:78:62: TypeVar default must be one of its constraints [incompatible_call]
+./generics_defaults_referential.py:97:16:   ~Z1@generics_defaults_referential.Bar is not equivalent to Any[explicit]
+./generics_defaults_referential.py:98:16:   ~ListDefaultT@generics_defaults_referential.Bar is not equivalent to list[Any[explicit]]
 """

--- a/conformance/results/pyrefly/generics_defaults_referential.toml
+++ b/conformance/results/pyrefly/generics_defaults_referential.toml
@@ -3,11 +3,11 @@ conformance_automated = "Pass"
 errors_diff = """
 """
 output = """
-ERROR generics_defaults_referential.py:37:17-18: Argument `str` is not assignable to parameter `b` with type `int` in function `Foo.__init__` [bad-argument-type]
-ERROR generics_defaults_referential.py:38:14-15: Argument `str` is not assignable to parameter `a` with type `int` in function `Foo.__init__` [bad-argument-type]
-ERROR generics_defaults_referential.py:54:7-13: Default of type parameter `Start2T` refers to out-of-scope type parameter `StopT` [invalid-type-var]
-ERROR generics_defaults_referential.py:61:11-15: Default of type parameter `S2` refers to out-of-scope type parameter `S1` [invalid-type-var]
-ERROR generics_defaults_referential.py:69:40-42: Expected default `TypeVar[X1]` of `Invalid1` to be assignable to the upper bound of `str` [invalid-type-var]
-ERROR generics_defaults_referential.py:75:52-54: Expected default `TypeVar[Y1]` of `Invalid2` to be one of the following constraints: `float`, `str` [invalid-type-var]
-ERROR generics_defaults_referential.py:79:63-65: Expected default `TypeVar[Y2]` of `AlsoInvalid2` to be one of the following constraints: `bool`, `complex` [invalid-type-var]
+ERROR generics_defaults_referential.py:36:17-18: Argument `str` is not assignable to parameter `b` with type `int` in function `Foo.__init__` [bad-argument-type]
+ERROR generics_defaults_referential.py:37:14-15: Argument `str` is not assignable to parameter `a` with type `int` in function `Foo.__init__` [bad-argument-type]
+ERROR generics_defaults_referential.py:53:7-13: Default of type parameter `Start2T` refers to out-of-scope type parameter `StopT` [invalid-type-var]
+ERROR generics_defaults_referential.py:60:11-15: Default of type parameter `S2` refers to out-of-scope type parameter `S1` [invalid-type-var]
+ERROR generics_defaults_referential.py:68:40-42: Expected default `TypeVar[X1]` of `Invalid1` to be assignable to the upper bound of `str` [invalid-type-var]
+ERROR generics_defaults_referential.py:74:52-54: Expected default `TypeVar[Y1]` of `Invalid2` to be one of the following constraints: `float`, `str` [invalid-type-var]
+ERROR generics_defaults_referential.py:78:63-65: Expected default `TypeVar[Y2]` of `AlsoInvalid2` to be one of the following constraints: `bool`, `complex` [invalid-type-var]
 """

--- a/conformance/results/pyright/generics_defaults_referential.toml
+++ b/conformance/results/pyright/generics_defaults_referential.toml
@@ -1,16 +1,16 @@
 conformant = "Pass"
 output = """
-generics_defaults_referential.py:37:17 - error: Argument of type "str" cannot be assigned to parameter "b" of type "int" in function "__init__"
+generics_defaults_referential.py:36:17 - error: Argument of type "str" cannot be assigned to parameter "b" of type "int" in function "__init__"
   "str" is not assignable to "int" (reportArgumentType)
-generics_defaults_referential.py:38:14 - error: Argument of type "str" cannot be assigned to parameter "a" of type "int" in function "__init__"
+generics_defaults_referential.py:37:14 - error: Argument of type "str" cannot be assigned to parameter "a" of type "int" in function "__init__"
   "str" is not assignable to "int" (reportArgumentType)
-generics_defaults_referential.py:54:7 - error: Type parameter "Start2T" has a default type that refers to one or more type variables that are out of scope
+generics_defaults_referential.py:53:7 - error: Type parameter "Start2T" has a default type that refers to one or more type variables that are out of scope
   Type variable "StopT" is not in scope (reportGeneralTypeIssues)
-generics_defaults_referential.py:61:11 - error: Type parameter "S2" has a default type that refers to one or more type variables that are out of scope
+generics_defaults_referential.py:60:11 - error: Type parameter "S2" has a default type that refers to one or more type variables that are out of scope
   Type variable "S1" is not in scope (reportGeneralTypeIssues)
-generics_defaults_referential.py:69:40 - error: TypeVar default type must be a subtype of the bound type (reportGeneralTypeIssues)
-generics_defaults_referential.py:75:52 - error: TypeVar default type must be one of the constrained types (reportGeneralTypeIssues)
-generics_defaults_referential.py:79:63 - error: TypeVar default type must be one of the constrained types (reportGeneralTypeIssues)
+generics_defaults_referential.py:68:40 - error: TypeVar default type must be a subtype of the bound type (reportGeneralTypeIssues)
+generics_defaults_referential.py:74:52 - error: TypeVar default type must be one of the constrained types (reportGeneralTypeIssues)
+generics_defaults_referential.py:78:63 - error: TypeVar default type must be one of the constrained types (reportGeneralTypeIssues)
 """
 conformance_automated = "Pass"
 errors_diff = """

--- a/conformance/results/ty/generics_defaults_referential.toml
+++ b/conformance/results/ty/generics_defaults_referential.toml
@@ -2,11 +2,11 @@ conformance_automated = "Pass"
 errors_diff = """
 """
 output = """
-generics_defaults_referential.py:37:17: error[invalid-argument-type] Argument to `Foo.__init__` is incorrect: Expected `int`, found `str`
-generics_defaults_referential.py:38:14: error[invalid-argument-type] Argument to `Foo.__init__` is incorrect: Expected `int`, found `str`
-generics_defaults_referential.py:54:7: error[invalid-generic-class] Default of `Start2T` cannot reference out-of-scope type variable `StopT`
-generics_defaults_referential.py:61:11: error[invalid-generic-class] Default of `S2` cannot reference out-of-scope type variable `S1`
-generics_defaults_referential.py:69:40: error[invalid-type-variable-default] Default `X1` of TypeVar `Invalid1` is not assignable to upper bound `str` of `Invalid1` because its upper bound `int` is not assignable to `str`
-generics_defaults_referential.py:75:52: error[invalid-type-variable-default] TypeVar default is inconsistent with the TypeVar's constraints: Bounded TypeVar cannot be used as the default for a constrained TypeVar
-generics_defaults_referential.py:79:63: error[invalid-type-variable-default] Default `Y2` of TypeVar `AlsoInvalid2` is inconsistent with its constraints `AlsoInvalid2` because constraint `int` of `Y2` is not one of the constraints of `AlsoInvalid2`
+generics_defaults_referential.py:36:17: error[invalid-argument-type] Argument to `Foo.__init__` is incorrect: Expected `int`, found `str`
+generics_defaults_referential.py:37:14: error[invalid-argument-type] Argument to `Foo.__init__` is incorrect: Expected `int`, found `str`
+generics_defaults_referential.py:53:7: error[invalid-generic-class] Default of `Start2T` cannot reference out-of-scope type variable `StopT`
+generics_defaults_referential.py:60:11: error[invalid-generic-class] Default of `S2` cannot reference out-of-scope type variable `S1`
+generics_defaults_referential.py:68:40: error[invalid-type-variable-default] Default `X1` of TypeVar `Invalid1` is not assignable to upper bound `str` of `Invalid1` because its upper bound `int` is not assignable to `str`
+generics_defaults_referential.py:74:52: error[invalid-type-variable-default] TypeVar default is inconsistent with the TypeVar's constraints: Bounded TypeVar cannot be used as the default for a constrained TypeVar
+generics_defaults_referential.py:78:63: error[invalid-type-variable-default] Default `Y2` of TypeVar `AlsoInvalid2` is inconsistent with its constraints `AlsoInvalid2` because constraint `int` of `Y2` is not one of the constraints of `AlsoInvalid2`
 """

--- a/conformance/results/zuban/generics_defaults_referential.toml
+++ b/conformance/results/zuban/generics_defaults_referential.toml
@@ -2,11 +2,11 @@ conformance_automated = "Pass"
 errors_diff = """
 """
 output = """
-generics_defaults_referential.py:37: error: Argument 2 to "Foo" has incompatible type "str"; expected "int"  [arg-type]
-generics_defaults_referential.py:38: error: Argument 1 to "Foo" has incompatible type "str"; expected "int"  [arg-type]
-generics_defaults_referential.py:54: error: Type parameter "Start2T" has a default type that refers to one or more type variables that are out of scope  [misc]
-generics_defaults_referential.py:61: error: Type parameter "S2" has a default type that refers to one or more type variables that are out of scope  [misc]
-generics_defaults_referential.py:69: error: TypeVar default must be a subtype of the bound type  [misc]
-generics_defaults_referential.py:75: error: TypeVar default must be one of the constraint types  [misc]
-generics_defaults_referential.py:79: error: TypeVar default must be one of the constraint types  [misc]
+generics_defaults_referential.py:36: error: Argument 2 to "Foo" has incompatible type "str"; expected "int"  [arg-type]
+generics_defaults_referential.py:37: error: Argument 1 to "Foo" has incompatible type "str"; expected "int"  [arg-type]
+generics_defaults_referential.py:53: error: Type parameter "Start2T" has a default type that refers to one or more type variables that are out of scope  [misc]
+generics_defaults_referential.py:60: error: Type parameter "S2" has a default type that refers to one or more type variables that are out of scope  [misc]
+generics_defaults_referential.py:68: error: TypeVar default must be a subtype of the bound type  [misc]
+generics_defaults_referential.py:74: error: TypeVar default must be one of the constraint types  [misc]
+generics_defaults_referential.py:78: error: TypeVar default must be one of the constraint types  [misc]
 """

--- a/conformance/tests/generics_defaults_referential.py
+++ b/conformance/tests/generics_defaults_referential.py
@@ -20,7 +20,6 @@ StepT = TypeVar("StepT", default=int | None)
 class slice(Generic[StartT, StopT, StepT]): ...
 
 
-assert_type(slice, type[slice[int, int, int | None]])
 assert_type(slice(), slice[int, int, int | None])
 assert_type(slice[str](), slice[str, str, int | None])
 assert_type(slice[str, bool, complex](), slice[str, bool, complex])


### PR DESCRIPTION
#2204 rewrote many defaults tests because type checkers are not required to infer a class expression as having a `type[C]` type, but the assertion for `slice` in `generics_defaults_referential.py` was missed. The same rationale applies here. I simply removed the line because the next line with `slice()` adequately tests the defaults.
